### PR TITLE
fix(toolhive): add writable temp dir for homeassistant mcp

### DIFF
--- a/kubernetes/apps/ai/toolhive/config/homeassistant.yaml
+++ b/kubernetes/apps/ai/toolhive/config/homeassistant.yaml
@@ -16,6 +16,8 @@ spec:
       value: http://${HOME_ASSISTANT_IP}:8123
     - name: FASTMCP_HOST
       value: "0.0.0.0"
+    - name: TMPDIR
+      value: /tmp
   secrets:
     - name: toolhive-secrets
       key: HOMEASSISTANT_API_TOKEN
@@ -24,9 +26,15 @@ spec:
     name: *name
   podTemplateSpec:
     spec:
+      volumes:
+        - name: tmp
+          emptyDir: {}
       containers:
         - name: mcp
           command: ["fastmcp", "run", "fastmcp-http.json"]
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
           ports:
             - name: mcp
               containerPort: *port
@@ -71,6 +79,8 @@ spec:
       value: http://${HOME_ASSISTANT_IP}:8123
     - name: FASTMCP_HOST
       value: "0.0.0.0"
+    - name: TMPDIR
+      value: /tmp
   secrets:
     - name: toolhive-secrets
       key: HOMEASSISTANT_API_TOKEN
@@ -79,9 +89,15 @@ spec:
     name: homeassistant
   podTemplateSpec:
     spec:
+      volumes:
+        - name: tmp
+          emptyDir: {}
       containers:
         - name: mcp
           command: ["fastmcp", "run", "fastmcp-http.json"]
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
           ports:
             - name: mcp
               containerPort: 8086


### PR DESCRIPTION
## Summary
- Mount an `emptyDir` at `/tmp` for both Home Assistant ToolHive MCPServer variants.
- Set `TMPDIR=/tmp` so FastMCP/Python has a writable temporary directory under ToolHive's read-only root filesystem defaults.

## Validation
- Verified both Home Assistant MCPServer manifests include `TMPDIR=/tmp`, a `tmp` `emptyDir`, and a `/tmp` volume mount with `python3`.
- `mise exec -- kubeconform -strict kubernetes/` could not be run in this environment because `mise` is not installed.