### PR TITLE
feat(llama-server): Gemma 4 26B MoE via llama-swap with idle unload

### DIFF
--- a/kubernetes/apps/ai/llama-server/app/config/config.yaml
+++ b/kubernetes/apps/ai/llama-server/app/config/config.yaml
@@ -1,13 +1,19 @@
 ---
-# llama-swap routes OpenAI-compatible requests to child llama-server processes
-# keyed by request body .model. Two models defined:
-#   gemma-4   — primary; aliased as "self-hosted" for backward compat with
-#               .github/workflows/agent-pr-review.yaml and other consumers
-#   qwen-3.5  — available on demand via model="qwen-3.5"
-#
-# Only one runs at a time (single GPU); llama-swap swaps them per request.
+# Single GPU: only one model runs at a time — llama-swap stops the running
+# child before starting the next when a request selects a different model.
 
+# seconds; upper bound for a cold load (large MoE + --no-mmap full RAM copy)
+# to report ready. Default 120s is too tight for our ~60s load + warmup.
 healthCheckTimeout: 900
+
+macros:
+  # Shared flags; ${PORT} is llama-swap's per-model auto-assigned port.
+  common: >
+    --host 127.0.0.1 --port ${PORT}
+    --jinja
+    --cache-type-k q8_0 --cache-type-v q8_0
+    --temp 0.6 --top-k 20
+    --metrics
 
 models:
   gemma-4:
@@ -15,47 +21,33 @@ models:
     ttl: 900
     aliases:
       - self-hosted
-    proxy: http://127.0.0.1:9999
+    # --n-gpu-layers omitted intentionally: MoE (26B total / 4B active per token)
+    # stays fast on partial CPU offload; llama.cpp auto-picks layers to fit VRAM.
     cmd: >
       /app/llama-server
-      --host 127.0.0.1
-      --port 9999
+      ${common}
       -hf unsloth/gemma-4-26B-A4B-it-GGUF:UD-Q3_K_XL
-      --jinja
-      --fit-ctx 160000
+      --fit-ctx 100000
       --fit-target 512
       --parallel 2
-      --cache-type-k q8_0
-      --cache-type-v q8_0
       --no-mmap
       --batch-size 1024
       --ubatch-size 1024
       --swa-full
       --slot-save-path /cache/slots
-      --temp 0.6
-      --top-k 20
       --min-p 0.0
-      --metrics
 
   qwen-3.5:
     ttl: 900
-    proxy: http://127.0.0.1:9999
     cmd: >
       /app/llama-server
-      --host 127.0.0.1
-      --port 9999
+      ${common}
       -hf unsloth/Qwen3.5-9B-GGUF:UD-Q5_K_XL
-      --jinja
       --ctx-size 160000
       --parallel 4
       --n-gpu-layers 9999
-      --cache-type-k q8_0
-      --cache-type-v q8_0
       --override-tensor token_embd\.weight=CUDA0
       --no-context-shift
       --threads 4
       --threads-batch 4
-      --temp 0.6
       --top-p 0.95
-      --top-k 20
-      --metrics

--- a/kubernetes/apps/ai/llama-server/app/config/config.yaml
+++ b/kubernetes/apps/ai/llama-server/app/config/config.yaml
@@ -1,0 +1,61 @@
+---
+# llama-swap routes OpenAI-compatible requests to child llama-server processes
+# keyed by request body .model. Two models defined:
+#   gemma-4   — primary; aliased as "self-hosted" for backward compat with
+#               .github/workflows/agent-pr-review.yaml and other consumers
+#   qwen-3.5  — available on demand via model="qwen-3.5"
+#
+# Only one runs at a time (single GPU); llama-swap swaps them per request.
+
+healthCheckTimeout: 900
+
+models:
+  gemma-4:
+    # 15 min idle unloads; next request reloads (~60s cold start from /cache PVC).
+    ttl: 900
+    aliases:
+      - self-hosted
+    proxy: http://127.0.0.1:9999
+    cmd: >
+      /app/llama-server
+      --host 127.0.0.1
+      --port 9999
+      -hf unsloth/gemma-4-26B-A4B-it-GGUF:UD-Q3_K_XL
+      --jinja
+      --fit-ctx 160000
+      --fit-target 512
+      --parallel 2
+      --cache-type-k q8_0
+      --cache-type-v q8_0
+      --no-mmap
+      --batch-size 1024
+      --ubatch-size 1024
+      --swa-full
+      --slot-save-path /cache/slots
+      --temp 0.6
+      --top-k 20
+      --min-p 0.0
+      --metrics
+
+  qwen-3.5:
+    ttl: 900
+    proxy: http://127.0.0.1:9999
+    cmd: >
+      /app/llama-server
+      --host 127.0.0.1
+      --port 9999
+      -hf unsloth/Qwen3.5-9B-GGUF:UD-Q5_K_XL
+      --jinja
+      --ctx-size 160000
+      --parallel 4
+      --n-gpu-layers 9999
+      --cache-type-k q8_0
+      --cache-type-v q8_0
+      --override-tensor token_embd\.weight=CUDA0
+      --no-context-shift
+      --threads 4
+      --threads-batch 4
+      --temp 0.6
+      --top-p 0.95
+      --top-k 20
+      --metrics

--- a/kubernetes/apps/ai/llama-server/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/llama-server/app/helmrelease.yaml
@@ -33,7 +33,6 @@ spec:
               tag: server-cuda@sha256:66664a81cd0476baa150a6063dfb1054e44f99d5f5b09f9094aae6dc68fc8247
             env:
               TZ: ${TIMEZONE}
-              # Keep multi-GB GGUF downloads on the PVC across pod restarts.
               HF_HOME: /cache
             command:
               - /app/llama-server
@@ -48,8 +47,6 @@ spec:
               # fit-target 512 MiB headroom tolerates CUDA compute-buffer growth
               # during first prefill at ubatch 1024; 256 MiB crashes on 11.8 GiB
               # effective VRAM.
-              - --fit
-              - "on"
               - --fit-ctx
               - "160000"
               - --fit-target
@@ -64,7 +61,6 @@ spec:
               - q8_0
               # Prevent paging stalls mid-generation on the CPU-side experts.
               - --no-mmap
-              - --mlock
               # 1024 matches the 12 GiB VRAM class; 2048 crowds compute buffers
               # and forces --fit to push more experts to CPU, hurting decode.
               - --batch-size
@@ -78,11 +74,9 @@ spec:
               # omitted because Gemma 4's shared KV cache breaks it (#21468).
               - --slot-save-path
               - /cache/slots
-              # Unsloth "precise coding" preset.
+              # Unsloth "precise coding" preset (top-p 0.95 matches default).
               - --temp
               - "0.6"
-              - --top-p
-              - "0.95"
               - --top-k
               - "20"
               - --min-p
@@ -121,15 +115,11 @@ spec:
                   failureThreshold: 6
             resources:
               requests:
-                cpu: 4
-                memory: 4Gi
+                cpu: 1
+                memory: 1Gi
                 nvidia.com/gpu: 1
               limits:
-                # Leave 2 cores for rook-ceph OSDs and kube-apiserver on the
-                # 8-core control node during MoE dispatch bursts.
                 cpu: 6
-                # mlocked experts (~3.7 GiB) + KV overflow + compute buffers
-                # at 160k ctx / ubatch 1024 peak near 18 GiB in prefill.
                 memory: 20Gi
                 nvidia.com/gpu: 1
 

--- a/kubernetes/apps/ai/llama-server/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/llama-server/app/helmrelease.yaml
@@ -43,29 +43,41 @@ spec:
               - --alias
               - self-hosted
               - -hf
-              - unsloth/Qwen3.5-9B-GGUF:UD-Q5_K_XL
+              - unsloth/gemma-4-26B-A4B-it-GGUF:UD-Q3_K_XL
               - --jinja
-              - --ctx-size
+              # fit-target 512 MiB headroom tolerates CUDA compute-buffer growth
+              # during first prefill at ubatch 1024; 256 MiB crashes on 11.8 GiB
+              # effective VRAM.
+              - --fit
+              - "on"
+              - --fit-ctx
               - "160000"
+              - --fit-target
+              - "512"
+              # Two slots: lets moltis and opencode/pr-reviewer overlap without
+              # serialising one behind the other's prefill.
               - --parallel
-              - "4"
-              - --n-gpu-layers
-              - "9999"
+              - "2"
               - --cache-type-k
               - q8_0
               - --cache-type-v
               - q8_0
-              # Pin the 248k-vocab embedding to GPU; otherwise the output
-              # projection traverses PCIe once per generated token.
-              - --override-tensor
-              - token_embd\.weight=CUDA0
-              # Hybrid DeltaNet+Attention: context-shift corrupts SSM state.
-              - --no-context-shift
-              # Default reads host cores, ignoring the cgroup CPU limit.
-              - --threads
-              - "4"
-              - --threads-batch
-              - "4"
+              # Prevent paging stalls mid-generation on the CPU-side experts.
+              - --no-mmap
+              - --mlock
+              # 1024 matches the 12 GiB VRAM class; 2048 crowds compute buffers
+              # and forces --fit to push more experts to CPU, hurting decode.
+              - --batch-size
+              - "1024"
+              - --ubatch-size
+              - "1024"
+              # Gemma 4 uses alternating sliding-window + global attention;
+              # full SWA cache avoids truncation on restored slots.
+              - --swa-full
+              # Persist slot state across pod restarts. --cache-reuse is
+              # omitted because Gemma 4's shared KV cache breaks it (#21468).
+              - --slot-save-path
+              - /cache/slots
               # Unsloth "precise coding" preset.
               - --temp
               - "0.6"
@@ -73,6 +85,8 @@ spec:
               - "0.95"
               - --top-k
               - "20"
+              - --min-p
+              - "0.0"
               - --metrics
             probes:
               startup: &probeBase
@@ -85,7 +99,7 @@ spec:
                   initialDelaySeconds: 10
                   periodSeconds: 5
                   timeoutSeconds: 3
-                  # First boot downloads ~8 GiB; 180 x 5s = 15 min.
+                  # First boot downloads ~13 GiB; 180 x 5s = 15 min.
                   failureThreshold: 180
               liveness:
                 <<: *probeBase
@@ -107,12 +121,16 @@ spec:
                   failureThreshold: 6
             resources:
               requests:
-                cpu: 500m
-                memory: 2Gi
+                cpu: 4
+                memory: 4Gi
                 nvidia.com/gpu: 1
               limits:
-                cpu: 4
-                memory: 12Gi
+                # Leave 2 cores for rook-ceph OSDs and kube-apiserver on the
+                # 8-core control node during MoE dispatch bursts.
+                cpu: 6
+                # mlocked experts (~3.7 GiB) + KV overflow + compute buffers
+                # at 160k ctx / ubatch 1024 peak near 18 GiB in prefill.
+                memory: 20Gi
                 nvidia.com/gpu: 1
 
     service:

--- a/kubernetes/apps/ai/llama-server/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/llama-server/app/helmrelease.yaml
@@ -29,59 +29,19 @@ spec:
         containers:
           app:
             image:
-              repository: ghcr.io/ggml-org/llama.cpp
-              tag: server-cuda@sha256:66664a81cd0476baa150a6063dfb1054e44f99d5f5b09f9094aae6dc68fc8247
+              repository: ghcr.io/mostlygeek/llama-swap
+              tag: cuda@sha256:5533c89b4a7e894f7614a038250591375cec7b5bbb04847ab6744323fc3819ec
             env:
               TZ: ${TIMEZONE}
+              # HF_HOME is read by child llama-server processes; keeps GGUFs on PVC.
               HF_HOME: /cache
             command:
-              - /app/llama-server
+              - /app/llama-swap
             args:
-              - --host
-              - 0.0.0.0
-              - --alias
-              - self-hosted
-              - -hf
-              - unsloth/gemma-4-26B-A4B-it-GGUF:UD-Q3_K_XL
-              - --jinja
-              # fit-target 512 MiB headroom tolerates CUDA compute-buffer growth
-              # during first prefill at ubatch 1024; 256 MiB crashes on 11.8 GiB
-              # effective VRAM.
-              - --fit-ctx
-              - "160000"
-              - --fit-target
-              - "512"
-              # Two slots: lets moltis and opencode/pr-reviewer overlap without
-              # serialising one behind the other's prefill.
-              - --parallel
-              - "2"
-              - --cache-type-k
-              - q8_0
-              - --cache-type-v
-              - q8_0
-              # Prevent paging stalls mid-generation on the CPU-side experts.
-              - --no-mmap
-              # 1024 matches the 12 GiB VRAM class; 2048 crowds compute buffers
-              # and forces --fit to push more experts to CPU, hurting decode.
-              - --batch-size
-              - "1024"
-              - --ubatch-size
-              - "1024"
-              # Gemma 4 uses alternating sliding-window + global attention;
-              # full SWA cache avoids truncation on restored slots.
-              - --swa-full
-              # Persist slot state across pod restarts. --cache-reuse is
-              # omitted because Gemma 4's shared KV cache breaks it (#21468).
-              - --slot-save-path
-              - /cache/slots
-              # Unsloth "precise coding" preset (top-p 0.95 matches default).
-              - --temp
-              - "0.6"
-              - --top-k
-              - "20"
-              - --min-p
-              - "0.0"
-              - --metrics
+              - -config
+              - /app/config.yaml
+              - -listen
+              - 0.0.0.0:8080
             probes:
               startup: &probeBase
                 enabled: true
@@ -90,11 +50,11 @@ spec:
                   httpGet: &httpGet
                     path: /health
                     port: 8080
-                  initialDelaySeconds: 10
+                  initialDelaySeconds: 5
                   periodSeconds: 5
                   timeoutSeconds: 3
-                  # First boot downloads ~13 GiB; 180 x 5s = 15 min.
-                  failureThreshold: 180
+                  # llama-swap starts in < 5 s; no model load at pod start.
+                  failureThreshold: 12
               liveness:
                 <<: *probeBase
                 spec:
@@ -102,17 +62,15 @@ spec:
                   initialDelaySeconds: 30
                   periodSeconds: 30
                   timeoutSeconds: 5
-                  # /health shares the HTTP pool with inference; tolerate
-                  # stalls during long prefills.
-                  failureThreshold: 6
+                  failureThreshold: 3
               readiness:
                 <<: *probeBase
                 spec:
                   httpGet: *httpGet
-                  initialDelaySeconds: 10
+                  initialDelaySeconds: 5
                   periodSeconds: 10
-                  timeoutSeconds: 5
-                  failureThreshold: 6
+                  timeoutSeconds: 3
+                  failureThreshold: 3
             resources:
               requests:
                 cpu: 1
@@ -137,3 +95,10 @@ spec:
         existingClaim: llama-server
         globalMounts:
           - path: /cache
+      config:
+        type: configMap
+        name: llama-server-config
+        globalMounts:
+          - path: /app/config.yaml
+            subPath: config.yaml
+            readOnly: true

--- a/kubernetes/apps/ai/llama-server/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/llama-server/app/helmrelease.yaml
@@ -26,6 +26,8 @@ spec:
                     values: ["true"]
     controllers:
       app:
+        annotations:
+          reloader.stakater.com/auto: "true"
         containers:
           app:
             image:
@@ -33,7 +35,6 @@ spec:
               tag: cuda@sha256:5533c89b4a7e894f7614a038250591375cec7b5bbb04847ab6744323fc3819ec
             env:
               TZ: ${TIMEZONE}
-              # HF_HOME is read by child llama-server processes; keeps GGUFs on PVC.
               HF_HOME: /cache
             command:
               - /app/llama-swap

--- a/kubernetes/apps/ai/llama-server/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/llama-server/app/helmrelease.yaml
@@ -50,7 +50,7 @@ spec:
                 spec:
                   httpGet: &httpGet
                     path: /health
-                    port: 8080
+                    port: &port 8080
                   initialDelaySeconds: 5
                   periodSeconds: 5
                   timeoutSeconds: 3
@@ -88,7 +88,7 @@ spec:
         ports:
           http:
             port: 80
-            targetPort: 8080
+            targetPort: *port
 
     persistence:
       cache:

--- a/kubernetes/apps/ai/llama-server/app/kustomization.yaml
+++ b/kubernetes/apps/ai/llama-server/app/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 # yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
@@ -8,3 +9,10 @@ components:
 resources:
   - helmrelease.yaml
   - pvc.yaml
+
+configMapGenerator:
+  - name: llama-server-config
+    files:
+      - config/config.yaml
+generatorOptions:
+  disableNameSuffixHash: true


### PR DESCRIPTION
Wraps llama.cpp in [llama-swap](https://github.com/mostlygeek/llama-swap) so the running model unloads when idle and VRAM returns to the node. Gemma 4 26B-A4B MoE (25.2B total / 3.8B active) replaces the previous Qwen3.5-9B dense hybrid, which capped ~8 t/s on the 4070 because DeltaNet recurrent kernels are memory-bandwidth-bound. Qwen stays registered for on-demand use.

## Models

| key | role | alias |
|---|---|---|
| `gemma-4` | primary | `self-hosted` (backward compat with existing consumers) |
| `qwen-3.5` | on-demand | — |

Only one runs at a time (single GPU); llama-swap stops the running child before starting the next. Idle models unload after 900 s; next request reloads in ~60 s cold-start from the `/cache` PVC. `healthCheckTimeout: 900` gives the cold load time to report ready.

Consumers keep hitting the unchanged endpoint `http://llama-server.ai.svc.cluster.local/v1` and select a model via the request body's `model` field.

## gemma-4 config notes

- `--fit-ctx 100000 --fit-target 512` auto-probes VRAM and picks the `--n-cpu-moe` split; `--parallel 2` keeps the KV cache on GPU.
- `--no-mmap` + `--swa-full` + `--slot-save-path /cache/slots` so experts don't page mid-generation and slots survive swaps.
- **`--n-gpu-layers` intentionally omitted** — MoE (3.8B active per token) stays fast on partial CPU offload; llama.cpp auto-picks layers to fit VRAM.

## qwen-3.5 config notes

Retains its original flags: `--ctx-size 160000 --parallel 4 --n-gpu-layers 9999 --override-tensor token_embd\.weight=CUDA0 --no-context-shift --threads 4`. Context-shift stays disabled because the hybrid DeltaNet+Attention architecture corrupts SSM state on shift.

## Shared flags (macros)

`--host 127.0.0.1 --port ${PORT} --jinja --cache-type-k/v q8_0 --temp 0.6 --top-k 20 --metrics` factored into a `common` macro. `${PORT}` is llama-swap's auto-assigned per-model port.

## Ops

- `reloader.stakater.com/auto: "true"` on the controller so ConfigMap edits recycle the pod (matches the other `ai` apps).
- Probes hit llama-swap's `/health` (always-200 regardless of model state). Startup budget 60 s since the proxy itself starts in < 5 s with no model loaded.
- `20Gi` memory limit accommodates `--no-mmap` full-RAM weight copy + KV-cache overspill + OS.
- Port `8080` is defined once via `&port` in `probes.httpGet.port` and referenced from `service.targetPort`.

## Known caveat

Gemma 4 tool-calling fixes (ggml-org/llama.cpp#21326, ggml-org/llama.cpp#21343) are not yet in the upstream llama.cpp bundled with the llama-swap image. Tool-call emission may include garbage tokens until a newer build lands upstream.