### PR TITLE
feat(kromgo): modernize metrics showcase

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,21 +6,21 @@ Welcome to my `fluxcd` kubernetes cluster running on `talos`. This is based on t
 
 <div align="center">
 
-[![Talos](https://kromgo.tanguille.site/badges/talos_version)](https://talos.dev)&nbsp;&nbsp;
-[![Kubernetes](https://kromgo.tanguille.site/badges/kubernetes_version)](https://kubernetes.io)&nbsp;&nbsp;
-[![Flux](https://kromgo.tanguille.site/badges/flux_version)](https://fluxcd.io)&nbsp;&nbsp;
+[![Talos](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.tanguille.site%2Ftalos_version&style=for-the-badge&logo=talos&logoColor=white&color=blue&label=%20)](https://talos.dev)&nbsp;&nbsp;
+[![Kubernetes](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.tanguille.site%2Fkubernetes_version&style=for-the-badge&logo=kubernetes&logoColor=white&color=blue&label=%20)](https://kubernetes.io)&nbsp;&nbsp;
+[![Flux](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.tanguille.site%2Fflux_version&style=for-the-badge&logo=flux&logoColor=white&color=blue&label=%20)](https://fluxcd.io)&nbsp;&nbsp;
 
 </div>
 
 <div align="center">
 
-[![Age-Days](https://kromgo.tanguille.site/badges/cluster_age_days)](https://kromgo.tanguille.site/)&nbsp;&nbsp;
-[![Uptime-Days](https://kromgo.tanguille.site/badges/cluster_uptime_days)](https://kromgo.tanguille.site/)&nbsp;&nbsp;
-[![Node-Count](https://kromgo.tanguille.site/badges/cluster_node_count)](https://kromgo.tanguille.site/)&nbsp;&nbsp;
-[![Pod-Count](https://kromgo.tanguille.site/badges/cluster_pod_count)](https://kromgo.tanguille.site/)&nbsp;&nbsp;
-[![CPU-Usage](https://kromgo.tanguille.site/badges/cluster_cpu_usage)](https://kromgo.tanguille.site/)&nbsp;&nbsp;
-[![Memory-Usage](https://kromgo.tanguille.site/badges/cluster_memory_usage)](https://kromgo.tanguille.site/)&nbsp;&nbsp;
-[![Alerts](https://kromgo.tanguille.site/badges/cluster_alert_count)](https://kromgo.tanguille.site/)
+[![Age-Days](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.tanguille.site%2Fcluster_age_days&style=flat-square&label=Age)](https://kromgo.tanguille.site/)&nbsp;&nbsp;
+[![Uptime-Days](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.tanguille.site%2Fcluster_uptime_days&style=flat-square&label=Uptime)](https://kromgo.tanguille.site/)&nbsp;&nbsp;
+[![Node-Count](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.tanguille.site%2Fcluster_node_count&style=flat-square&label=Nodes)](https://kromgo.tanguille.site/)&nbsp;&nbsp;
+[![Pod-Count](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.tanguille.site%2Fcluster_pod_count&style=flat-square&label=Pods)](https://kromgo.tanguille.site/)&nbsp;&nbsp;
+[![CPU-Usage](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.tanguille.site%2Fcluster_cpu_usage&style=flat-square&label=CPU)](https://kromgo.tanguille.site/)&nbsp;&nbsp;
+[![Memory-Usage](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.tanguille.site%2Fcluster_memory_usage&style=flat-square&label=Memory)](https://kromgo.tanguille.site/)&nbsp;&nbsp;
+[![Alerts](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.tanguille.site%2Fcluster_alert_count&style=flat-square&label=Alerts)](https://kromgo.tanguille.site/)
 
 </div>
 

--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@ Welcome to my `fluxcd` kubernetes cluster running on `talos`. This is based on t
 
 <div align="center">
 
-[![Age-Days](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.tanguille.site%2Fcluster_age_days&style=flat-square&label=Age)](https://kromgo.tanguille.site/)&nbsp;&nbsp;
-[![Uptime-Days](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.tanguille.site%2Fcluster_uptime_days&style=flat-square&label=Uptime)](https://kromgo.tanguille.site/)&nbsp;&nbsp;
-[![Node-Count](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.tanguille.site%2Fcluster_node_count&style=flat-square&label=Nodes)](https://kromgo.tanguille.site/)&nbsp;&nbsp;
-[![Pod-Count](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.tanguille.site%2Fcluster_pod_count&style=flat-square&label=Pods)](https://kromgo.tanguille.site/)&nbsp;&nbsp;
-[![CPU-Usage](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.tanguille.site%2Fcluster_cpu_usage&style=flat-square&label=CPU)](https://kromgo.tanguille.site/)&nbsp;&nbsp;
-[![Memory-Usage](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.tanguille.site%2Fcluster_memory_usage&style=flat-square&label=Memory)](https://kromgo.tanguille.site/)&nbsp;&nbsp;
-[![Alerts](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.tanguille.site%2Fcluster_alert_count&style=flat-square&label=Alerts)](https://kromgo.tanguille.site/)
+[![Age-Days](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.tanguille.site%2Fcluster_age_days&style=flat-square&label=Age)](https://github.com/kashalls/kromgo)&nbsp;&nbsp;
+[![Uptime-Days](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.tanguille.site%2Fcluster_uptime_days&style=flat-square&label=Uptime)](https://github.com/kashalls/kromgo)&nbsp;&nbsp;
+[![Node-Count](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.tanguille.site%2Fcluster_node_count&style=flat-square&label=Nodes)](https://github.com/kashalls/kromgo)&nbsp;&nbsp;
+[![Pod-Count](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.tanguille.site%2Fcluster_pod_count&style=flat-square&label=Pods)](https://github.com/kashalls/kromgo)&nbsp;&nbsp;
+[![CPU-Usage](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.tanguille.site%2Fcluster_cpu_usage&style=flat-square&label=CPU)](https://github.com/kashalls/kromgo)&nbsp;&nbsp;
+[![Memory-Usage](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.tanguille.site%2Fcluster_memory_usage&style=flat-square&label=Memory)](https://github.com/kashalls/kromgo)&nbsp;&nbsp;
+[![Alerts](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.tanguille.site%2Fcluster_alert_count&style=flat-square&label=Alerts)](https://github.com/kashalls/kromgo)
 
 </div>
 

--- a/README.md
+++ b/README.md
@@ -6,21 +6,31 @@ Welcome to my `fluxcd` kubernetes cluster running on `talos`. This is based on t
 
 <div align="center">
 
-[![Talos](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.tanguille.site%2Ftalos_version&style=for-the-badge&logo=talos&logoColor=white&color=blue&label=%20)](https://talos.dev)&nbsp;&nbsp;
-[![Kubernetes](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.tanguille.site%2Fkubernetes_version&style=for-the-badge&logo=kubernetes&logoColor=white&color=blue&label=%20)](https://kubernetes.io)&nbsp;&nbsp;
-[![Flux](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.tanguille.site%2Fflux_version&style=for-the-badge&logo=flux&logoColor=white&color=blue&label=%20)](https://fluxcd.io)&nbsp;&nbsp;
+[![Talos](https://kromgo.tanguille.site/badges/talos_version)](https://talos.dev)&nbsp;&nbsp;
+[![Kubernetes](https://kromgo.tanguille.site/badges/kubernetes_version)](https://kubernetes.io)&nbsp;&nbsp;
+[![Flux](https://kromgo.tanguille.site/badges/flux_version)](https://fluxcd.io)&nbsp;&nbsp;
 
 </div>
 
 <div align="center">
 
-[![Age-Days](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.tanguille.site%2Fcluster_age_days&style=flat-square&label=Age)](https://github.com/kashalls/kromgo)&nbsp;&nbsp;
-[![Uptime-Days](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.tanguille.site%2Fcluster_uptime_days&style=flat-square&label=Uptime)](https://github.com/kashalls/kromgo)&nbsp;&nbsp;
-[![Node-Count](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.tanguille.site%2Fcluster_node_count&style=flat-square&label=Nodes)](https://github.com/kashalls/kromgo)&nbsp;&nbsp;
-[![Pod-Count](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.tanguille.site%2Fcluster_pod_count&style=flat-square&label=Pods)](https://github.com/kashalls/kromgo)&nbsp;&nbsp;
-[![CPU-Usage](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.tanguille.site%2Fcluster_cpu_usage&style=flat-square&label=CPU)](https://github.com/kashalls/kromgo)&nbsp;&nbsp;
-[![Memory-Usage](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.tanguille.site%2Fcluster_memory_usage&style=flat-square&label=Memory)](https://github.com/kashalls/kromgo)&nbsp;&nbsp;
-[![Alerts](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.tanguille.site%2Fcluster_alert_count&style=flat-square&label=Alerts)](https://github.com/kashalls/kromgo)
+[![Age-Days](https://kromgo.tanguille.site/badges/cluster_age_days)](https://kromgo.tanguille.site/)&nbsp;&nbsp;
+[![Uptime-Days](https://kromgo.tanguille.site/badges/cluster_uptime_days)](https://kromgo.tanguille.site/)&nbsp;&nbsp;
+[![Node-Count](https://kromgo.tanguille.site/badges/cluster_node_count)](https://kromgo.tanguille.site/)&nbsp;&nbsp;
+[![Pod-Count](https://kromgo.tanguille.site/badges/cluster_pod_count)](https://kromgo.tanguille.site/)&nbsp;&nbsp;
+[![CPU-Usage](https://kromgo.tanguille.site/badges/cluster_cpu_usage)](https://kromgo.tanguille.site/)&nbsp;&nbsp;
+[![Memory-Usage](https://kromgo.tanguille.site/badges/cluster_memory_usage)](https://kromgo.tanguille.site/)&nbsp;&nbsp;
+[![Alerts](https://kromgo.tanguille.site/badges/cluster_alert_count)](https://kromgo.tanguille.site/)
+
+</div>
+
+<div align="center">
+
+[Live metrics gallery](https://kromgo.tanguille.site/) ·
+[CPU graph](https://kromgo.tanguille.site/graphs/cluster_cpu_usage?last=24h) ·
+[Memory graph](https://kromgo.tanguille.site/graphs/cluster_memory_usage?last=24h) ·
+[Pods graph](https://kromgo.tanguille.site/graphs/cluster_pod_count?last=24h) ·
+[Alerts graph](https://kromgo.tanguille.site/graphs/cluster_alert_count?last=24h)
 
 </div>
 

--- a/kubernetes/apps/observability/kromgo/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kromgo/app/helmrelease.yaml
@@ -18,12 +18,17 @@ spec:
         containers:
           app:
             image:
-              repository: ghcr.io/kashalls/kromgo
-              tag: v0.10.0@sha256:965ecc92d68dc1a4a969397855367bbc70da03227a941ea607b73bb7e0b78fd6
+              repository: ghcr.io/home-operations/kromgo
+              tag: 0.14.0
             env:
               PROMETHEUS_URL: http://vmsingle-victoria-metrics.observability.svc.cluster.local:8428
               SERVER_PORT: &port 80
               HEALTH_PORT: &healthPort 8080
+              QUERY_TIMEOUT: 10s
+              SERVER_READ_TIMEOUT: 5s
+              SERVER_WRITE_TIMEOUT: 10s
+              LOG_LEVEL: info
+              LOG_FORMAT: json
             probes:
               liveness: &probes
                 enabled: true
@@ -76,5 +81,5 @@ spec:
         type: configMap
         name: kromgo-configmap
         globalMounts:
-          - path: /kromgo/config.yaml
+          - path: /config/config.yaml
             subPath: config.yaml

--- a/kubernetes/apps/observability/kromgo/app/resources/config.yaml
+++ b/kubernetes/apps/observability/kromgo/app/resources/config.yaml
@@ -44,14 +44,14 @@ badges:
     title: Nodes
     icon: mdi:server-network
     query: count(count by (node) (kube_node_status_condition{condition="Ready"}))
-    valueExpr: 'string(int(result))'
+    valueExpr: "string(int(result))"
     colorExpr: 'result >= 1.0 ? "green" : "red"'
 
   - id: cluster_pod_count
     title: Pods
     icon: mdi:cube-outline
     query: sum(kube_pod_status_phase{phase="Running"})
-    valueExpr: 'humanizeCommas(result)'
+    valueExpr: "humanizeCommas(result)"
     colorExpr: 'result >= 1.0 ? "green" : "red"'
 
   - id: cluster_cpu_usage

--- a/kubernetes/apps/observability/kromgo/app/resources/config.yaml
+++ b/kubernetes/apps/observability/kromgo/app/resources/config.yaml
@@ -1,85 +1,104 @@
 ---
-# yaml-language-server: $schema=https://raw.githubusercontent.com/kashalls/kromgo/main/config.schema.json
-badge:
-  font: Verdana.ttf
-  size: 12
+# yaml-language-server: $schema=https://raw.githubusercontent.com/home-operations/kromgo/main/config.schema.json
 
-metrics:
-  - name: talos_version
-    query: label_replace(node_os_info{name="Talos"}, "version_id", "$1", "version_id", "v(.+)")
-    label: version_id
+gallery:
+  enabled: true
+
+cache:
+  enabled: true
+  maxAge: 300
+
+defaults:
+  badge:
+    font: dejavu-sans
+    size: 11
+    style: flat-square
+    labelColor: "#374151"
+  graph:
+    maxDuration: 7d
+    width: 800
+    height: 240
+    legend: true
+    theme: catppuccin-mocha
+
+badges:
+  - id: talos_version
     title: Talos
+    icon: mdi:server
+    query: label_replace(node_os_info{name="Talos"}, "version_id", "$1", "version_id", "v(.+)")
+    valueExpr: 'labels[?"version_id"].orValue("unknown")'
 
-  - name: kubernetes_version
-    query: label_replace(kubernetes_build_info{service="kubernetes"}, "git_version", "$1", "git_version", "v(.+)")
-    label: git_version
+  - id: kubernetes_version
     title: Kubernetes
+    icon: si:kubernetes
+    query: label_replace(kubernetes_build_info{service="kubernetes"}, "git_version", "$1", "git_version", "v(.+)")
+    valueExpr: 'labels[?"git_version"].orValue("unknown")'
 
-  - name: flux_version
-    query: label_replace(flux_instance_info, "revision", "$1", "revision", "v(.+)@sha256:.+")
-    label: revision
+  - id: flux_version
     title: Flux
+    icon: mdi:sync
+    query: label_replace(flux_instance_info, "revision", "$1", "revision", "v(.+)@sha256:.+")
+    valueExpr: 'labels[?"revision"].orValue("unknown")'
 
-  - name: cluster_node_count
-    query: count(count by (node) (kube_node_status_condition{condition="Ready"}))
-    colors:
-      - { color: "green", min: 0, max: 9999 }
+  - id: cluster_node_count
     title: Nodes
+    icon: mdi:server-network
+    query: count(count by (node) (kube_node_status_condition{condition="Ready"}))
+    valueExpr: 'string(int(result))'
+    colorExpr: 'result >= 1.0 ? "green" : "red"'
 
-  - name: cluster_pod_count
-    query: sum(kube_pod_status_phase{phase="Running"})
-    colors:
-      - { color: "green", min: 0, max: 9999 }
+  - id: cluster_pod_count
     title: Pods
+    icon: mdi:cube-outline
+    query: sum(kube_pod_status_phase{phase="Running"})
+    valueExpr: 'humanizeCommas(result)'
+    colorExpr: 'result >= 1.0 ? "green" : "red"'
 
-  - name: cluster_cpu_usage
-    query: round(avg(instance:node_cpu_utilisation:rate5m{pod!=""}) * 100, 0.1)
-    suffix: "%"
-    colors:
-      - { color: "green", min: 0, max: 35 }
-      - { color: "orange", min: 36, max: 75 }
-      - { color: "red", min: 76, max: 9999 }
+  - id: cluster_cpu_usage
     title: CPU
+    icon: mdi:cpu-64-bit
+    query: round(avg(instance:node_cpu_utilisation:rate5m{pod!=""}) * 100, 0.1)
+    valueExpr: 'math.isNaN(result) ? "n/a" : humanizeFloat(result) + "%"'
+    colorExpr: 'colorScale(result, [35.0, 75.0], ["green", "orange", "red"])'
 
-  - name: cluster_memory_usage
-    query: round(sum(node_memory_MemTotal_bytes{pod!=""} - node_memory_MemAvailable_bytes{pod!=""}) / sum(node_memory_MemTotal_bytes{pod!=""}) * 100, 0.1)
-    suffix: "%"
-    colors:
-      - { color: green, min: 0, max: 35 }
-      - { color: orange, min: 36, max: 75 }
-      - { color: red, min: 76, max: 9999 }
+  - id: cluster_memory_usage
     title: Memory
+    icon: mdi:memory
+    query: round(sum(node_memory_MemTotal_bytes{pod!=""} - node_memory_MemAvailable_bytes{pod!=""}) / sum(node_memory_MemTotal_bytes{pod!=""}) * 100, 0.1)
+    valueExpr: 'math.isNaN(result) ? "n/a" : humanizeFloat(result) + "%"'
+    colorExpr: 'colorScale(result, [35.0, 75.0], ["green", "orange", "red"])'
 
-  - name: cluster_power_usage
-    query: round(upsHighPrecOutputLoad, 0.1)
-    suffix: "w"
-    colors:
-      - { color: "green", min: 0, max: 400 }
-      - { color: "orange", min: 401, max: 750 }
-      - { color: "red", min: 751, max: 9999 }
-    title: Power
-
-  - name: cluster_age_days
-    query: round((time() - min(kube_node_created) ) / 86400)
-    suffix: "d"
-    colors:
-      - { color: "green", min: 0, max: 180 }
-      - { color: "orange", min: 181, max: 360 }
-      - { color: "red", min: 361, max: 9999 }
+  - id: cluster_age_days
     title: Age
+    icon: mdi:calendar-clock
+    query: round((time() - min(kube_node_created) ) / 86400)
+    valueExpr: 'humanizeFloat(result) + "d"'
+    colorExpr: 'colorScale(result, [181.0, 361.0], ["green", "orange", "red"])'
 
-  - name: cluster_uptime_days
-    query: round(avg(node_time_seconds{pod!=""} - node_boot_time_seconds{pod!=""}) / 86400)
-    suffix: "d"
-    colors:
-      - { color: "green", min: 0, max: 180 }
-      - { color: "orange", min: 181, max: 360 }
-      - { color: "red", min: 361, max: 9999 }
+  - id: cluster_uptime_days
     title: Uptime
+    icon: mdi:timer-outline
+    query: round(avg(node_time_seconds{pod!=""} - node_boot_time_seconds{pod!=""}) / 86400)
+    valueExpr: 'humanizeFloat(result) + "d"'
+    colorExpr: 'colorScale(result, [181.0, 361.0], ["green", "orange", "red"])'
 
-  - name: cluster_alert_count
-    query: alertmanager_alerts{state="active"} - 1 # Ignore Watchdog
-    colors:
-      - { color: "green", min: 0, max: 0 }
-      - { color: "red", min: 1, max: 9999 }
+  - id: cluster_alert_count
     title: Alerts
+    icon: mdi:alert-outline
+    query: clamp_min((max(alertmanager_alerts{state="active"}) or vector(0)) - 1, 0)
+    valueExpr: 'math.isNaN(result) ? "0" : humanizeCommas(result)'
+    colorExpr: 'result > 0.0 ? "red" : "green"'
+
+graphs:
+  - id: cluster_cpu_usage
+    title: CPU
+    query: round(avg(instance:node_cpu_utilisation:rate5m{pod!=""}) * 100, 0.1)
+  - id: cluster_memory_usage
+    title: Memory
+    query: round(sum(node_memory_MemTotal_bytes{pod!=""} - node_memory_MemAvailable_bytes{pod!=""}) / sum(node_memory_MemTotal_bytes{pod!=""}) * 100, 0.1)
+  - id: cluster_pod_count
+    title: Pods
+    query: sum(kube_pod_status_phase{phase="Running"})
+  - id: cluster_alert_count
+    title: Alerts
+    query: clamp_min((max(alertmanager_alerts{state="active"}) or vector(0)) - 1, 0)


### PR DESCRIPTION
## Summary
- upgrade Kromgo to the home-operations 0.14.0 image and mount the new config path
- migrate the Kromgo configuration to the gallery/cache/defaults/badges/graphs schema
- update README badges to use direct Kromgo SVG endpoints and add gallery/graph links

## Validation
- bash .agents/skills/pr-review/scripts/validate-pr.sh
- kustomize build kubernetes/apps/observability/kromgo/app
- final whole-change review approved with only low/info notes
