### PR TITLE
fix(renovate): group qBitrr image with ConfigVersion in one PR

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -143,10 +143,14 @@
       }
     },
     {
+      // Don't constrain matchManagers: the HelmRelease image is detected by BOTH the helm-values
+      // and kubernetes managers (the home-ops preset points both at every .yaml). Listing only a
+      // subset let the kubernetes-detected copy escape the group into a duplicate solo PR (#3155
+      // alongside the grouped #3157). Scoping by datasource+file+package already pins this to the
+      // image tag + ConfigVersion, so any manager that finds them now joins the one group PR.
       description: "qBitrr: group image tag and ConfigVersion",
       groupName: "qbitrr",
       matchDatasources: ["docker"],
-      matchManagers: ["custom.regex", "flux", "helm-values"],
       matchFileNames: ["kubernetes/apps/media/qbittorrent/tools/qbitrr/**"],
       matchPackageNames: ["/feramance\\/qbitrr/"],
       group: {

--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -143,11 +143,9 @@
       }
     },
     {
-      // Don't constrain matchManagers: the HelmRelease image is detected by BOTH the helm-values
-      // and kubernetes managers (the home-ops preset points both at every .yaml). Listing only a
-      // subset let the kubernetes-detected copy escape the group into a duplicate solo PR (#3155
-      // alongside the grouped #3157). Scoping by datasource+file+package already pins this to the
-      // image tag + ConfigVersion, so any manager that finds them now joins the one group PR.
+      // No matchManagers on purpose: the HelmRelease image is detected by both helm-values and
+      // kubernetes (home-ops points both at every .yaml); constraining managers let one copy
+      // escape into a duplicate PR. datasource+file+package already scope this precisely.
       description: "qBitrr: group image tag and ConfigVersion",
       groupName: "qbitrr",
       matchDatasources: ["docker"],

--- a/docker/llama-cpp-rocm/Dockerfile
+++ b/docker/llama-cpp-rocm/Dockerfile
@@ -84,7 +84,6 @@ RUN mkdir -p /opt/rocm-runtime \
 
 # ---------------------------------------------------------------------------------------------
 # Runtime stage — slim Ubuntu + only the ROCm runtime libs + llama.cpp binaries. No toolchain.
-# Renovate's built-in dockerfile manager keeps this FROM tag/digest current (no annotation needed).
 FROM docker.io/library/ubuntu:26.04@sha256:f3d28607ddd78734bb7f71f117f3c6706c666b8b76cbff7c9ff6e5718d46ff64 AS runtime
 
 # Runtime system deps confirmed via ldd of llama-server + libamdhip64/librocblas/libhipblaslt:

--- a/docker/llama-cpp-rocm/Dockerfile
+++ b/docker/llama-cpp-rocm/Dockerfile
@@ -84,7 +84,7 @@ RUN mkdir -p /opt/rocm-runtime \
 
 # ---------------------------------------------------------------------------------------------
 # Runtime stage — slim Ubuntu + only the ROCm runtime libs + llama.cpp binaries. No toolchain.
-# renovate: datasource=docker depName=docker.io/library/ubuntu
+# Renovate's built-in dockerfile manager keeps this FROM tag/digest current (no annotation needed).
 FROM docker.io/library/ubuntu:26.04@sha256:f3d28607ddd78734bb7f71f117f3c6706c666b8b76cbff7c9ff6e5718d46ff64 AS runtime
 
 # Runtime system deps confirmed via ldd of llama-server + libamdhip64/librocblas/libhipblaslt:


### PR DESCRIPTION
Renovate split the last qBitrr bump into two PRs — grouped #3157 (`config.toml` + `helmrelease.yaml`) and a duplicate solo #3155 (`helmrelease.yaml` only, autoclosed) — leaving the cluster stuck at 5.12.2 while 5.12.4 shipped.

## Root cause

The home-operations preset points the `flux`, `helm-values`, **and** `kubernetes` managers at every `.yaml`. The bjw-s `image.repository`/`image.tag` in the HelmRelease is detected by more than one of them. The `qbitrr` group rule constrained `matchManagers: ["custom.regex", "flux", "helm-values"]`, so the `kubernetes`-manager copy of the image fell outside the group and spawned its own PR.

## Fix

- Drop `matchManagers` from the `qbitrr` group rule. `matchDatasources` (docker) + `matchFileNames` (qbitrr dir) + `matchPackageNames` (`feramance/qbitrr`) already scope it to the image tag and ConfigVersion, so any detecting manager now folds into the single group PR.
- Drop the redundant `# renovate:` annotation on the `ubuntu` runtime `FROM` in `docker/llama-cpp-rocm/Dockerfile` — the built-in dockerfile manager detects FROM tags/digests natively (no double-detection there; the preset's annotated manager only scans `.env`/`.sh`/`.yaml`).

Config validates clean on current Renovate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)