### PR TITLE
fix(monerod): revert simple-monerod image update

### DIFF
--- a/kubernetes/apps/web3/monero/monerod/helmrelease.yaml
+++ b/kubernetes/apps/web3/monero/monerod/helmrelease.yaml
@@ -18,7 +18,7 @@ spec:
           app:
             image:
               repository: ghcr.io/sethforprivacy/simple-monerod
-              tag: v0.18.5.0@sha256:fd8bc12e93b3734e579a86ec6a6082d117fa0d53aa24e9174820dbf7ec4bc760
+              tag: v0.18.5.0@sha256:54b68cae321119c794930af32e4fec6772d9bd9e5a2b1a2e2b8efcf49ae68d8f
             args:
               - "--data-dir=/home/monero/.bitmonero"
               - "--log-file=/var/log/monero/monerod.log"
@@ -46,10 +46,10 @@ spec:
             resources:
               requests:
                 cpu: 50m
-                memory: 1Gi
+                memory: 512Mi
               limits:
                 cpu: 500m
-                memory: 4Gi
+                memory: 1Gi
             probes:
               liveness:
                 enabled: true
@@ -76,7 +76,7 @@ spec:
                   httpGet:
                     path: /get_info
                     port: 18089
-                  failureThreshold: 120
+                  failureThreshold: 60
                   periodSeconds: 10
     defaultPodOptions:
       securityContext:


### PR DESCRIPTION
## Summary
- revert simple-monerod back to the pre-update image digest
- restore monerod memory requests/limits and startup probe threshold from before the update

## Validation
- git diff --check for the Monero manifests
- YAML parse for monerod, p2pool, and dashboard HelmReleases