### PR TITLE
fix(litellm): dashboard vars query a metric VictoriaMetrics actually keeps

### DIFF
--- a/kubernetes/apps/ai/litellm/app/dashboard/litellm.json
+++ b/kubernetes/apps/ai/litellm/app/dashboard/litellm.json
@@ -1730,12 +1730,12 @@
       },
       {
         "current": {},
-        "definition": "label_values(litellm_proxy_total_requests_metric_created,job)",
+        "definition": "label_values(litellm_proxy_total_requests_metric_total,job)",
         "name": "job",
         "options": [],
         "query": {
           "qryType": 1,
-          "query": "label_values(litellm_proxy_total_requests_metric_created,job)",
+          "query": "label_values(litellm_proxy_total_requests_metric_total,job)",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 1,
@@ -1749,14 +1749,14 @@
       {
         "allValue": ".*",
         "current": {},
-        "definition": "label_values(litellm_proxy_total_requests_metric_created,instance)",
+        "definition": "label_values(litellm_proxy_total_requests_metric_total,instance)",
         "includeAll": true,
         "multi": true,
         "name": "instance",
         "options": [],
         "query": {
           "qryType": 1,
-          "query": "label_values(litellm_proxy_total_requests_metric_created,instance)",
+          "query": "label_values(litellm_proxy_total_requests_metric_total,instance)",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 2,


### PR DESCRIPTION
## The actual root cause (the datasource was a red herring)
After the datasource fixes (#3232, #3234) the dashboard was *still* empty. Verifying the dashboard's queries **directly against VictoriaMetrics** showed why:

- The `job` and `instance` template variables query `label_values(litellm_proxy_total_requests_metric_**created**, …)`.
- **VictoriaMetrics drops `_created` series by default** → `count(litellm_proxy_total_requests_metric_created)` = **0** (no litellm `*_created` series exist at all).
- So `$job` and `$instance` resolve **empty** → the `model` var (`…{job=~"$job",instance=~"$instance"}`) matches nothing → every panel filters `{job=~"",instance=~"",model=~""}` → **No data**, on any datasource.

Everything the panels need is present in VM: `litellm_proxy_total_requests_metric_total` (8 series, `job="litellm"`), `litellm_deployment_state`, latency/ttft buckets (18), `litellm_spend_metric_total` (8).

## Fix
Point the `job`/`instance` variables at `litellm_proxy_total_requests_metric_total` (confirmed: `label_values(..._total, job)` → `["litellm"]`). This repopulates `$job → $instance → $model` and unblocks every panel.

## Verification
Confirmed against live VictoriaMetrics: `_created` count = 0 (empty), `_total` count = 8 with `job=litellm`. This is a query-vs-data fix verified at the source, not an inference.

(The two panels using `litellm_proxy_failed_requests_metric_total` / `litellm_deployment_failed_fallbacks_total` will stay empty until there's actually a failure/fallback — those series only exist after the event. Expected, not a bug.)