### PR TITLE
fix(ai): vLLM Qwen3.6-27B needs --dtype float16 (GPTQ)

### DIFF
--- a/kubernetes/apps/ai/vllm/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/vllm/app/helmrelease.yaml
@@ -54,7 +54,11 @@ spec:
               - --served-model-name
               - qwen3.6-27b
               - --quantization
-              - gptq # let vLLM pick the ROCm-compatible GPTQ kernel (not Marlin/CUDA)
+              - gptq # only working 4-bit path on gfx1201: gptq_marlin is unavailable on RDNA4,
+              # and AWQ/compressed-tensors checkpoints crash the engine core. The vLLM "gptq_gemm
+              # is buggy" warning is conservative — output verified coherent on the R9700.
+              - --dtype
+              - float16 # GPTQ requires fp16; vLLM's bf16 default is rejected at config validation
               - --max-model-len
               - "65536" # start conservative; raise toward 262144 in Step 5
               - --enable-prefix-caching


### PR DESCRIPTION
## Problem

The merged `ai/vllm` deployment crashloops: vLLM defaults to **bfloat16**, but the GPTQ checkpoint requires **float16**, so it fails at config validation (`torch.bfloat16 is not supported for quantization method gptq`) before the engine ever starts.

## Fix

Add `--dtype float16`. One-line, makes the deployment actually start.

## Why GPTQ (not AWQ) — validated on-cluster

I brought this up live on the R9700 (gfx1201) and tested the alternatives:

| Quant | Result on gfx1201 |
|---|---|
| **GPTQ** (`btbtyler09/Qwen3.6-27B-GPTQ-4bit`) | ✅ loads (19.2 GiB), serves, **coherent output verified** |
| `gptq_marlin` | ❌ unavailable on RDNA4 (rejected — model config says `gptq`) |
| `--quantization awq` on `cyankiwi/...AWQ-INT4` | ❌ rejected — checkpoint is actually `compressed-tensors` format |
| `compressed-tensors` | ❌ **engine core crashes** (no working W4A16 kernel on gfx1201) |

So GPTQ is the only working 4-bit path here, and vLLM's `gptq_gemm is buggy` warning is **conservative** — output was confirmed correct (model correctly answered a factual prompt with full reasoning trace).

## Validation evidence

- vLLM `0.19.1+rocm7.13.0rc2`, architecture resolved as `Qwen3_5ForConditionalGeneration`
- ROCm init OK (`world_size=1`), **gated-DeltaNet linear-attention running via Triton/FLA GDN kernel** on RDNA4
- `Using ROCM_ATTN backend`, CUDA graphs captured, server reached `Application startup complete`
- Live `/v1/chat/completions` returned a correct, coherent answer

## Notes / follow-ups (not in this PR)

- KV cache currently ~7 GiB → 28k tokens → **1.62x concurrency at 64k** context. Tuning (raise `--max-model-len` target, consider `--kv-cache-dtype fp8_e4m3`, adjust `--gpu-memory-utilization`) is the next step.
- `HF_TOKEN` is optional (model is public; only affects HF rate limits) — left out deliberately.
- A *true* AWQ checkpoint (not compressed-tensors) could be revisited if a better-performing kernel path on gfx1201 is wanted.