### PR TITLE
fix(llama-server): dashboard state panels show one tile (latest), not one per dead pod

### DIFF
--- a/kubernetes/apps/ai/llama-server/app/dashboard/llama-server.json
+++ b/kubernetes/apps/ai/llama-server/app/dashboard/llama-server.json
@@ -99,9 +99,10 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "llama_model_loaded{model=\"qwen-3.6\"}",
+          "expr": "max without(endpoint, instance, pod, prometheus) (llama_model_loaded{model=\"qwen-3.6\"})",
           "legendFormat": "qwen-3.6",
-          "refId": "A"
+          "refId": "A",
+          "instant": true
         }
       ],
       "title": "Model state",
@@ -172,9 +173,10 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "llama_upstream_metrics_up{model=\"qwen-3.6\"}",
+          "expr": "max without(endpoint, instance, pod, prometheus) (llama_upstream_metrics_up{model=\"qwen-3.6\"})",
           "legendFormat": "upstream",
-          "refId": "A"
+          "refId": "A",
+          "instant": true
         }
       ],
       "title": "Metrics scrape state",
@@ -233,9 +235,10 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "clamp_min(time() - llama_exporter_last_successful_scrape_timestamp_seconds, 0)",
+          "expr": "clamp_min(time() - max without(endpoint, instance, pod, prometheus) (llama_exporter_last_successful_scrape_timestamp_seconds), 0)",
           "legendFormat": "freshness",
-          "refId": "A"
+          "refId": "A",
+          "instant": true
         }
       ],
       "title": "Metrics freshness",
@@ -290,9 +293,10 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "llama_exporter_upstream_http_status{model=\"qwen-3.6\"}",
+          "expr": "max without(endpoint, instance, pod, prometheus) (llama_exporter_upstream_http_status{model=\"qwen-3.6\"})",
           "legendFormat": "HTTP status",
-          "refId": "A"
+          "refId": "A",
+          "instant": true
         }
       ],
       "title": "Last upstream status",
@@ -368,7 +372,8 @@
           },
           "expr": "max without(endpoint, instance, pod, prometheus) (llamacpp:prompt_tokens_seconds)",
           "legendFormat": "Prefill",
-          "refId": "A"
+          "refId": "A",
+          "instant": true
         }
       ],
       "title": "Prompt (prefill) tokens/second",
@@ -431,7 +436,8 @@
           },
           "expr": "max without(endpoint, instance, pod, prometheus) (llamacpp:predicted_tokens_seconds)",
           "legendFormat": "Decode",
-          "refId": "A"
+          "refId": "A",
+          "instant": true
         }
       ],
       "title": "Decode tokens/second",
@@ -513,7 +519,8 @@
           },
           "expr": "max without(endpoint, instance, pod, prometheus) (llamacpp:requests_processing)",
           "legendFormat": "Processing",
-          "refId": "A"
+          "refId": "A",
+          "instant": true
         },
         {
           "datasource": {
@@ -522,7 +529,8 @@
           },
           "expr": "max without(endpoint, instance, pod, prometheus) (llamacpp:requests_deferred)",
           "legendFormat": "Deferred",
-          "refId": "B"
+          "refId": "B",
+          "instant": true
         }
       ],
       "title": "Active / deferred requests",
@@ -585,7 +593,8 @@
           },
           "expr": "max without(endpoint, instance, pod, prometheus) (llamacpp:n_tokens_max)",
           "legendFormat": "context tokens",
-          "refId": "A"
+          "refId": "A",
+          "instant": true
         }
       ],
       "title": "Observed context high watermark",


### PR DESCRIPTION
## Problem
The "Model metrics state" stat panels rendered **one tile per pod** that existed in the time window — after a few restarts: `Hot Hot Hot`, `Collecting Collecting Collecting`, `200 200 200`, three freshness values. As pods recycled it grew 1 → 2 → 3.

## Cause
Those 4 panels queried the raw `llama_*` series with **no aggregation**, as **range queries**. Each restarted pod is a distinct series (`pod`/`instance` labels), and a range query over "Last 12h" returns every series that reported in the window → the Stat panel draws one tile each. (The throughput/GPU panels were already fine — they use `max without(endpoint, instance, pod, prometheus)`.)

## Fix (matches the dashboard's own pattern + Grafana guidance)
- Wrap the 4 state queries in `max without(endpoint, instance, pod, prometheus) (...)` → collapses pods to a single series.
- Set all current-value stat/gauge panels to **instant queries** — the documented best practice for "latest value" panels (returns the value at *now*, not the whole range). [Grafana: retrieve latest value with a stat panel](https://grafana.com/blog/2023/10/18/how-to-easily-retrieve-values-from-a-range-in-grafana-using-a-stat-panel/), [Stat panel docs](https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/stat/).

llama-server runs one pod on a single GPU, so this yields exactly one tile showing the current pod's value.