### PR TITLE
fix(observability): pin autoscaling dashboard URLs

### DIFF
--- a/kubernetes/apps/observability/victoria-metrics/app/grafanadashboard.yaml
+++ b/kubernetes/apps/observability/victoria-metrics/app/grafanadashboard.yaml
@@ -13,7 +13,7 @@ spec:
   datasources:
     - datasourceName: VictoriaMetrics
       inputName: DS_PROMETHEUS
-  url: https://raw.githubusercontent.com/monitoring-mixins/website/master/assets/kubernetes-autoscaling/dashboards/kubernetes-autoscaling-mixin-hpa.json
+  url: https://raw.githubusercontent.com/monitoring-mixins/website/b200a115e32a4db3045c7e1be1567a315d35cc4e/assets/kubernetes-autoscaling/dashboards/kubernetes-autoscaling-mixin-hpa.json
 ---
 # yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/grafana.integreatly.org/grafanadashboard_v1beta1.json
 apiVersion: grafana.integreatly.org/v1beta1
@@ -29,7 +29,7 @@ spec:
   datasources:
     - datasourceName: VictoriaMetrics
       inputName: DS_PROMETHEUS
-  url: https://raw.githubusercontent.com/monitoring-mixins/website/master/assets/kubernetes-autoscaling/dashboards/kubernetes-autoscaling-mixin-pdb.json
+  url: https://raw.githubusercontent.com/monitoring-mixins/website/b200a115e32a4db3045c7e1be1567a315d35cc4e/assets/kubernetes-autoscaling/dashboards/kubernetes-autoscaling-mixin-pdb.json
 ---
 # yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/grafana.integreatly.org/grafanadashboard_v1beta1.json
 apiVersion: grafana.integreatly.org/v1beta1


### PR DESCRIPTION
## Summary
- Pin monitoring-mixins autoscaling GrafanaDashboard URLs to a commit SHA instead of `master`
- Avoid GitOps drift from mutable upstream dashboard JSON

## Validation
- `git diff --check`
- YAML parse with Python/PyYAML
- `/home/tanguille/.local/bin/mise exec -- kustomize build kubernetes/apps/observability/victoria-metrics/app`
- `/home/tanguille/.local/bin/mise exec -- kubeconform -strict -ignore-missing-schemas -skip Secret /tmp/victoria-metrics-kustomize.yaml`
- `lsp_diagnostics` on `grafanadashboard.yaml`

## Notes
- Default `yamllint` reports line-length errors because this checkout has no `.yamllint*` config and the file already contains long schema/URL lines.
- The live Alertmanager Discord 429 regression was investigated separately: Alertmanager config loads and Discord returns rate limits while multiple real alerts and failed one-off `vmctl-prometheus-backfill-*` Jobs are firing. This PR does not hide those alerts or reroute them to blackhole.