### PR TITLE
feat(default): add printguard

### DIFF
--- a/kubernetes/apps/default/kustomization.yaml
+++ b/kubernetes/apps/default/kustomization.yaml
@@ -16,5 +16,6 @@ resources:
   - ./karakeep/ks.yaml
   - ./nextcloud/ks.yaml
   - ./picoshare/ks.yaml
+  - ./printguard/ks.yaml
   - ./searxng/ks.yaml
   - ./spoolman/ks.yaml

--- a/kubernetes/apps/default/printguard/app/helmrelease.yaml
+++ b/kubernetes/apps/default/printguard/app/helmrelease.yaml
@@ -13,7 +13,6 @@ spec:
   values:
     controllers:
       printguard:
-        strategy: RollingUpdate
         annotations:
           reloader.stakater.com/auto: "true"
         containers:

--- a/kubernetes/apps/default/printguard/app/helmrelease.yaml
+++ b/kubernetes/apps/default/printguard/app/helmrelease.yaml
@@ -19,7 +19,7 @@ spec:
           app:
             image:
               repository: ghcr.io/oliverbravery/printguard
-              tag: v1.0.0b3
+              tag: latest@sha256:220f3e174c006e9565798d11669b4a3b637061f225e6988548051c6e99085b79
             env:
               TZ: ${TIMEZONE}
             probes:

--- a/kubernetes/apps/default/printguard/app/helmrelease.yaml
+++ b/kubernetes/apps/default/printguard/app/helmrelease.yaml
@@ -1,0 +1,90 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app printguard
+spec:
+  interval: 30m
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+
+  values:
+    controllers:
+      printguard:
+        strategy: RollingUpdate
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: ghcr.io/oliverbravery/printguard
+              tag: v1.0.0b3
+            env:
+              TZ: ${TIMEZONE}
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket:
+                    port: &port 8000
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket:
+                    port: *port
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket:
+                    port: *port
+                  failureThreshold: 30
+                  periodSeconds: 5
+            resources:
+              requests:
+                cpu: 50m
+                memory: 256Mi
+              limits:
+                memory: 2Gi
+
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+
+    service:
+      app:
+        controller: *app
+        ports:
+          http:
+            port: *port
+
+    route:
+      app:
+        hostnames:
+          - "{{ .Release.Name }}.${SECRET_DOMAIN}"
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+
+    persistence:
+      data:
+        enabled: true
+        storageClass: ceph-block
+        accessMode: ReadWriteOnce
+        size: 10Gi
+        globalMounts:
+          - path: /data

--- a/kubernetes/apps/default/printguard/app/kustomization.yaml
+++ b/kubernetes/apps/default/printguard/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/SchemaStore/schemastore/master/src/schemas/json/kustomization.json
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml

--- a/kubernetes/apps/default/printguard/ks.yaml
+++ b/kubernetes/apps/default/printguard/ks.yaml
@@ -1,0 +1,17 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ishioni/CRDs-catalog/main/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: printguard
+  namespace: &namespace default
+spec:
+  targetNamespace: *namespace
+  path: ./kubernetes/apps/default/printguard/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false
+  interval: 30m


### PR DESCRIPTION
## Summary

- Deploy [PrintGuard](https://github.com/oliverbravery/PrintGuard) (3D-print failure detection via CV) to the `default` namespace
- Image `ghcr.io/oliverbravery/printguard:v1.0.0b3` on port 8000, exposed at `printguard.${SECRET_DOMAIN}` via `envoy-internal`
- 10Gi `ceph-block` PVC mounted at `/data` for encrypted secrets, SSL/VAPID keys, ML model artifacts, and camera/printer config

## Notes

- Project is in beta; pinned to the latest tagged release (`v1.0.0b3`)
- No env vars / secrets / DB required — initial setup is done via the `/setup` web wizard after first deploy
- Probes use `tcpSocket` on 8000 (no documented HTTP health endpoint upstream)
- Assumes RTSP camera streams; USB camera passthrough would require `privileged: true` + hostPath for `/dev/video*` and is intentionally not configured
- No GPU / Coral TPU needed (CPU inference)

## Test plan

- [ ] Flux reconciles `default-printguard` Kustomization
- [ ] HelmRelease becomes Ready
- [ ] PVC binds on `ceph-block`
- [ ] HTTPRoute resolves at `printguard.${SECRET_DOMAIN}` and serves the `/setup` wizard