### PR TITLE
feat(observability): cut over metrics queries to VictoriaMetrics

### DIFF
--- a/docs/database/postgres-cnpg-performance-check.md
+++ b/docs/database/postgres-cnpg-performance-check.md
@@ -1,16 +1,16 @@
 # Check PostgreSQL (CloudNative-PG) performance after tuning
 
-Use this after tuning (e.g. NVMe/PLP, work_mem, autovacuum) to see if performance improved. Run from a machine with `kubectl` and cluster access, or use the **observability** MCP (Grafana/Prometheus) when connected.
+Use this after tuning (e.g. NVMe/PLP, work_mem, autovacuum) to see if performance improved. Run from a machine with `kubectl` and cluster access, or use the **observability** MCP (Grafana/VictoriaMetrics) when connected.
 
-## 1. Prometheus (PromQL)
+## 1. VictoriaMetrics VMSingle (PromQL)
 
-Port-forward then query, or use Grafana Explore with datasource `prometheus`:
+Port-forward then query, or use Grafana Explore with the VictoriaMetrics datasource:
 
 ```bash
-kubectl port-forward -n observability svc/prometheus-operated 9090:9090
+kubectl port-forward -n observability svc/vmsingle-victoria-metrics 8428:8428
 ```
 
-Then open `http://localhost:9090` and run these in the Graph/Query UI.
+Then open `http://localhost:8428` and run these in the Graph/Query UI.
 
 **Cache hit ratio** (higher is better; aim > 99%):
 
@@ -79,11 +79,11 @@ Interpretation:
 
 When the **observability** MCP server is connected, use `grafana_query_prometheus` to run the same PromQL as in section 1.
 
-**Setup:** Resolve the Prometheus datasource UID (e.g. `grafana_list_datasources` with `type: "prometheus"` or `grafana_get_datasource_by_name` with `name: "prometheus"`). Typical UID: `prometheus`.
+**Setup:** Resolve the VictoriaMetrics datasource UID (e.g. `grafana_list_datasources` with `type: "prometheus"` or `grafana_get_datasource_by_name` with `name: "vmsingle-victoria-metrics"`).
 
 **Tool:** `grafana_query_prometheus` with:
 
-- `datasourceUid`: `"prometheus"` (or the UID from the step above)
+- `datasourceUid`: the UID from the step above
 - `expr`: one of the PromQL expressions below
 - `startTime`: `"now"` for current snapshot
 - `queryType`: `"instant"` for a single point, or `"range"` for a trend

--- a/docs/database/postgres-cnpg-performance-check.md
+++ b/docs/database/postgres-cnpg-performance-check.md
@@ -4,7 +4,7 @@ Use this after tuning (e.g. NVMe/PLP, work_mem, autovacuum) to see if performanc
 
 ## 1. VictoriaMetrics VMSingle (PromQL)
 
-Port-forward then query, or use Grafana Explore with the VictoriaMetrics datasource:
+Port-forward VMSingle directly, or use Grafana Explore with the canonical `prometheus` datasource now backed by VictoriaMetrics/VMSingle:
 
 ```bash
 kubectl port-forward -n observability svc/vmsingle-victoria-metrics 8428:8428
@@ -79,7 +79,7 @@ Interpretation:
 
 When the **observability** MCP server is connected, use `grafana_query_prometheus` to run the same PromQL as in section 1.
 
-**Setup:** Resolve the VictoriaMetrics datasource UID (e.g. `grafana_list_datasources` with `type: "prometheus"` or `grafana_get_datasource_by_name` with `name: "vmsingle-victoria-metrics"`).
+**Setup:** Resolve the canonical `prometheus` datasource UID (e.g. `grafana_list_datasources` with `type: "prometheus"` or `grafana_get_datasource_by_name` with `name: "prometheus"`), which is backed by VictoriaMetrics/VMSingle after PR2.
 
 **Tool:** `grafana_query_prometheus` with:
 

--- a/kubernetes/apps/observability/grafana/instance/grafana.yaml
+++ b/kubernetes/apps/observability/grafana/instance/grafana.yaml
@@ -5,6 +5,7 @@ kind: Grafana
 metadata:
   name: grafana
   labels:
+    dashboards: grafana
     grafana.internal/instance: grafana
 spec:
   config:

--- a/kubernetes/apps/observability/grafana/instance/grafanadatasource.yaml
+++ b/kubernetes/apps/observability/grafana/instance/grafanadatasource.yaml
@@ -14,7 +14,7 @@ spec:
     uid: prometheus
     access: proxy
     isDefault: true
-    url: http://prometheus-operated.observability.svc.cluster.local:9090
+    url: http://vmsingle-victoria-metrics.observability.svc.cluster.local:8428
     jsonData:
       httpMethod: POST
       queryTimeout: 60s

--- a/kubernetes/apps/observability/kromgo/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kromgo/app/helmrelease.yaml
@@ -21,7 +21,7 @@ spec:
               repository: ghcr.io/kashalls/kromgo
               tag: v0.9.1@sha256:1624b1a10009978243d7d54e83269cbf9e3a4ec7f14c2548bdd11e63db5c4ad7
             env:
-              PROMETHEUS_URL: http://prometheus-operated.observability.svc.cluster.local:9090
+              PROMETHEUS_URL: http://vmsingle-victoria-metrics.observability.svc.cluster.local:8428
               SERVER_PORT: &port 80
               HEALTH_PORT: &healthPort 8080
             probes:

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -48,7 +48,7 @@ spec:
         enabled: true
         urlPrefix: /
         ssl: false
-        prometheusEndpoint: http://prometheus-operated.observability.svc.cluster.local:9090
+        prometheusEndpoint: http://vmsingle-victoria-metrics.observability.svc.cluster.local:8428
       mgr:
         modules:
           - name: diskprediction_local

--- a/kubernetes/apps/web3/monero/xmrig/scaledobject.yaml
+++ b/kubernetes/apps/web3/monero/xmrig/scaledobject.yaml
@@ -45,7 +45,7 @@ spec:
   triggers:
     - type: prometheus
       metadata:
-        serverAddress: http://prometheus-operated.observability.svc.cluster.local:9090
+        serverAddress: http://vmsingle-victoria-metrics.observability.svc.cluster.local:8428
         # Query: Use 15-minute average to smooth out solar power fluctuations
         # Invert power value and clamp to 0 minimum
         # When power is negative (exporting), this returns positive value for scaling

--- a/kubernetes/components/nfs-scaler/scaledobject.yaml
+++ b/kubernetes/components/nfs-scaler/scaledobject.yaml
@@ -17,7 +17,7 @@ spec:
   triggers:
     - type: prometheus
       metadata:
-        serverAddress: http://prometheus-operated.observability.svc.cluster.local:9090
+        serverAddress: http://vmsingle-victoria-metrics.observability.svc.cluster.local:8428
         query: max_over_time(probe_success{instance=~".+:2049"}[1m])
         threshold: "1"
         ignoreNullValues: "0"


### PR DESCRIPTION
## Summary
- Retarget the canonical Grafana `prometheus` datasource and direct metrics consumers to VictoriaMetrics VMSingle.
- Add the Grafana `dashboards: grafana` label so VictoriaMetrics chart-generated Grafana dashboards/datasources match the Grafana operator selector.
- Update the CNPG performance runbook while keeping kube-prometheus-stack and production Alertmanager paths unchanged for rollback and alert continuity.

## Validation
- `git diff --check <merge-base>...HEAD`
- Focused `kustomize build | kubeconform -strict -ignore-missing-schemas -skip Secret` for changed app roots.
- Rendered Grafana label check confirmed `dashboards=grafana`.
- Confirmed `http://prometheus-operated.observability.svc.cluster.local:9090` is absent from Kubernetes YAML.

## Notes
- Full-repo strict kubeconform remains unsuitable here due existing missing schemas/SOPS-style manifests.
- The separate canonical Alertmanager GrafanaDatasource HTTP 500 sync issue is intentionally not changed in this PR.