### PR TITLE
fix(toolhive): mount writable emptyDir at /tmp for talos-mcp inner container

### DIFF
--- a/kubernetes/apps/ai/toolhive/config/talos-mcp.yaml
+++ b/kubernetes/apps/ai/toolhive/config/talos-mcp.yaml
@@ -37,6 +37,12 @@ spec:
         - name: talos
           secret:
             secretName: talos-mcp
+        # Required because ToolHive sets readOnlyRootFilesystem=true on the
+        # inner mcp container. `npx -y talos-mcp@...` must download the
+        # package, so it needs a writable path. Mount an emptyDir at /tmp;
+        # HOME=/tmp (above) then points npx's cache at it.
+        - name: tmp
+          emptyDir: {}
       containers:
         - name: mcp
           command: ["npx"]
@@ -44,6 +50,8 @@ spec:
             - name: talos
               mountPath: /var/run/secrets/talos.dev
               readOnly: true
+            - name: tmp
+              mountPath: /tmp
           resources:
             requests:
               cpu: 10m
@@ -89,6 +97,10 @@ spec:
         - name: talos
           secret:
             secretName: talos-mcp
+        # See talos-mcp block above: emptyDir at /tmp gives npx a writable
+        # cache dir on a readOnlyRootFilesystem.
+        - name: tmp
+          emptyDir: {}
       containers:
         - name: mcp
           command: ["npx"]
@@ -96,6 +108,8 @@ spec:
             - name: talos
               mountPath: /var/run/secrets/talos.dev
               readOnly: true
+            - name: tmp
+              mountPath: /tmp
           resources:
             requests:
               cpu: 10m


### PR DESCRIPTION
## Summary
- Mount an `emptyDir` volume at `/tmp` on the inner `mcp` container in both `talos-mcp` and `talos-mcp-opt`, complementing #3114.

## Root cause (refinement of #3114)
- #3114 set `HOME=/tmp`, but post-merge the pods still fail. The new error is the same shape, just one level deeper:
  ```
  npm error path /tmp/.npm
  npm error errno ENOENT
  npm error enoent Invalid response body while trying to fetch
    https://registry.npmjs.org/talos-mcp: ENOENT: no such file
    or directory, mkdir '/tmp/.npm'
  ```
- `kubectl get pod talos-mcp-0 -o jsonpath='{.spec.containers[0].securityContext}'` confirms `readOnlyRootFilesystem: true` on the inner container.
- The inner pod's `volumes` list has only the `talos` secret and the projected `kube-api-access-*` token — **no tmpfs/emptyDir for /tmp**. So `/tmp` does not exist at all in the inner container's filesystem; the root is fully read-only.
- ToolHive's `HOME=/tmp` injection is applied to the *outer* proxy-runner container (verified in proxy-runner env), not propagated to the inner mcp container. The `MCPServer.spec.env.HOME` we set in #3114 *does* reach the inner container, but without a writable `/tmp` mount, npm still can't create its cache.
- The karakeep `HOME=/tmp` pattern works because karakeep is a remote/HTTP proxy MCP — its image ships pre-installed, no `npx` on startup.

## Fix
- Add `volumes: [{name: tmp, emptyDir: {}}]` and `volumeMounts: [{name: tmp, mountPath: /tmp}]` to the inner `mcp` container in both MCPServers' `podTemplateSpec`. The emptyDir is wiped on pod restart, which is fine for npx's transient cache.
- Combined with #3114's `HOME=/tmp`, npx now has a writable `/tmp/.npm` cache.

## Test plan
- [ ] After merge and Flux reconcile, `talos-mcp-0` and `talos-mcp-opt-0` StatefulSet pods reach `1/1 Running`.
- [ ] `kubectl -n ai logs talos-mcp-0 -c mcp` shows successful npx package fetch (no `ENOENT`), then the talos-mcp stdio server's banner / first tool registration.
- [ ] `kubectl -n ai get mcpserver` shows `Ready=True` for both `talos-mcp` and `talos-mcp-opt`.
- [ ] `kubectl -n ai get pod talos-mcp-0 -o jsonpath='{.spec.volumes}'` includes an `emptyDir` volume named `tmp`.