### PR TITLE
feat(llama-server): raise image-min-tokens to 1024 for Qwen-VL grounding

### DIFF
--- a/kubernetes/apps/ai/llama-server/app/config/models.ini
+++ b/kubernetes/apps/ai/llama-server/app/config/models.ini
@@ -18,6 +18,7 @@ n-gpu-layers = 99
 fit = off # auto-fit hangs on this model (MTP ctx + q8 KV); pin ngl/ctx instead
 no-mmap = true # mmap re-faults the 18Gi weights from the cache PVC (130s+ cold load)
 flash-attn = on
+image-min-tokens = 1024 # Qwen-VL grounding degrades below 1024 image tokens (load_hparams warning)
 ctx-size = 262144
 cache-type-k = q8_0
 cache-type-v = q8_0


### PR DESCRIPTION
## What
Add `image-min-tokens = 1024` to the qwen-3.6 preset.

## Why
The server log shows the Unsloth Qwen3.6-27B GGUF loads a **Qwen-VL vision projector** (`mmproj-BF16.gguf`), and llama.cpp warns on startup:

```
load_hparams: Qwen-VL models require at minimum 1024 image tokens to function correctly on grounding tasks
load_hparams: if you encounter problems with accuracy, try adding --image-min-tokens 1024
```

Since this model serves image input, this follows the model's own guidance to keep grounding accuracy intact.

## Note
VRAM is tight on the R9700 — peak ~29.4 / 31.9 GiB with qwen-3.6 + the vision projector resident at full 256K context. `--models-max 2` (embedding co-residence) is therefore best-effort, not guaranteed; worth watching if the embedding route is enabled later.