### PR TITLE
fix(renovate): repair qBitrr ConfigVersion autoReplace template

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -44,7 +44,9 @@
       matchStrings: ['ConfigVersion\\s*=\\s*"(?<currentValue>[^"]+)"'],
       depNameTemplate: "feramance/qbitrr",
       datasourceTemplate: "docker",
-      autoReplaceStringTemplate: 'ConfigVersion = "{{replace newValue "v" ""}}"'
+      // newValue is already v-stripped by the config.toml extractVersion rule below, so write it
+      // verbatim. (A {{replace}} here would re-extract empty and abort the branch with "update failure".)
+      autoReplaceStringTemplate: 'ConfigVersion = "{{{newValue}}}"'
     }
   ],
   packageRules: [


### PR DESCRIPTION
The `renovate/qbitrr` branch was aborting on every run, so the 5.12.2→5.12.4 bump never landed. Log (`...23-19...log`):

```
manager.getUpdatedPackageFiles() → config.toml
No dependencies found in file for custom regex manager
Could not extract .../qbitrr/config/config.toml (manager=regex) after autoreplace.
Error updating branch: update failure
```

## Root cause

Renovate's `replace` helper signature is `{{replace 'pattern' 'replacement' input}}` — **the input string is the last argument**. The template had the arguments reversed:

```
ConfigVersion = "{{replace newValue "v" ""}}"
```

That treats `newValue` as the regex pattern and `""` as the input, so it searches for `5.12.4` inside an empty string and renders `ConfigVersion = ""`. Renovate then re-extracts to verify the replacement, the `[^"]+` matchString can't match the now-empty value, and the whole branch aborts with `update failure`.

## Fix

`extractVersion` already strips the `v` prefix, so `newValue` needs no transform — write it verbatim:

```
ConfigVersion = "{{{newValue}}}"
```

This is separate from #3217 (which stopped the duplicate solo PR); this is why the *grouped* branch itself kept failing. Config validates clean on current Renovate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)