### PR TITLE
perf(llama-cpp-rocm): slim runtime — drop unused MIOpen/FFT/RAND/RCCL

### DIFF
--- a/docker/llama-cpp-rocm/Dockerfile
+++ b/docker/llama-cpp-rocm/Dockerfile
@@ -34,9 +34,13 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Install ROCm 7.13 (gfx1201-tuned) from AMD's packages-multi-arch APT repo. The repo path is
 # .../ubuntu2404 with codename `stable` — NOT a per-Ubuntu-codename repo, and NOT mirrored on
-# repo.radeon.com (which tops out at 7.2.x). Packages:
-#   amdrocm7.13-gfx1201             runtime metapackage: HIP runtime, LLVM/clang, hipcc, and the
-#                                   gfx1201-tuned rocBLAS/hipBLASLt + Tensile kernels
+# repo.radeon.com (which tops out at 7.2.x). We pull the BLAS leaf, not the umbrella
+# amdrocm7.13-gfx1201 metapackage: its hard deps give us exactly what GGML_HIP links (HIP runtime,
+# LLVM/clang+libLLVM, rocBLAS+gfx1201 Tensile, hipBLASLt) while skipping the metapackage's
+# MIOpen/rocFFT/rocRAND/RCCL (~330MB installed) that llama.cpp never loads — that bloat would
+# otherwise ride along in the staged runtime layer. Packages:
+#   amdrocm-blas7.13-gfx1201        rocBLAS + gfx1201 Tensile kernels; pulls HIP runtime, LLVM,
+#                                   hipBLASLt (and rocSOLVER/rocSPARSE) via hard deps
 #   amdrocm-runtime-dev7.13         HIP runtime headers + hipcc dev files
 #   amdrocm-blas-dev7.13            rocBLAS headers (with amdrocm-hipblas-common-dev7.13 for hipBLAS)
 #   amdrocm-llvm-dev7.13            clang/LLVM dev files for the HIP compile
@@ -48,7 +52,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/amdrocm.gpg] https://repo.amd.com/rocm/packages-multi-arch/ubuntu2404 stable main" \
          | tee /etc/apt/sources.list.d/rocm.list \
     && apt-get update && apt-get install -y --no-install-recommends \
-        amdrocm7.13-gfx1201 \
+        amdrocm-blas7.13-gfx1201 \
         amdrocm-runtime-dev7.13 \
         amdrocm-blas-dev7.13 \
         amdrocm-hipblas-common-dev7.13 \


### PR DESCRIPTION
## What

Found while reviewing the first APT build's log (run `27496256677`, 15m57s). The build works, but the runtime image carries ROCm libraries llama.cpp never loads.

The umbrella `amdrocm7.13-gfx1201` metapackage pulls in **MIOpen/DNN (~293 MB installed), rocFFT, rocRAND, and RCCL**. The runtime stage `cp -a`'s the whole `/opt/rocm/core-7.13/lib` tree, so all of that ships in the final image — inflating the layer export (104s in that build), the push, and every deploy-time pull.

## Fix

Install the **`amdrocm-blas7.13-gfx1201`** leaf instead of the metapackage. Its hard deps still give us exactly what `GGML_HIP` links — HIP runtime, LLVM/libLLVM, rocBLAS + gfx1201 Tensile kernels, hipBLASLt — but skip MIOpen/FFT/RAND/RCCL. ~330 MB of installed libs leave the runtime layer.

- Build-time compiler + headers unchanged (clang/hipcc/libLLVM all still pulled).
- Staging safety checks (`libamdhip64`/`librocblas`/`libhipblaslt`/`libLLVM`) still pass.
- rocSOLVER/rocSPARSE remain (hard deps of rocBLAS) but are small.

## Build log facts (current image)

| Step | Time |
|---|---|
| ROCm APT install (#5) | 160s |
| llama.cpp compile (#8) | 433s |
| runtime layer export (#13) | 104s |
| **total** | ~16 min |

The compile dominates and is unchanged; this PR targets the export/push/pull size, not build time.

## Needs validation before merge

This drops runtime libraries, so it must be proven on hardware, not just built:
1. `workflow_dispatch` the build on this branch (note: it pushes the in-place `gfx1201` tag, so coordinate with the running deployment).
2. Confirm llama-server starts and serves an inference on the R9700 (rocBLAS path intact, ~34 tok/s unchanged).