### PR TITLE
feat(ai): restore llama.cpp router mode with non-Python metrics gate

### DIFF
--- a/kubernetes/apps/ai/litellm/app/configmap.yaml
+++ b/kubernetes/apps/ai/litellm/app/configmap.yaml
@@ -13,6 +13,13 @@ data:
           api_key: os.environ/LLAMA_SERVER_API_KEY
         model_info:
           mode: chat
+      # Auto-expose every other model the llama-server router serves (e.g. qwen3-embedding) without a
+      # per-model entry. litellm matches exact names first, then falls through to this wildcard.
+      - model_name: "*"
+        litellm_params:
+          model: openai/*
+          api_base: http://llama-server.ai.svc.cluster.local/v1
+          api_key: os.environ/LLAMA_SERVER_API_KEY
 
     litellm_settings:
       callbacks: ["prometheus"]

--- a/kubernetes/apps/ai/llama-server/app/config/llama-metrics-gate.sh
+++ b/kubernetes/apps/ai/llama-server/app/config/llama-metrics-gate.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+# Hot-only metrics gate (non-Python replacement for PR #3042). Scrapes the router with
+# autoload=false so a scrape never force-loads a cold model, then serves a Prometheus file
+# (hot/cold state + passthrough llamacpp:* when hot) via busybox httpd — always HTTP 200, so the
+# vmagent target never flaps while qwen-3.6 is cold. Single-model by design: iterate the router's
+# /v1/models if a second model starts serving traffic.
+# set -u (not -e): keep the loop alive through transient upstream failures.
+set -u
+
+URL="http://127.0.0.1:8080/metrics?model=qwen-3.6&autoload=false"
+OUT=/run/metrics/metrics
+LASTOK=0
+
+: >"$OUT" # seed so the first scrape is 200 before the loop's first write
+
+(
+  while true; do
+    if BODY="$(wget -qO- "$URL" 2>/dev/null)" && [ -n "$BODY" ]; then
+      LOADED=1; UP=1; CODE=200; LASTOK="$(date +%s)"
+    else
+      LOADED=0; UP=0; CODE=400; BODY=""
+    fi
+    {
+      echo "# HELP llama_model_loaded 1 when live llama.cpp metrics were collected without autoloading."
+      echo "# TYPE llama_model_loaded gauge"
+      echo "llama_model_loaded{model=\"qwen-3.6\"} $LOADED"
+      echo "# HELP llama_upstream_metrics_up 1 when the upstream metrics request succeeded."
+      echo "# TYPE llama_upstream_metrics_up gauge"
+      echo "llama_upstream_metrics_up{model=\"qwen-3.6\"} $UP"
+      echo "# HELP llama_exporter_last_successful_scrape_timestamp_seconds Unix time of the last successful upstream scrape."
+      echo "# TYPE llama_exporter_last_successful_scrape_timestamp_seconds gauge"
+      echo "llama_exporter_last_successful_scrape_timestamp_seconds $LASTOK"
+      echo "# HELP llama_exporter_upstream_http_status Last upstream metrics HTTP status (200 = hot, 400 = cold/unloaded)."
+      echo "# TYPE llama_exporter_upstream_http_status gauge"
+      echo "llama_exporter_upstream_http_status{model=\"qwen-3.6\"} $CODE"
+      if [ -n "$BODY" ]; then printf '%s\n' "$BODY"; fi
+    } >"$OUT.tmp" && mv "$OUT.tmp" "$OUT"
+    sleep 55 # just under the 1m scrape — one fresh sample per scrape, not ~4x
+  done
+) &
+
+exec httpd -f -v -p 9108 -h /run/metrics

--- a/kubernetes/apps/ai/llama-server/app/config/models.ini
+++ b/kubernetes/apps/ai/llama-server/app/config/models.ini
@@ -1,0 +1,45 @@
+version = 1
+
+; llama.cpp router presets (--models-preset). Clients pick the model via the OpenAI `model`
+; field; per-model metrics at /metrics?model=<id>. R9700 (gfx1201, 32 GB); --models-max 2 keeps
+; both presets resident (no idle eviction), so qwen-3.6 stays hot.
+[*]
+jinja = true
+flash-attn = auto
+metrics = true
+slots = true
+parallel = 1
+
+[qwen-3.6]
+; Proven 27B-MTP config (~34 tok/s): full 256K ctx + q8 KV + all experts on the 32 GB GPU.
+hf-repo = unsloth/Qwen3.6-27B-MTP-GGUF
+hf-file = Qwen3.6-27B-UD-Q4_K_XL.gguf
+n-gpu-layers = 99
+fit = off # auto-fit hangs on this model (MTP ctx + q8 KV); pin ngl/ctx instead
+no-mmap = true # mmap re-faults the 18Gi weights from the cache PVC (130s+ cold load)
+flash-attn = on
+ctx-size = 262144
+cache-type-k = q8_0
+cache-type-v = q8_0
+spec-type = draft-mtp # MTP self-speculative decoding (n-max 3 = sweep optimum, 1.42x)
+spec-draft-n-max = 3
+cache-ram = 8192 # host-RAM prompt cache: agentic prefix reuse, 7.5x warm TTFT
+ctx-checkpoints = 32
+; Unsloth thinking-mode sampling defaults.
+temp = 1.0
+top-k = 20
+top-p = 0.95
+min-p = 0.0
+
+[qwen3-embedding]
+; Dormant (embeddings run on TEI today); resident alongside chat via --models-max 2,
+; ready for a litellm embedding route later.
+hf-repo = Qwen/Qwen3-Embedding-0.6B-GGUF
+hf-file = Qwen3-Embedding-0.6B-f16.gguf
+embeddings = true
+pooling = last
+n-gpu-layers = 99
+ctx-size = 8192
+batch-size = 8192
+ubatch-size = 8192
+threads = 4

--- a/kubernetes/apps/ai/llama-server/app/dashboard/llama-server.json
+++ b/kubernetes/apps/ai/llama-server/app/dashboard/llama-server.json
@@ -15,54 +15,344 @@
       }
     ]
   },
-  "description": "llama.cpp router inference metrics, scraped from /metrics?model=qwen-3.6 without autoloading the model.",
+  "description": "llama.cpp router inference metrics, scraped through llama-metrics-gate so cold models do not cause vmagent scrape failures or monitoring-triggered autoload.",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
-  "links": [
-    {
-      "title": "AMD GPU",
-      "url": "/d/amdgpu-node/amdgpu",
-      "icon": "graph",
-      "targetBlank": false,
-      "type": "dashboards"
-    }
-  ],
   "liveNow": false,
   "panels": [
     {
       "collapsed": false,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 900,
+      "panels": [],
+      "title": "Model metrics state",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "text": "Cold"
+                },
+                "1": {
+                  "text": "Hot"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "orange",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 0,
+        "y": 1
+      },
+      "id": 901,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "llama_model_loaded{model=\"qwen-3.6\"}",
+          "legendFormat": "qwen-3.6",
+          "refId": "A"
+        }
+      ],
+      "title": "Model state",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "text": "Cold / unavailable"
+                },
+                "1": {
+                  "text": "Collecting"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "orange",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 6,
+        "y": 1
+      },
+      "id": 902,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "llama_upstream_metrics_up{model=\"qwen-3.6\"}",
+          "legendFormat": "upstream",
+          "refId": "A"
+        }
+      ],
+      "title": "Metrics scrape state",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 300
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 12,
+        "y": 1
+      },
+      "id": 903,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "clamp_min(time() - llama_exporter_last_successful_scrape_timestamp_seconds, 0)",
+          "legendFormat": "freshness",
+          "refId": "A"
+        }
+      ],
+      "title": "Metrics freshness",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 18,
+        "y": 1
+      },
+      "id": 904,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "llama_exporter_upstream_http_status{model=\"qwen-3.6\"}",
+          "legendFormat": "HTTP status",
+          "refId": "A"
+        }
+      ],
+      "title": "Last upstream status",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 7
+      },
       "id": 100,
       "panels": [],
       "title": "Throughput",
       "type": "row"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "description": "Current prompt-processing (prefill) speed reported by llama.cpp. Sparkline shows recent trend.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Current prompt-processing (prefill) speed reported by llama.cpp. Gauge value from the most recent completed request. Missing data can mean the model is cold and llama-metrics-gate is intentionally not waking it.",
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
+          "color": {
+            "mode": "thresholds"
+          },
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
-            "steps": [{ "color": "blue", "value": null }]
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
           },
           "unit": "short",
           "decimals": 1
         },
         "overrides": []
       },
-      "gridPos": { "h": 6, "w": 6, "x": 0, "y": 1 },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 0,
+        "y": 8
+      },
       "id": 1,
       "options": {
         "colorMode": "value",
-        "graphMode": "area",
+        "graphMode": "none",
         "justifyMode": "center",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -72,7 +362,10 @@
       "pluginVersion": "11.0.0",
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "expr": "max without(endpoint, instance, pod, prometheus) (llamacpp:prompt_tokens_seconds)",
           "legendFormat": "Prefill",
           "refId": "A"
@@ -82,30 +375,47 @@
       "type": "stat"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "description": "Current decode (generation) speed. Sparkline shows recent trend.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Current decode (generation) speed. Gauge value from the most recent completed request. Missing data can mean the model is cold and llama-metrics-gate is intentionally not waking it.",
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
+          "color": {
+            "mode": "thresholds"
+          },
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
-            "steps": [{ "color": "green", "value": null }]
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
           },
           "unit": "short",
           "decimals": 1
         },
         "overrides": []
       },
-      "gridPos": { "h": 6, "w": 6, "x": 6, "y": 1 },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 6,
+        "y": 8
+      },
       "id": 2,
       "options": {
         "colorMode": "value",
-        "graphMode": "area",
+        "graphMode": "none",
         "justifyMode": "center",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -115,7 +425,10 @@
       "pluginVersion": "11.0.0",
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "expr": "max without(endpoint, instance, pod, prometheus) (llamacpp:predicted_tokens_seconds)",
           "legendFormat": "Decode",
           "refId": "A"
@@ -125,34 +438,56 @@
       "type": "stat"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "description": "Active request slots in llama.cpp. `processing` = currently decoding; `deferred` = queued because all parallel slots are busy.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Active request slots in llama.cpp. `processing` = currently decoding; `deferred` = queued because all parallel slots are busy. Missing data can mean the model is cold and llama-metrics-gate is intentionally not waking it.",
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
+          "color": {
+            "mode": "thresholds"
+          },
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null },
-              { "color": "orange", "value": 1 }
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1
+              }
             ]
           },
           "unit": "none"
         },
         "overrides": [
           {
-            "matcher": { "id": "byName", "options": "Deferred" },
+            "matcher": {
+              "id": "byName",
+              "options": "Deferred"
+            },
             "properties": [
               {
                 "id": "color",
-                "value": { "fixedColor": "red", "mode": "fixed" }
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
               }
             ]
           }
         ]
       },
-      "gridPos": { "h": 6, "w": 6, "x": 12, "y": 1 },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 12,
+        "y": 8
+      },
       "id": 3,
       "options": {
         "colorMode": "value",
@@ -160,7 +495,9 @@
         "justifyMode": "center",
         "orientation": "horizontal",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -170,13 +507,19 @@
       "pluginVersion": "11.0.0",
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "expr": "max without(endpoint, instance, pod, prometheus) (llamacpp:requests_processing)",
           "legendFormat": "Processing",
           "refId": "A"
         },
         {
-          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "expr": "max without(endpoint, instance, pod, prometheus) (llamacpp:requests_deferred)",
           "legendFormat": "Deferred",
           "refId": "B"
@@ -186,19 +529,25 @@
       "type": "stat"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "description": "Configured context window tokens reported by the loaded llama.cpp child model.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Maximum context tokens observed/reported by llama.cpp; this is not the configured context capacity. Missing data can mean the model is cold and llama-metrics-gate is intentionally not waking it.",
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
+          "color": {
+            "mode": "thresholds"
+          },
           "mappings": [],
           "min": 0,
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null },
-              { "color": "blue", "value": 32768 },
-              { "color": "purple", "value": 131072 }
+              {
+                "color": "blue",
+                "value": null
+              }
             ]
           },
           "unit": "short",
@@ -206,14 +555,21 @@
         },
         "overrides": []
       },
-      "gridPos": { "h": 6, "w": 6, "x": 18, "y": 1 },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 18,
+        "y": 8
+      },
       "id": 4,
       "options": {
         "minVizHeight": 75,
         "minVizWidth": 75,
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -223,21 +579,29 @@
       "pluginVersion": "11.0.0",
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "expr": "max without(endpoint, instance, pod, prometheus) (llamacpp:n_tokens_max)",
           "legendFormat": "context tokens",
           "refId": "A"
         }
       ],
-      "title": "Context window",
+      "title": "Observed context high watermark",
       "type": "gauge"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "description": "Prompt (prefill) and decode speed over time, from the most recent completed request.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Prompt (prefill) and decode speed over time, from the most recent completed request. Missing data can mean the model is cold and llama-metrics-gate is intentionally not waking it.",
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
             "axisCenteredZero": false,
             "axisColorMode": "text",
@@ -247,46 +611,79 @@
             "drawStyle": "line",
             "fillOpacity": 10,
             "gradientMode": "none",
-            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
             "lineInterpolation": "linear",
             "lineWidth": 2,
             "pointSize": 4,
-            "scaleDistribution": { "type": "linear" },
+            "scaleDistribution": {
+              "type": "linear"
+            },
             "showPoints": "never",
             "spanNulls": true,
-            "stacking": { "group": "A", "mode": "none" },
-            "thresholdsStyle": { "mode": "off" }
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
           },
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
-            "steps": [{ "color": "green", "value": null }]
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
           },
           "unit": "short"
         },
         "overrides": []
       },
-      "gridPos": { "h": 10, "w": 24, "x": 0, "y": 7 },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 14
+      },
       "id": 5,
       "options": {
         "legend": {
-          "calcs": ["mean", "max"],
+          "calcs": [
+            "mean",
+            "max"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
         },
-        "tooltip": { "mode": "multi", "sort": "desc" }
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
       "pluginVersion": "11.0.0",
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "expr": "max without(endpoint, instance, pod, prometheus) (llamacpp:prompt_tokens_seconds)",
           "legendFormat": "Prefill",
           "refId": "A"
         },
         {
-          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "expr": "max without(endpoint, instance, pod, prometheus) (llamacpp:predicted_tokens_seconds)",
           "legendFormat": "Decode",
           "refId": "B"
@@ -297,18 +694,28 @@
     },
     {
       "collapsed": false,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 17 },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 24
+      },
       "id": 101,
       "panels": [],
       "title": "Context, cache & queue",
       "type": "row"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "description": "Configured context window tokens over time. Recent upstream llama.cpp metrics no longer expose KV cache fill ratio directly.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Maximum context tokens observed/reported by llama.cpp; this is not the configured context capacity. Missing data can mean the model is cold and llama-metrics-gate is intentionally not waking it.",
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
             "axisCenteredZero": false,
             "axisColorMode": "text",
@@ -327,44 +734,64 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null },
-              { "color": "blue", "value": 32768 },
-              { "color": "purple", "value": 131072 }
+              {
+                "color": "blue",
+                "value": null
+              }
             ]
           },
           "unit": "short"
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 18 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 25
+      },
       "id": 6,
       "options": {
         "legend": {
-          "calcs": ["mean", "max"],
+          "calcs": [
+            "mean",
+            "max"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
         },
-        "tooltip": { "mode": "multi", "sort": "desc" }
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
       "pluginVersion": "11.0.0",
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "expr": "max without(endpoint, instance, pod, prometheus) (llamacpp:n_tokens_max)",
           "legendFormat": "context tokens",
           "refId": "A"
         }
       ],
-      "title": "Context window",
+      "title": "Observed context high watermark",
       "type": "timeseries"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "description": "Average number of busy slots per decode step. This is the closest currently exported upstream signal for slot/KV pressure.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Average number of busy slots per decode step. This is the closest currently exported upstream signal for slot/KV pressure. Missing data can mean the model is cold and llama-metrics-gate is intentionally not waking it.",
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
             "axisCenteredZero": false,
             "axisColorMode": "text",
@@ -381,27 +808,46 @@
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
-            "steps": [{ "color": "green", "value": null }]
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
           },
           "unit": "short"
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 18 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 25
+      },
       "id": 7,
       "options": {
         "legend": {
-          "calcs": ["mean", "max"],
+          "calcs": [
+            "mean",
+            "max"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
         },
-        "tooltip": { "mode": "multi", "sort": "desc" }
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
       "pluginVersion": "11.0.0",
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "expr": "max without(endpoint, instance, pod, prometheus) (llamacpp:n_busy_slots_per_decode)",
           "legendFormat": "busy slots/decode",
           "refId": "A"
@@ -411,11 +857,16 @@
       "type": "timeseries"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "description": "Processing and deferred request counts over time. Deferred > 0 sustained means you need more --parallel slots or callers are too bursty.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Processing and deferred request counts over time. Deferred > 0 sustained means you need more --parallel slots or callers are too bursty. Missing data can mean the model is cold and llama-metrics-gate is intentionally not waking it.",
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
             "axisCenteredZero": false,
             "axisColorMode": "text",
@@ -427,39 +878,64 @@
             "lineWidth": 2,
             "showPoints": "never",
             "spanNulls": true,
-            "stacking": { "group": "A", "mode": "none" }
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
           },
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
-            "steps": [{ "color": "green", "value": null }]
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
           },
           "unit": "none",
           "decimals": 0
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 26 },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 33
+      },
       "id": 8,
       "options": {
         "legend": {
-          "calcs": ["mean", "max"],
+          "calcs": [
+            "mean",
+            "max"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
         },
-        "tooltip": { "mode": "multi", "sort": "desc" }
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
       "pluginVersion": "11.0.0",
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "expr": "max without(endpoint, instance, pod, prometheus) (llamacpp:requests_processing)",
           "legendFormat": "Processing",
           "refId": "A"
         },
         {
-          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "expr": "max without(endpoint, instance, pod, prometheus) (llamacpp:requests_deferred)",
           "legendFormat": "Deferred",
           "refId": "B"
@@ -470,18 +946,28 @@
     },
     {
       "collapsed": false,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 34 },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 41
+      },
       "id": 102,
       "panels": [],
       "title": "Cumulative token totals",
       "type": "row"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "description": "Total tokens llama.cpp has ingested (prompt) and emitted (predicted) since the process started. Counters reset on pod restart.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Total tokens llama.cpp has ingested (prompt) and emitted (predicted) since the process started. Counters reset on pod restart. Missing data can mean the model is cold and llama-metrics-gate is intentionally not waking it.",
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
             "axisCenteredZero": false,
             "axisColorMode": "text",
@@ -497,33 +983,54 @@
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
-            "steps": [{ "color": "green", "value": null }]
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
           },
           "unit": "short"
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 35 },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 42
+      },
       "id": 9,
       "options": {
         "legend": {
-          "calcs": ["last"],
+          "calcs": [
+            "last"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
         },
-        "tooltip": { "mode": "multi", "sort": "desc" }
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
       "pluginVersion": "11.0.0",
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "expr": "max without(endpoint, instance, pod, prometheus) (llamacpp:prompt_tokens_total)",
           "legendFormat": "prompt tokens",
           "refId": "A"
         },
         {
-          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "expr": "max without(endpoint, instance, pod, prometheus) (llamacpp:tokens_predicted_total)",
           "legendFormat": "predicted tokens",
           "refId": "B"
@@ -534,18 +1041,28 @@
     },
     {
       "collapsed": false,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 43 },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 50
+      },
       "id": 103,
       "panels": [],
       "title": "GPU",
       "type": "row"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "description": "GPU utilization percent. On our single-GPU node this is effectively llama.cpp's share.",
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
             "axisCenteredZero": false,
             "drawStyle": "line",
@@ -560,29 +1077,48 @@
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
-            "steps": [{ "color": "green", "value": null }]
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
           },
           "unit": "percent"
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 44 },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 51
+      },
       "id": 10,
       "options": {
         "legend": {
-          "calcs": ["mean", "max"],
+          "calcs": [
+            "mean",
+            "max"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
         },
-        "tooltip": { "mode": "multi", "sort": "desc" }
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
       "pluginVersion": "11.0.0",
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-          "expr": "DCGM_FI_DEV_GPU_UTIL",
-          "legendFormat": "{{Hostname}} gpu{{gpu}}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "node_drm_gpu_busy_percent",
+          "legendFormat": "{{nodename}}",
           "refId": "A"
         }
       ],
@@ -590,11 +1126,16 @@
       "type": "timeseries"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "description": "VRAM used/free in GiB. Full is ~8 GiB on RTX 2070.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "VRAM used vs total. The R9700 has 32 GiB.",
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
             "axisCenteredZero": false,
             "drawStyle": "line",
@@ -607,35 +1148,57 @@
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
-            "steps": [{ "color": "green", "value": null }]
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
           },
-          "unit": "suffix: GiB"
+          "unit": "bytes"
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 44 },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 51
+      },
       "id": 11,
       "options": {
         "legend": {
-          "calcs": ["mean", "max"],
+          "calcs": [
+            "mean",
+            "max"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
         },
-        "tooltip": { "mode": "multi", "sort": "desc" }
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
       "pluginVersion": "11.0.0",
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-          "expr": "DCGM_FI_DEV_FB_USED / 1024",
-          "legendFormat": "{{Hostname}} gpu{{gpu}} used",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "node_drm_memory_vram_used_bytes",
+          "legendFormat": "{{nodename}} used",
           "refId": "A"
         },
         {
-          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-          "expr": "DCGM_FI_DEV_FB_FREE / 1024",
-          "legendFormat": "{{Hostname}} gpu{{gpu}} free",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "node_drm_memory_vram_size_bytes",
+          "legendFormat": "{{nodename}} total",
           "refId": "B"
         }
       ],
@@ -643,11 +1206,16 @@
       "type": "timeseries"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "description": "GPU temperature, Celsius.",
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
+          "color": {
+            "mode": "thresholds"
+          },
           "custom": {
             "axisCenteredZero": false,
             "drawStyle": "line",
@@ -661,32 +1229,55 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null },
-              { "color": "orange", "value": 75 },
-              { "color": "red", "value": 85 }
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 75
+              },
+              {
+                "color": "red",
+                "value": 85
+              }
             ]
           },
           "unit": "celsius"
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 44 },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 51
+      },
       "id": 12,
       "options": {
         "legend": {
-          "calcs": ["mean", "max"],
+          "calcs": [
+            "mean",
+            "max"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
         },
-        "tooltip": { "mode": "multi", "sort": "desc" }
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
       "pluginVersion": "11.0.0",
       "targets": [
         {
-          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-          "expr": "DCGM_FI_DEV_GPU_TEMP",
-          "legendFormat": "{{Hostname}} gpu{{gpu}}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "max by (nodename) (node_hwmon_temp_celsius and on (chip, instance) node_hwmon_chip_names{chip_name=\"amdgpu\"})",
+          "legendFormat": "{{nodename}}",
           "refId": "A"
         }
       ],
@@ -695,8 +1286,12 @@
     }
   ],
   "refresh": "1m",
-  "schemaVersion": 41,
-  "tags": ["ai", "llama-server", "llama-cpp"],
+  "schemaVersion": 39,
+  "tags": [
+    "ai",
+    "llama-server",
+    "llama-cpp"
+  ],
   "templating": {
     "list": [
       {
@@ -715,11 +1310,28 @@
       }
     ]
   },
-  "time": { "from": "now-1h", "to": "now" },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
   "timepicker": {},
   "timezone": "browser",
   "title": "llama-server",
   "uid": "ai-llama-server",
   "version": 1,
-  "weekStart": ""
+  "weekStart": "",
+  "links": [
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": false,
+      "keepTime": false,
+      "tags": [],
+      "targetBlank": false,
+      "title": "AMD GPU",
+      "tooltip": "",
+      "type": "link",
+      "url": "/d/amdgpu-node/amdgpu"
+    }
+  ]
 }

--- a/kubernetes/apps/ai/llama-server/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/llama-server/app/helmrelease.yaml
@@ -48,54 +48,18 @@ spec:
               tag: gfx1201@sha256:b617d31bcce8ed30e3c1650677a8c131612cb00f1d759545346c06d18356c978
             env:
               TZ: ${TIMEZONE}
-              LLAMA_CACHE: /cache # -hf downloads the GGUF here (the cache PVC); ties to the mount below
+              LLAMA_CACHE: /cache # GGUF download cache (the cache PVC)
             args:
               - --host
               - 0.0.0.0
               - --port
               - "8080"
-              # Unsloth MTP GGUF (UD-Q4_K_XL, MTP head embedded). First boot downloads ~18Gi to /cache.
-              - -hf
-              - unsloth/Qwen3.6-27B-MTP-GGUF
-              - --hf-file
-              - Qwen3.6-27B-UD-Q4_K_XL.gguf
-              - --alias
-              - qwen-3.6 # served-model-name litellm targets
-              - -ngl
-              - "99"
-              - --fit
-              - "off" # we pin ngl/ctx; the auto-fit step hangs on this model (708Mi MTP ctx + q8 KV)
-              - --no-mmap # REQUIRED: mmap re-faults the 18Gi weights from the PVC on cold cache (130s+ load)
-              - -fa
-              - "1"
-              - -ctk
-              - q8_0 # near-lossless KV; gibberish-safe at full context (q4_0 only if VRAM-bound)
-              - -ctv
-              - q8_0
-              - -c
-              - "262144" # full native context (Qwen3-Next 256K); only 16/64 layers grow KV
-              - -np
-              - "1" # max 1 session for now (frees VRAM for full-context q8_0 KV)
-              # MTP self-speculative decoding: 34 tok/s (n-max=3 was the sweep optimum, 1.42x baseline).
-              - --spec-type
-              - draft-mtp
-              - --spec-draft-n-max
-              - "3"
-              # Prompt cache (host RAM) — agentic prefix reuse, 7.5x warm TTFT. Coexists with batching.
-              - --cache-ram
-              - "8192"
-              - --ctx-checkpoints
-              - "32"
-              # Unsloth thinking-mode sampling defaults (agentic reasoning workload).
-              - --temp
-              - "1.0"
-              - --top-k
-              - "20"
-              - --top-p
-              - "0.95"
-              - --min-p
-              - "0.0"
-              - --jinja # use the GGUF chat template (tool-calling / thinking split)
+              # Router mode: per-model serving lives in /app/models.ini (mounted below).
+              # --models-max 2 keeps both presets (27B chat + 0.6B embedding) resident.
+              - --models-preset
+              - /app/models.ini
+              - --models-max
+              - "2"
               - --metrics
               - --slots
             probes:
@@ -106,11 +70,11 @@ spec:
                   httpGet: &httpGet
                     path: /health
                     port: &port 8080
-                  initialDelaySeconds: 15
-                  periodSeconds: 15
+                  initialDelaySeconds: 10
+                  periodSeconds: 10
                   timeoutSeconds: 5
-                  # First boot: ~18Gi GGUF download + load. Generous ceiling (~20 min).
-                  failureThreshold: 80
+                  # Router /health is up at process start (models load lazily) — cover start only.
+                  failureThreshold: 18
               liveness:
                 <<: *probeBase
                 spec:
@@ -137,6 +101,43 @@ spec:
                 memory: 28Gi # 8Gi prompt cache + load buffers + headroom (weights live in VRAM)
                 squat.ai/dri: 1
 
+          # Hot-only metrics gate (busybox; config/llama-metrics-gate.sh). Scrapes the router with
+          # autoload=false and always serves 200 so the scrape target never flaps when cold.
+          metrics-gate:
+            image:
+              repository: docker.io/library/busybox
+              tag: "1.37.0" # Renovate digest-pins on next run
+            command: ["/bin/sh", "/scripts/llama-metrics-gate.sh"]
+            ports:
+              - name: metrics
+                containerPort: 9108
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  exec:
+                    command: ["/bin/sh", "-c", "find /run/metrics/metrics -mmin -1 | grep -q ."]
+                  initialDelaySeconds: 30
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+            securityContext:
+              # Root (writes the emptyDir, avoids an fsGroup chown of the cache PVC) but hardened.
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop: ["ALL"]
+              seccompProfile:
+                type: RuntimeDefault
+            resources:
+              requests:
+                cpu: 10m
+                memory: 16Mi
+              limits:
+                cpu: 50m
+                memory: 64Mi
+
     service:
       app:
         controller: app
@@ -144,6 +145,9 @@ spec:
           http:
             port: 80
             targetPort: *port
+          metrics:
+            port: 9108
+            targetPort: 9108
 
     route:
       app:
@@ -164,15 +168,44 @@ spec:
                 port: 80
 
     persistence:
+      # advancedMounts scope these to the app container (keep them off the gate sidecar).
+      config:
+        type: configMap
+        name: llama-server-config
+        advancedMounts:
+          app:
+            app:
+              - path: /app/models.ini
+                subPath: models.ini
+                readOnly: true
       cache:
         enabled: true
         existingClaim: llama-server
-        globalMounts:
-          - path: /cache
+        advancedMounts:
+          app:
+            app:
+              - path: /cache
       # llama.cpp uses /dev/shm for slot/IPC; bump from the default 64Mi.
       shm:
         type: emptyDir
         medium: Memory
         sizeLimit: 2Gi
-        globalMounts:
-          - path: /dev/shm
+        advancedMounts:
+          app:
+            app:
+              - path: /dev/shm
+      # gate sidecar: script ConfigMap + output dir.
+      gate-script:
+        type: configMap
+        name: llama-metrics-gate
+        advancedMounts:
+          app:
+            metrics-gate:
+              - path: /scripts
+                readOnly: true
+      metrics:
+        type: emptyDir
+        advancedMounts:
+          app:
+            metrics-gate:
+              - path: /run/metrics

--- a/kubernetes/apps/ai/llama-server/app/kustomization.yaml
+++ b/kubernetes/apps/ai/llama-server/app/kustomization.yaml
@@ -13,6 +13,16 @@ resources:
   - grafanadashboard.yaml
 
 configMapGenerator:
+  - name: llama-server-config
+    files:
+      - config/models.ini
+  # substitute disabled: Flux envsubst would otherwise strip the script's $VAR.
+  - name: llama-metrics-gate
+    files:
+      - config/llama-metrics-gate.sh
+    options:
+      annotations:
+        kustomize.toolkit.fluxcd.io/substitute: disabled
   - name: llama-server-dashboard
     files:
       - dashboard/llama-server.json

--- a/kubernetes/apps/ai/llama-server/app/servicemonitor.yaml
+++ b/kubernetes/apps/ai/llama-server/app/servicemonitor.yaml
@@ -10,17 +10,10 @@ spec:
       app.kubernetes.io/name: llama-server
       app.kubernetes.io/instance: llama-server
   endpoints:
-    # llama.cpp router exposes per-model metrics via /metrics?model=...
-    # Upstream returns HTTP 400 for unloaded models when autoload=false; keep
-    # autoload=true so vmagent can scrape metrics without target-down churn.
-    - port: http
+    # Scrape the metrics-gate sidecar (always 200, never autoloads the model; see the gate script).
+    - port: metrics
       path: /metrics
-      params:
-        model: [qwen-3.6]
-        autoload: ["true"]
       interval: 1m
-      scrapeTimeout: 30s
-  # llama.cpp's /metrics exposition uses OpenMetrics-ish text/plain without
-  # an explicit content-type version header; force the legacy protocol so
-  # Prometheus doesn't reject it under strict negotiation.
+      scrapeTimeout: 10s
+  # busybox httpd omits a content-type version header; force the legacy text protocol for vmagent.
   fallbackScrapeProtocol: PrometheusText0.0.4


### PR DESCRIPTION
## Summary
- Restore llama.cpp **router mode** (the deleted `config/models.ini`). The ServiceMonitor + dashboard were already router-shaped (`/metrics?model=…`), so reverting to single-model serving is why the dashboard had no data.
- `[qwen-3.6]` preset keeps the current **proven 27B-MTP tuning** (256K q8 KV, draft-mtp n-max 3, cache-ram 8192) — translated to router form, not the old 35B/RTX-2070 config. `--models-max 2` so the 27B chat + 0.6B embedding models stay resident together on the 32 GiB R9700.
- **Non-Python hot-metrics gate**: a ~25-line busybox sidecar (`config/llama-metrics-gate.sh`) scrapes the router with `autoload=false` (a scrape never force-loads the model), always returns 200, and emits hot/cold state metrics. Re-implements the gate from #3042 without Python (no runtime, no test suite, no ConfigMap-mounted Python).
- **Dashboard**: model-state panels (hot/cold, scrape state, freshness, upstream status); GPU panels fixed NVIDIA `DCGM_*` → AMD `node_drm_*`/`node_hwmon_*`; replaced the dashboard-list link (rendered a dropdown of *every* dashboard) with a single link to the AMD GPU dashboard.
- **litellm**: `model_name: "*"` → `openai/*` wildcard auto-exposes every router model (qwen3-embedding, future presets); `qwen-3.6` stays explicit for `model_info.mode: chat`.

Supersedes #3042 (re-implements its hot-metrics gate without Python).

## Validation
- `kubectl kustomize` builds clean (llama-server + litellm)
- `helm template` (app-template 5.0.1) renders the sidecar and per-container volume scoping correctly (app gets `/cache`+`/app/models.ini`+`/dev/shm`; gate gets only `/scripts`+`/run/metrics`)
- `sh -n` + `shellcheck` clean on the gate script
- dashboard JSON valid (`jq`)

## Not verified pre-merge (needs a live reconcile)
- that the `llamacpp:*` metric names match what build `b9626` actually exposes
- that busybox httpd's content-type parses in vmagent (kept `fallbackScrapeProtocol: PrometheusText0.0.4` as the safety net)
- that all `models.ini` preset keys parse on first boot
