### PR TITLE
fix(gpu): set generic-device-plugin domain to squat.ai

### DIFF
--- a/kubernetes/apps/kube-system/generic-device-plugin/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/generic-device-plugin/app/helmrelease.yaml
@@ -20,7 +20,10 @@ spec:
               tag: latest@sha256:dc192e164c69b03f156765793a1be62ca437709ae477b27ca7d8f3dcf5021576
             args:
               # Expose /dev/dri as a shared squat.ai/dri resource so multiple
-              # pods (jellyfin, fileflows, ...) can transcode on the same GPU
+              # pods (jellyfin, fileflows, ...) can transcode on the same GPU.
+              # Override the plugin's default "devic.es" domain to match the
+              # squat.ai/dri resource the workloads request.
+              - --domain=squat.ai
               - --device
               - |
                 name: dri


### PR DESCRIPTION
## Problem

After the AMD GPU migration merged, jellyfin/fileflows stayed `Pending`. The generic-device-plugin advertises its resource under the **default `devic.es` domain** (`devic.es/dri`), but the workloads request `squat.ai/dri` — so the requested resource never existed.

Verified on the live node:
```
$ kubectl get node control-1 -o json | jq '.status.allocatable'
devic.es/dri: "4"      # plugin discovered /dev/dri fine, just wrong domain
```

The device discovery itself works (`/dev/dri` → `card0`+`renderD128`, count 4); only the domain was mismatched.

## Fix

Pass `--domain=squat.ai` to the plugin so it registers `squat.ai/dri`, matching the resource requests already in the jellyfin/fileflows manifests. One-line change, keeps the readable resource name.