### PR TITLE
feat(workflow): add GitHub Actions workflow for pull request reviews

### DIFF
--- a/.github/workflows/agent-pr-review.yaml
+++ b/.github/workflows/agent-pr-review.yaml
@@ -1,6 +1,6 @@
 ---
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
-name: agent-pr-review
+name: Agent PR Review
 
 on:
   pull_request:

--- a/.github/workflows/agent-pr-review.yaml
+++ b/.github/workflows/agent-pr-review.yaml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   review:
-    runs-on: self-hosted
+    runs-on: cluster-runner
     if: ${{ github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository }}
     steps:
       - name: Checkout

--- a/.github/workflows/agent-pr-review.yaml
+++ b/.github/workflows/agent-pr-review.yaml
@@ -8,8 +8,8 @@ on:
     types: [opened, reopened, synchronize, ready_for_review]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
-  cancel-in-progress: false
+  group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read

--- a/.github/workflows/agent-pr-review.yaml
+++ b/.github/workflows/agent-pr-review.yaml
@@ -1,0 +1,36 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: agent-pr-review
+
+on:
+  pull_request:
+    branches: ["main"]
+    types: [opened, reopened, synchronize, ready_for_review]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  review:
+    runs-on: self-hosted
+    if: ${{ github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Run reviewer
+        uses: joryirving/pr-reviewer-action@1c0483d41f1200845a82db146c275fb930169af7 # v1.0.2
+        with:
+          github_token: ${{ github.token }}
+          ai_base_url: http://ollama.ai.svc.cluster.local:11434/v1
+          ai_model: qwen3.5:9b
+          standards_file: AGENTS.md
+          publish_review_comment: "true"

--- a/.github/workflows/flux-local.yaml
+++ b/.github/workflows/flux-local.yaml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         id: app-token
         with:
-          app-id: ${{ secrets.BOT_APP_ID }}
+          client-id: ${{ secrets.BOT_APP_ID }}
           private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
           owner: Tanguille
           repositories: cluster
@@ -76,7 +76,7 @@ jobs:
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         id: app-token
         with:
-          app-id: ${{ secrets.BOT_APP_ID }}
+          client-id: ${{ secrets.BOT_APP_ID }}
           private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
           owner: Tanguille
           repositories: cluster

--- a/.github/workflows/image-pull.yaml
+++ b/.github/workflows/image-pull.yaml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         id: app-token
         with:
-          app-id: ${{ secrets.BOT_APP_ID }}
+          client-id: ${{ secrets.BOT_APP_ID }}
           private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
 
       - name: Checkout

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         id: app-token
         with:
-          app-id: ${{ secrets.BOT_APP_ID }}
+          client-id: ${{ secrets.BOT_APP_ID }}
           private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
 
       - name: Labeler


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces a new `pull_request` workflow that runs on a self-hosted runner and posts review comments, which can impact CI security/permissions and runner capacity if misconfigured.
> 
> **Overview**
> Adds a new `.github/workflows/agent-pr-review.yaml` workflow that triggers on key `pull_request` events to run an automated PR review.
> 
> The job runs on a *self-hosted* runner, checks out the PR head SHA, and invokes `joryirving/pr-reviewer-action` against an internal Ollama endpoint using `AGENTS.md` as the standards file, with `pull-requests: write` to publish the review comment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d5673e09186878f520d41fb0fb448f4d579d8a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->