### PR TITLE
fix(network): align cloudflared envoy routing

### DIFF
--- a/kubernetes/apps/network/cloudflared/app/helmrelease.yaml
+++ b/kubernetes/apps/network/cloudflared/app/helmrelease.yaml
@@ -25,9 +25,6 @@ spec:
             env:
               NO_AUTOUPDATE: true
               TUNNEL_METRICS: 0.0.0.0:8080
-              TUNNEL_ORIGIN_ENABLE_HTTP2: true
-              TUNNEL_POST_QUANTUM: true
-              TUNNEL_TRANSPORT_PROTOCOL: quic
             envFrom:
               - secretRef:
                   name: "{{ .Release.Name }}-secret"
@@ -68,8 +65,8 @@ spec:
               app.kubernetes.io/name: cloudflared
       securityContext:
         runAsNonRoot: true
-        runAsUser: 65534
-        runAsGroup: 65534
+        runAsUser: 1000
+        runAsGroup: 1000
     service:
       app:
         ports:

--- a/kubernetes/apps/network/cloudflared/app/resources/config.yaml
+++ b/kubernetes/apps/network/cloudflared/app/resources/config.yaml
@@ -1,17 +1,13 @@
 ---
 ingress:
   - hostname: ${SECRET_DOMAIN}
-    originRequest:
+    originRequest: &originRequest
       http2Origin: true
       keepAliveTimeout: 3600s
       originServerName: external.${SECRET_DOMAIN}
       tcpKeepAlive: 7200s
-    service: https://envoy-external.network.svc.cluster.local:443
+    service: &svc https://envoy-external.network.svc.cluster.local:443
   - hostname: "*.${SECRET_DOMAIN}"
-    originRequest:
-      http2Origin: true
-      keepAliveTimeout: 3600s
-      originServerName: external.${SECRET_DOMAIN}
-      tcpKeepAlive: 7200s
-    service: https://envoy-external.network.svc.cluster.local:443
+    originRequest: *originRequest
+    service: *svc
   - service: http_status:404

--- a/kubernetes/apps/network/cloudflared/app/resources/config.yaml
+++ b/kubernetes/apps/network/cloudflared/app/resources/config.yaml
@@ -1,10 +1,13 @@
 ---
-originRequest:
-  originServerName: external.${SECRET_DOMAIN}
-
 ingress:
   - hostname: ${SECRET_DOMAIN}
+    originRequest: &originRequest
+      http2Origin: true
+      keepAliveTimeout: 3600s
+      originServerName: external.${SECRET_DOMAIN}
+      tcpKeepAlive: 7200s
     service: &svc https://envoy-external.network.svc.cluster.local:443
   - hostname: "*.${SECRET_DOMAIN}"
+    originRequest: *originRequest
     service: *svc
   - service: http_status:404

--- a/kubernetes/apps/network/cloudflared/app/resources/config.yaml
+++ b/kubernetes/apps/network/cloudflared/app/resources/config.yaml
@@ -1,13 +1,17 @@
 ---
 ingress:
   - hostname: ${SECRET_DOMAIN}
-    originRequest: &originRequest
+    originRequest:
       http2Origin: true
       keepAliveTimeout: 3600s
       originServerName: external.${SECRET_DOMAIN}
       tcpKeepAlive: 7200s
-    service: &svc https://envoy-external.network.svc.cluster.local:443
+    service: https://envoy-external.network.svc.cluster.local:443
   - hostname: "*.${SECRET_DOMAIN}"
-    originRequest: *originRequest
-    service: *svc
+    originRequest:
+      http2Origin: true
+      keepAliveTimeout: 3600s
+      originServerName: external.${SECRET_DOMAIN}
+      tcpKeepAlive: 7200s
+    service: https://envoy-external.network.svc.cluster.local:443
   - service: http_status:404

--- a/kubernetes/apps/network/envoy-gateway/app/envoy.yaml
+++ b/kubernetes/apps/network/envoy-gateway/app/envoy.yaml
@@ -11,7 +11,8 @@ spec:
   provider:
     type: Kubernetes
     kubernetes:
-      envoyDaemonSet:
+      envoyDeployment:
+        replicas: 2
         container:
           image: mirror.gcr.io/envoyproxy/envoy:v1.38.0
           # imageRepository: mirror.gcr.io/envoyproxy/envoy

--- a/kubernetes/apps/network/envoy-gateway/app/envoy.yaml
+++ b/kubernetes/apps/network/envoy-gateway/app/envoy.yaml
@@ -11,8 +11,7 @@ spec:
   provider:
     type: Kubernetes
     kubernetes:
-      envoyDeployment:
-        replicas: 2
+      envoyDaemonSet:
         container:
           image: mirror.gcr.io/envoyproxy/envoy:v1.38.0
           # imageRepository: mirror.gcr.io/envoyproxy/envoy


### PR DESCRIPTION
## Summary
- Move Cloudflared HTTP/2 origin settings into per-ingress config with explicit keepalive tuning
- Remove global Cloudflared QUIC/post-quantum/origin HTTP2 env toggles to mirror home-ops
- Keep Envoy Gateway data plane as a DaemonSet

## Validation
- kustomize build kubernetes/apps/network/cloudflared/app | kubeconform -strict -summary -skip Secret ...
- kustomize build kubernetes/apps/network/envoy-gateway/app with Flux substitutions | kubeconform -strict -summary ...