### PR TITLE
fix(actions-runner): allow gpu-builder runner to run as root

### DIFF
--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/gpu-builder/helmrelease.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/gpu-builder/helmrelease.yaml
@@ -42,6 +42,10 @@ spec:
               # Run the job in the runner pod (no nested container) to inherit the GPU + disk.
               - name: ACTIONS_RUNNER_REQUIRE_JOB_CONTAINER
                 value: "false"
+              # The runner agent refuses to run as root unless this is set; we need root
+              # (+ privileged) for `podman build --device`.
+              - name: RUNNER_ALLOW_RUNASROOT
+                value: "1"
             resources:
               requests:
                 squat.ai/dri: 1 # binds /dev/dri + /dev/kfd into the pod (shared, count:4)


### PR DESCRIPTION
The `gpu-builder` runner pod crash-looped on first run:

```
Must not run interactively with sudo
Exiting runner...
```

The GitHub Actions runner agent refuses to start as root unless `RUNNER_ALLOW_RUNASROOT=1` is set — and we run it as root (+ privileged) on purpose, because the in-pod `podman build --device /dev/kfd` needs it. This adds that env var so the runner starts, registers, and can pick up the queued build job.

Verified live: the runner authenticates and scales onto control-1; it was only the agent's root-guard stopping it.