### PR TITLE
feat(observability): add victoria-metrics stack

### DIFF
--- a/kubernetes/apps/observability/kustomization.yaml
+++ b/kubernetes/apps/observability/kustomization.yaml
@@ -18,3 +18,4 @@ resources:
   - ./silence-operator/ks.yaml
   - ./siren/ks.yaml
   - ./victoria-logs/ks.yaml
+  - ./victoria-metrics/ks.yaml

--- a/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
@@ -1,0 +1,205 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: victoria-metrics
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: victoria-metrics
+  interval: 1h
+  values:
+    fullnameOverride: victoria-metrics
+    global:
+      image:
+        registry: quay.io
+
+    victoria-metrics-operator:
+      crds:
+        cleanup:
+          enabled: false
+      operator:
+        enable_converter_ownership: true
+      resources:
+        requests:
+          cpu: 10m
+          memory: 64Mi
+        limits:
+          cpu: 500m
+          memory: 512Mi
+
+    defaultDashboards:
+      grafanaOperator:
+        enabled: true
+        spec:
+          instanceSelector:
+            matchLabels:
+              grafana.internal/instance: grafana
+          allowCrossNamespaceImport: true
+
+    defaultDatasources:
+      grafanaOperator:
+        enabled: true
+        spec:
+          instanceSelector:
+            matchLabels:
+              grafana.internal/instance: grafana
+          allowCrossNamespaceImport: true
+      victoriametrics:
+        datasources:
+          - name: VictoriaMetrics
+            uid: victoriametrics
+            type: prometheus
+            access: proxy
+            isDefault: false
+            jsonData:
+              httpMethod: POST
+              queryTimeout: 60s
+              timeInterval: 15s
+              seriesLimit: 40000
+      alertmanager:
+        datasources:
+          - name: VictoriaMetrics Alertmanager
+            uid: vmalertmanager
+            access: proxy
+            jsonData:
+              implementation: prometheus
+
+    defaultRules:
+      create: false
+
+    grafana:
+      enabled: false
+      forceDeployDatasource: true
+
+    prometheus-node-exporter:
+      enabled: false
+    kube-state-metrics:
+      enabled: false
+
+    coreDns:
+      enabled: false
+    kubeApiServer:
+      enabled: false
+    kubeControllerManager:
+      enabled: false
+    kubeEtcd:
+      enabled: false
+    kubelet:
+      enabled: false
+    kubeProxy:
+      enabled: false
+    kubeScheduler:
+      enabled: false
+
+    alertmanager:
+      enabled: true
+      useManagedConfig: false
+      config:
+        route:
+          receiver: blackhole
+        receivers:
+          - name: blackhole
+      monzoTemplate:
+        enabled: false
+      route:
+        enabled: true
+        hostnames:
+          - vmalertmanager.${SECRET_DOMAIN}
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+      spec:
+        selectAllByDefault: false
+        externalURL: https://vmalertmanager.${SECRET_DOMAIN}
+        resources:
+          requests:
+            cpu: 10m
+            memory: 64Mi
+          limits:
+            cpu: 500m
+            memory: 256Mi
+        storage:
+          volumeClaimTemplate:
+            spec:
+              storageClassName: ceph-block
+              resources:
+                requests:
+                  storage: 1Gi
+
+    vmalert:
+      enabled: true
+      remoteWriteVMAgent: false
+      route:
+        enabled: true
+        hostnames:
+          - vmalert.${SECRET_DOMAIN}
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+      spec:
+        datasource:
+          url: http://vmsingle-victoria-metrics.observability.svc.cluster.local:8428
+        extraArgs:
+          "external.url": https://vmalert.${SECRET_DOMAIN}
+        notifier:
+          url: http://vmalertmanager-victoria-metrics.observability.svc.cluster.local:9093
+        remoteRead:
+          url: http://vmsingle-victoria-metrics.observability.svc.cluster.local:8428
+        remoteWrite:
+          url: http://vmsingle-victoria-metrics.observability.svc.cluster.local:8428/api/v1/write
+        resources:
+          requests:
+            cpu: 25m
+            memory: 128Mi
+          limits:
+            cpu: 500m
+            memory: 512Mi
+
+    vmagent:
+      enabled: true
+      rbac:
+        namespaced: false
+      spec:
+        selectAllByDefault: true
+        resources:
+          requests:
+            cpu: 100m
+            memory: 256Mi
+          limits:
+            cpu: 1
+            memory: 1Gi
+        extraArgs:
+          promscrape.dropOriginalLabels: "true"
+          promscrape.maxScrapeSize: 50MiB
+          promscrape.streamParse: "true"
+
+    vmauth:
+      enabled: false
+
+    vmsingle:
+      enabled: true
+      route:
+        enabled: true
+        hostnames:
+          - vmsingle.${SECRET_DOMAIN}
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+      spec:
+        retentionPeriod: 365d
+        resources:
+          requests:
+            cpu: 250m
+            memory: 512Mi
+          limits:
+            cpu: 2
+            memory: 2Gi
+        storage:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 200Gi
+          storageClassName: ceph-block

--- a/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
@@ -3,14 +3,14 @@
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
-  name: victoria-metrics
+  name: &app victoria-metrics
 spec:
   chartRef:
     kind: OCIRepository
-    name: victoria-metrics
+    name: *app
   interval: 1h
   values:
-    fullnameOverride: victoria-metrics
+    fullnameOverride: *app
     global:
       image:
         registry: quay.io
@@ -52,6 +52,7 @@ spec:
             uid: victoriametrics
             type: prometheus
             access: proxy
+            url: &vmsingleUrl http://vmsingle-victoria-metrics.observability.svc.cluster.local:8428
             isDefault: false
             jsonData:
               httpMethod: POST
@@ -62,7 +63,9 @@ spec:
         datasources:
           - name: VictoriaMetrics Alertmanager
             uid: vmalertmanager
+            type: alertmanager
             access: proxy
+            url: &vmalertmanagerUrl http://vmalertmanager-victoria-metrics.observability.svc.cluster.local:9093
             jsonData:
               implementation: prometheus
 
@@ -107,7 +110,7 @@ spec:
         enabled: true
         hostnames:
           - vmalertmanager.${SECRET_DOMAIN}
-        parentRefs:
+        parentRefs: &internalParentRefs
           - name: envoy-internal
             namespace: network
       spec:
@@ -123,7 +126,7 @@ spec:
         storage:
           volumeClaimTemplate:
             spec:
-              storageClassName: ceph-block
+              storageClassName: &blockStorageClass ceph-block
               resources:
                 requests:
                   storage: 1Gi
@@ -135,18 +138,16 @@ spec:
         enabled: true
         hostnames:
           - vmalert.${SECRET_DOMAIN}
-        parentRefs:
-          - name: envoy-internal
-            namespace: network
+        parentRefs: *internalParentRefs
       spec:
         datasource:
-          url: http://vmsingle-victoria-metrics.observability.svc.cluster.local:8428
+          url: *vmsingleUrl
         extraArgs:
           "external.url": https://vmalert.${SECRET_DOMAIN}
         notifier:
-          url: http://vmalertmanager-victoria-metrics.observability.svc.cluster.local:9093
+          url: *vmalertmanagerUrl
         remoteRead:
-          url: http://vmsingle-victoria-metrics.observability.svc.cluster.local:8428
+          url: *vmsingleUrl
         remoteWrite:
           url: http://vmsingle-victoria-metrics.observability.svc.cluster.local:8428/api/v1/write
         resources:
@@ -184,9 +185,7 @@ spec:
         enabled: true
         hostnames:
           - vmsingle.${SECRET_DOMAIN}
-        parentRefs:
-          - name: envoy-internal
-            namespace: network
+        parentRefs: *internalParentRefs
       spec:
         retentionPeriod: 365d
         resources:
@@ -202,4 +201,4 @@ spec:
           resources:
             requests:
               storage: 200Gi
-          storageClassName: ceph-block
+          storageClassName: *blockStorageClass

--- a/kubernetes/apps/observability/victoria-metrics/app/kustomization.yaml
+++ b/kubernetes/apps/observability/victoria-metrics/app/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: observability
+
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/observability/victoria-metrics/app/ocirepository.yaml
+++ b/kubernetes/apps/observability/victoria-metrics/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: victoria-metrics
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.78.0
+  url: oci://ghcr.io/victoriametrics/helm-charts/victoria-metrics-k8s-stack

--- a/kubernetes/apps/observability/victoria-metrics/ks.yaml
+++ b/kubernetes/apps/observability/victoria-metrics/ks.yaml
@@ -7,8 +7,6 @@ metadata:
   namespace: &namespace observability
 spec:
   dependsOn:
-    - name: grafana-instance
-      namespace: observability
     - name: kube-prometheus-stack
       namespace: observability
     - name: rook-ceph-cluster

--- a/kubernetes/apps/observability/victoria-metrics/ks.yaml
+++ b/kubernetes/apps/observability/victoria-metrics/ks.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: victoria-metrics
+  namespace: &namespace observability
+spec:
+  dependsOn:
+    - name: grafana-instance
+      namespace: observability
+    - name: kube-prometheus-stack
+      namespace: observability
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+  interval: 1h
+  path: ./kubernetes/apps/observability/victoria-metrics/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  wait: false


### PR DESCRIPTION
## Summary
- Add `victoria-metrics-k8s-stack` side-by-side in the existing `observability` namespace.
- Configure VMSingle on `ceph-block` with `200Gi` storage and `365d` retention.
- Add non-default Grafana datasources and blackhole-only VMAlertmanager so existing Prometheus/Alertmanager consumers remain primary.

## Migration Notes
- This is PR 1 only: deploy VictoriaMetrics without retargeting existing consumers.
- Prometheus converter/VMAgent selection is enabled intentionally so VMSingle can ingest existing Prometheus Operator scrape resources side-by-side.
- Discord notifications are not configured here; alerting cutover stays in a later PR.

## Validation
- [x] `mise x aqua:yannh/kubeconform@0.7.0 -- kubeconform -strict -ignore-missing-schemas kubernetes/apps/observability/victoria-metrics kubernetes/apps/observability/kustomization.yaml`
- [x] `mise x aqua:kubernetes-sigs/kustomize@5.8.1 -- kustomize build kubernetes/apps/observability/victoria-metrics/app`
- [x] `mise x aqua:kubernetes-sigs/kustomize@5.8.1 -- kustomize build kubernetes/apps/observability`
- [x] Local 6-phase review completed with no blocking findings
- [ ] `mise exec -- kubeconform -strict kubernetes/` is currently blocked by `aqua:siderolabs/talos@1.13.1` release 404 before kubeconform runs