### PR TITLE
fix(llama-server): pin vocab embedding to GPU, tune for 100k ctx

### DIFF
--- a/kubernetes/apps/ai/llama-server/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/llama-server/app/helmrelease.yaml
@@ -56,32 +56,30 @@ spec:
               - none
               - --kv-unified
               - --ctx-size
-              - "120000"
+              - "100000"
               - --parallel
-              - "4"
+              - "2"
               - --n-gpu-layers
               - "9999"
               - --flash-attn
               - "on"
-              # TurboQuant CUDA fork only supports turbo quant on V cache;
-              # K must stay q8_0.
+              # q8_0 K + turbo3_0 V keeps KV at ~1.2 GiB for 100k ctx; q8/q8
+              # would need ~1.6 GiB and doesn't fit after pinning the
+              # embedding matrix on a 12 GiB card.
               - --cache-type-k
               - q8_0
               - --cache-type-v
               - turbo3_0
+              # Unsloth's Qwen3.5-9B GGUF carries a 248k-vocab embedding
+              # (~1 GiB) that auto-fit leaves on CPU, forcing every output
+              # projection through PCIe (measured ~2 t/s generation). Pin it
+              # to the GPU.
+              - --override-tensor
+              - token_embd.weight=CUDA0
               # Qwen3.5's hybrid DeltaNet+Attention breaks llama.cpp's
               # context-shift eviction; error on overflow instead of silently
               # corrupting SSM state.
               - --no-context-shift
-              # Periodic KV snapshots: when the hybrid recurrent state
-              # invalidates ("forcing full prompt re-processing due to ... SWA
-              # or hybrid/recurrent memory" in the logs), restore from the
-              # nearest checkpoint instead of re-prefilling from scratch.
-              # Unsloth's long-ctx guidance for Qwen3.5 hybrid.
-              - --ctx-checkpoints
-              - "128"
-              - --checkpoint-every-n-tokens
-              - "4096"
               # Match the cgroup CPU limit; default picks host cores which is
               # wrong under Kubernetes resource limits.
               - --threads


### PR DESCRIPTION
## Summary

Current llama-server is measured at **2 t/s generation / 11 t/s prefill** (should be 35-50 / ~1000 on RTX 4070). One 19k-prompt request takes ~42 minutes.

## Root causes (from pod logs)

- Unsloth's 248k-vocab embedding matrix (~1 GiB) was left on CPU by auto-fit, forcing every output projection through PCIe on every generated token.
- `--ctx-checkpoints` / `--checkpoint-every-n-tokens` are structurally broken for Qwen3.5's hybrid DeltaNet+Attention; every request cold-prefilled anyway and the checkpoints were pure overhead.

## Fixes

- `--override-tensor token_embd.weight=CUDA0` pins the embedding on GPU (primary fix).
- Removed the hybrid-incompatible checkpoint flags.
- `--ctx-size 120000 -> 100000` to free VRAM for the pinned embedding while keeping >=100k as requested.
- `--parallel 4 -> 2` to match actual concurrency and trim recurrent-state footprint.
- Kept K q8_0 / V turbo3_0: q8/q8 V wouldn't fit at 100k ctx after pinning the embedding.

## Test plan

- [ ] Flux reconciles and pod restarts
- [ ] Startup logs show `token_embd.weight` on CUDA0 and no `CPU_Mapped model buffer`
- [ ] `/metrics` shows generation tokens/s well above 2
- [ ] Fire a real agent-pr-review run and confirm it completes in a sane time