### PR TITLE
feat(ai/llama-server): migrate to ik_llama.cpp with explicit MoE expert offload

### DIFF
--- a/kubernetes/apps/ai/llama-server/app/config/config.yaml
+++ b/kubernetes/apps/ai/llama-server/app/config/config.yaml
@@ -2,8 +2,8 @@
 # Single GPU: only one model runs at a time — llama-swap stops the running
 # child before starting the next when a request selects a different model.
 
-# seconds; upper bound for a cold load (large MoE + --no-mmap full RAM copy)
-# to report ready. Default 120s is too tight for our ~60s load + warmup.
+# seconds; upper bound for a cold load (large MoE mmap warmup + first-token
+# page-fault round-trips from PVC). Default 120s is too tight for MoE models.
 healthCheckTimeout: 900
 
 macros:
@@ -20,26 +20,30 @@ macros:
 
 models:
   gemma-4:
-    # 15 min idle unloads; next request reloads (~60s cold start from /cache PVC).
+    # 26B-A4B MoE. -ot exps=CPU pins expert FFN weights to CPU; mmap lets
+    # the OS page cache hold hot experts (sparse MoE access = most pages
+    # fault once and stay warm). Attention/router/KV live on the 4070.
+    # UD-Q4_K_M (not _XL) — avoids f16 tensors ik_llama.cpp refuses to load.
+    # -fmoe / -rtr are ik_llama.cpp-specific (fused MoE FFN / runtime repack).
     ttl: 900
-    aliases:
-      - self-hosted
-    # --n-gpu-layers omitted intentionally: MoE (26B total / 4B active per token)
-    # stays fast on partial CPU offload; llama.cpp auto-picks layers to fit VRAM.
     cmd: >
       /app/llama-server
       --port $${PORT}
       $${common}
-      -hf unsloth/gemma-4-26B-A4B-it-GGUF:UD-Q3_K_XL
-      --fit-ctx 100000
-      --fit-target 512
+      -hf unsloth/gemma-4-26B-A4B-it-GGUF:UD-Q4_K_M
+      --ctx-size 131072
       --parallel 2
-      --no-mmap
+      --n-gpu-layers 99
+      --override-tensor exps=CPU
       --batch-size 1024
       --ubatch-size 1024
+      --threads 6
+      --threads-batch 6
       --swa-full
       --slot-save-path /cache/slots
       --min-p 0.0
+      -fmoe
+      -rtr
 
   qwen-3.5:
     ttl: 900
@@ -58,20 +62,29 @@ models:
       --top-p 0.95
 
   qwen-3.6:
+    # 35B-A3B MoE. -ot exps=CPU pins expert FFN weights (~18 GB) to CPU; mmap
+    # lets the OS page cache hold hot experts in RAM (sparse MoE access = most
+    # pages fault once and stay warm). Attention/router/KV live on the 4070.
     # UD-Q4_K_M (not _XL) — avoids f16 tensors ik_llama.cpp refuses to load.
-    # -fmoe is ik_llama.cpp-specific (fused MoE FFN; not in mainline llama.cpp).
+    # -fmoe / -rtr are ik_llama.cpp-specific (fused MoE FFN / runtime repack).
     ttl: 900
+    aliases:
+      - self-hosted
     cmd: >
       /app/llama-server
-      --port ${PORT}
-      ${common}
+      --port $${PORT}
+      $${common}
       -hf unsloth/Qwen3.6-35B-A3B-GGUF:UD-Q4_K_M
-      --fit-ctx 100000
-      --fit-target 512
+      --ctx-size 131072
       --parallel 2
-      --no-mmap
+      --n-gpu-layers 99
+      --override-tensor exps=CPU
       --batch-size 1024
       --ubatch-size 1024
+      --threads 6
+      --threads-batch 6
       --slot-save-path /cache/slots
+      --top-p 0.95
       --min-p 0.0
       -fmoe
+      -rtr

--- a/kubernetes/apps/ai/llama-server/app/config/config.yaml
+++ b/kubernetes/apps/ai/llama-server/app/config/config.yaml
@@ -56,3 +56,25 @@ models:
       --threads 4
       --threads-batch 4
       --top-p 0.95
+
+  qwen-3.6:
+    # 35B-A3B MoE (3B active per token): generation throughput is bound by
+    # active params, so expected to outpace gemma-4's 4B-active on the same HW.
+    # UD-Q4_K_M (not _XL) is ~22.1 GB and avoids the f16 tensors that
+    # ik_llama.cpp refuses to load; 12 GB in VRAM, ~10 GB spills to RAM.
+    # -fmoe: ik_llama.cpp's fused MoE FFN ops.
+    ttl: 900
+    cmd: >
+      /app/llama-server
+      --port ${PORT}
+      ${common}
+      -hf unsloth/Qwen3.6-35B-A3B-GGUF:UD-Q4_K_M
+      --fit-ctx 100000
+      --fit-target 512
+      --parallel 2
+      --no-mmap
+      --batch-size 1024
+      --ubatch-size 1024
+      --slot-save-path /cache/slots
+      --min-p 0.0
+      -fmoe

--- a/kubernetes/apps/ai/llama-server/app/config/config.yaml
+++ b/kubernetes/apps/ai/llama-server/app/config/config.yaml
@@ -58,11 +58,8 @@ models:
       --top-p 0.95
 
   qwen-3.6:
-    # 35B-A3B MoE (3B active per token): generation throughput is bound by
-    # active params, so expected to outpace gemma-4's 4B-active on the same HW.
-    # UD-Q4_K_M (not _XL) is ~22.1 GB and avoids the f16 tensors that
-    # ik_llama.cpp refuses to load; 12 GB in VRAM, ~10 GB spills to RAM.
-    # -fmoe: ik_llama.cpp's fused MoE FFN ops.
+    # UD-Q4_K_M (not _XL) — avoids f16 tensors ik_llama.cpp refuses to load.
+    # -fmoe is ik_llama.cpp-specific (fused MoE FFN; not in mainline llama.cpp).
     ttl: 900
     cmd: >
       /app/llama-server

--- a/kubernetes/apps/ai/llama-server/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/llama-server/app/helmrelease.yaml
@@ -31,8 +31,8 @@ spec:
         containers:
           app:
             image:
-              repository: ghcr.io/mostlygeek/llama-swap
-              tag: cuda@sha256:7dcd2caa408258bcc5c69fd04cc1588a8ec59e884960a296db535a5915ab9a66
+              repository: ghcr.io/ikawrakow/ik-llama-cpp
+              tag: cu13-swap-4417@sha256:e2cfa912d3c2bf47922294e5b530840d47c30849207c2b26a7784c63ec33a220
             env:
               TZ: ${TIMEZONE}
               HF_HOME: /cache


### PR DESCRIPTION
## Summary

Migrate llama-server to ik_llama.cpp and retune both MoE models for its recommended hybrid CPU/GPU inference pattern. No pod memory bump required.

### Image swap

`ghcr.io/mostlygeek/llama-swap:cuda` → `ghcr.io/ikawrakow/ik-llama-cpp:cu13-swap-4417`

Upstream ships a llama-swap-bundled variant so this is drop-in with no entrypoint changes. The fork specifically targets hybrid CPU+GPU MoE workloads (fused FFN ops, better auto-fit tensor offload).

### MoE tuning (gemma-4 and qwen-3.6)

Both entries switch to the explicit expert-offload pattern:

```
--n-gpu-layers 99
--override-tensor exps=CPU
```

Expert FFN weights stay on CPU; attention, router, embeddings, and KV cache live on the 4070. Per-token hot path is small matmuls in VRAM; experts stream from the OS page cache. Beats auto-fit layer slicing on ≤16 GB GPUs for MoE.

Dropping `--no-mmap` lets the kernel page cache handle expert residency adaptively — MoE access is sparse and clustered so most pages fault once and stay warm. Cold start is faster, the 20 GiB pod memory limit holds, and unload releases pages immediately.

### Per-model changes

- **`gemma-4`**: UD-Q3_K_XL → **UD-Q4_K_M** (ik_llama.cpp refuses the _XL variant's f16 tensors; Q4_K_M matches or exceeds Q3_K_XL quality at similar size)
- **`qwen-3.6`** (new): `unsloth/Qwen3.6-35B-A3B-GGUF:UD-Q4_K_M` with `--top-p 0.95` per Unsloth's Qwen sampling guide
- **Both**: `--threads 6 --threads-batch 6` (experts now on CPU, threading is the bottleneck; matches the 6-CPU cgroup); `--ctx-size 131072` (auto-fit conflicts with explicit tensor placement); `-fmoe` + `-rtr` (ik_llama.cpp-specific fused MoE FFN + runtime repack)
- **`qwen-3.5`**: intentionally untouched — dense 9B, fully GPU-offloaded, different optimization profile. Its `_XL` quant may break on ik_llama.cpp; if reload fails, follow-up PR.

## Test plan

- [ ] Flux reconciles the HelmRelease cleanly; pod restarts with new image
- [ ] `curl http://llama-server/health` reports healthy after cold start
- [ ] `qwen-3.6` loads and completes a chat request (`curl -X POST /v1/chat/completions -d '{"model":"qwen-3.6",...}'`)
- [ ] `gemma-4` reloads on first request after image swap (quant changed, expect fresh download of Q4_K_M)
- [ ] `nvidia-smi` during inference shows ~3–5 GB VRAM for weights + KV cache, not the full 12 GB
- [ ] `kubectl top pod` stays under the 20 GiB memory limit with experts mmap'd in page cache
- [ ] `qwen-3.5` still reloads (watch for f16-tensor load error on its `_XL` quant; if so, follow-up)