### PR TITLE
fix(toolhive): redirect npx cache to /tmp for readOnlyRootFilesystem

### DIFF
--- a/kubernetes/apps/ai/toolhive/config/talos-mcp.yaml
+++ b/kubernetes/apps/ai/toolhive/config/talos-mcp.yaml
@@ -25,6 +25,10 @@ spec:
       value: /var/run/secrets/talos.dev/talosconfig
     - name: TALOS_MCP_READ_ONLY
       value: "true"
+    # ToolHive sets readOnlyRootFilesystem=true on the inner mcp container.
+    # `npx` needs a writable cache dir; redirect HOME to /tmp (writable tmpfs).
+    - name: HOME
+      value: /tmp
   toolConfigRef:
     name: *name
   podTemplateSpec:
@@ -73,6 +77,10 @@ spec:
       value: /var/run/secrets/talos.dev/talosconfig
     - name: TALOS_MCP_READ_ONLY
       value: "true"
+    # ToolHive sets readOnlyRootFilesystem=true on the inner mcp container.
+    # `npx` needs a writable cache dir; redirect HOME to /tmp (writable tmpfs).
+    - name: HOME
+      value: /tmp
   toolConfigRef:
     name: talos-mcp
   podTemplateSpec:


### PR DESCRIPTION
## Summary
- Add `HOME=/tmp` to the env of both `talos-mcp` and `talos-mcp-opt` MCPServers so npx can write its package cache to a writable tmpfs under ToolHive's `readOnlyRootFilesystem=true` security context.

## Root cause
- ToolHive applies `readOnlyRootFilesystem: true` to MCP containers.
- The `node:24.16.0-alpine3.23` image runs npm/npx as the `node` user (home `/home/node`).
- npx tries to `mkdir /home/node/.npm` and fails with `npm error code ENOENT` on every pod start, producing a CrashLoopBackOff loop on:
  - `talos-mcp-0` (StatefulSet)
  - `talos-mcp-6ff7fbfdb4-*` (Deployment)
  - `talos-mcp-opt-*`
- Setting `HOME=/tmp` redirects npm's cache to `/tmp/.npm` (writable tmpfs). This is the same pattern the karakeep inner mcp container already uses successfully.

## Test plan
- [ ] After merge and Flux reconcile, talos-mcp pods reach `Ready 1/1` instead of `CrashLoopBackOff`.
- [ ] `kubectl logs -n ai <pod> -c mcp` shows successful npx package fetch and the MCP server's stdio banner, no `ENOENT` errors.
- [ ] `kubectl get mcpserver -n ai talos-mcp` shows `Ready=True`.
- [ ] `toolhive dbmcpserver talos` is reachable and read-only tools (Talos cluster info, read endpoints) return data through the VirtualMCP grouping.

## Notes
- This PR contains only the minimum required fix to restore the service. A separate hardening change (version bump to talos-mcp@2.4.3, `permissionProfile: builtin/network`, `defaultMode: 0o400` on the talos secret volume) is staged on the `feat/add-talos-mcp` branch from the previous review and can be merged independently.