### PR TITLE
fix(grafana): address llama dashboard review feedback

### DIFF
--- a/kubernetes/apps/ai/llama-server/app/dashboard/llama-server.json
+++ b/kubernetes/apps/ai/llama-server/app/dashboard/llama-server.json
@@ -64,7 +64,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-          "expr": "max without(endpoint, instance, job, namespace, pod, prometheus, service) (llamacpp:prompt_tokens_seconds)",
+          "expr": "max without(endpoint, instance, pod, prometheus) (llamacpp:prompt_tokens_seconds)",
           "legendFormat": "Prefill",
           "refId": "A"
         }
@@ -107,7 +107,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-          "expr": "max without(endpoint, instance, job, namespace, pod, prometheus, service) (llamacpp:predicted_tokens_seconds)",
+          "expr": "max without(endpoint, instance, pod, prometheus) (llamacpp:predicted_tokens_seconds)",
           "legendFormat": "Decode",
           "refId": "A"
         }
@@ -162,13 +162,13 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-          "expr": "sum without(endpoint, instance, job, namespace, pod, prometheus, service) (llamacpp:requests_processing)",
+          "expr": "max without(endpoint, instance, pod, prometheus) (llamacpp:requests_processing)",
           "legendFormat": "Processing",
           "refId": "A"
         },
         {
           "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-          "expr": "sum without(endpoint, instance, job, namespace, pod, prometheus, service) (llamacpp:requests_deferred)",
+          "expr": "max without(endpoint, instance, pod, prometheus) (llamacpp:requests_deferred)",
           "legendFormat": "Deferred",
           "refId": "B"
         }
@@ -216,7 +216,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-          "expr": "max without(endpoint, instance, job, namespace, pod, prometheus, service) (llamacpp:kv_cache_usage_ratio)",
+          "expr": "max without(endpoint, instance, pod, prometheus) (llamacpp:kv_cache_usage_ratio)",
           "legendFormat": "KV cache",
           "refId": "A"
         }
@@ -273,13 +273,13 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-          "expr": "max without(endpoint, instance, job, namespace, pod, prometheus, service) (llamacpp:prompt_tokens_seconds)",
+          "expr": "max without(endpoint, instance, pod, prometheus) (llamacpp:prompt_tokens_seconds)",
           "legendFormat": "Prefill",
           "refId": "A"
         },
         {
           "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-          "expr": "max without(endpoint, instance, job, namespace, pod, prometheus, service) (llamacpp:predicted_tokens_seconds)",
+          "expr": "max without(endpoint, instance, pod, prometheus) (llamacpp:predicted_tokens_seconds)",
           "legendFormat": "Decode",
           "refId": "B"
         }
@@ -344,7 +344,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-          "expr": "max without(endpoint, instance, job, namespace, pod, prometheus, service) (llamacpp:kv_cache_usage_ratio)",
+          "expr": "max without(endpoint, instance, pod, prometheus) (llamacpp:kv_cache_usage_ratio)",
           "legendFormat": "KV cache usage",
           "refId": "A"
         }
@@ -395,7 +395,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-          "expr": "sum without(endpoint, instance, job, namespace, pod, prometheus, service) (llamacpp:kv_cache_tokens)",
+          "expr": "max without(endpoint, instance, pod, prometheus) (llamacpp:kv_cache_tokens)",
           "legendFormat": "KV cache tokens",
           "refId": "A"
         }
@@ -447,13 +447,13 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-          "expr": "sum without(endpoint, instance, job, namespace, pod, prometheus, service) (llamacpp:requests_processing)",
+          "expr": "max without(endpoint, instance, pod, prometheus) (llamacpp:requests_processing)",
           "legendFormat": "Processing",
           "refId": "A"
         },
         {
           "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-          "expr": "sum without(endpoint, instance, job, namespace, pod, prometheus, service) (llamacpp:requests_deferred)",
+          "expr": "max without(endpoint, instance, pod, prometheus) (llamacpp:requests_deferred)",
           "legendFormat": "Deferred",
           "refId": "B"
         }
@@ -511,13 +511,13 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-          "expr": "sum without(endpoint, instance, job, namespace, pod, prometheus, service) (llamacpp:prompt_tokens_total)",
+          "expr": "max without(endpoint, instance, pod, prometheus) (llamacpp:prompt_tokens_total)",
           "legendFormat": "prompt tokens",
           "refId": "A"
         },
         {
           "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-          "expr": "sum without(endpoint, instance, job, namespace, pod, prometheus, service) (llamacpp:tokens_predicted_total)",
+          "expr": "max without(endpoint, instance, pod, prometheus) (llamacpp:tokens_predicted_total)",
           "legendFormat": "predicted tokens",
           "refId": "B"
         }


### PR DESCRIPTION
## Summary
- Preserve `job`, `namespace`, and `service` labels in the llama-server dashboard aggregations.
- Drop only scrape/pod identity labels with `without(endpoint, instance, pod, prometheus)`.
- Use `max without(...)` for duplicated gauge/counter series that should not be summed across scrape targets.

## Validation
- `/home/tanguille/.local/bin/mise exec -- jq empty kubernetes/apps/ai/llama-server/app/dashboard/llama-server.json`
- `/home/tanguille/.local/bin/mise exec -- kustomize build kubernetes/apps/ai/llama-server/app >/tmp/llama-server-review-kustomize.yaml`
- `/home/tanguille/.local/bin/mise exec -- kubeconform -strict -ignore-missing-schemas /tmp/llama-server-review-kustomize.yaml`
- Queried representative PromQL expressions against Grafana datasource `prometheus` and confirmed they return series with `job`, `namespace`, and `service` labels.

Follow-up to #2928.