### PR TITLE
perf(llama-server): Recreate strategy, cold-load probe headroom, right-size mem request

### DIFF
--- a/kubernetes/apps/ai/llama-server/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/llama-server/app/helmrelease.yaml
@@ -37,6 +37,11 @@ spec:
 
     controllers:
       app:
+        # Recreate, not RollingUpdate: this is a singleton holding the node's only squat.ai/dri:1.
+        # A rolling update surges the new pod first, but it can't get the GPU until the old one
+        # releases it — image bumps would stall with the new pod Pending. Recreate frees the GPU
+        # first, then starts the replacement. (Matches the hermes GPU pod.)
+        strategy: Recreate
         annotations:
           reloader.stakater.com/auto: "true"
         containers:
@@ -74,7 +79,9 @@ spec:
                   periodSeconds: 10
                   timeoutSeconds: 5
                   # Router /health is up at process start (models load lazily) — cover start only.
-                  failureThreshold: 18
+                  # 30×10s + 10s = ~310s budget: comfortably clears the 130s+ cold load of the 18Gi
+                  # weights (no-mmap read from the hostpath PVC) so a slow load never CrashLoops.
+                  failureThreshold: 30
               liveness:
                 <<: *probeBase
                 spec:
@@ -94,11 +101,15 @@ spec:
             resources:
               requests:
                 cpu: 2
-                memory: 12Gi
+                # Reserve the real steady-state working set: the 8Gi host prompt cache (cache-ram)
+                # + llama.cpp arenas/slot buffers. Matching the request to actual use keeps this
+                # singleton from being the eviction target under node memory pressure (an eviction
+                # costs a 130s+ cold reload). Was 12Gi.
+                memory: 16Gi
                 squat.ai/dri: 1
               limits:
                 cpu: 12
-                memory: 28Gi # 8Gi prompt cache + load buffers + headroom (weights live in VRAM)
+                memory: 28Gi # peak: 8Gi prompt cache + 18Gi no-mmap load buffer (weights then live in VRAM)
                 squat.ai/dri: 1
 
           # Hot-only metrics gate (busybox; config/llama-metrics-gate.sh). Scrapes the router with


### PR DESCRIPTION
Deployment-level tuning for the llama-server GPU pod (the serving config in `models.ini` is already well-optimized; this targets the k8s wrapper).

## Changes

**1. `strategy: Recreate`** — the most impactful fix. The pod is a singleton holding the node's only `squat.ai/dri: 1`. The default RollingUpdate surges the new pod *before* terminating the old one, but the new pod can't acquire the GPU until the old releases it → image bumps (like the slim-image one that just merged) can stall with the new pod `Pending`. Recreate frees the GPU first. Matches the existing `hermes` GPU pod.

**2. Startup probe `failureThreshold` 18 → 30** (~190s → ~310s budget). The cold load of the 18Gi weights (no-mmap read from the hostpath PVC) takes 130s+; the old budget left thin margin. Now a slow disk or a larger model won't CrashLoop during load. Liveness/readiness unchanged (they only run after startup passes).

**3. Memory request 12Gi → 16Gi.** Right-sizes the *reservation* to the real steady-state working set (8Gi host prompt cache + llama.cpp arenas/slot buffers) so this critical singleton isn't the first eviction target under node memory pressure — an eviction costs a full 130s+ cold reload. Limit unchanged at 28Gi (the no-mmap load peak).

## Notes / what I did NOT change
- **CPU limit kept at 12** — every AI app in the repo sets a CPU limit, so removing it would break convention. It's a burst ceiling, not a reservation, so it doesn't affect scheduling headroom.
- **Raw cold-load time is disk/VRAM-bound**, not k8s-tunable. The cold-start wins here are indirect: Recreate + the higher mem request reduce *unnecessary* restarts, and the probe headroom keeps a legit slow load from looping. `--models-max 2` already keeps both models resident (no idle eviction).
- **True resource right-sizing needs live metrics**, which I couldn't pull (repo kubeconfig points at the dead `.3` VIP and I won't disable TLS verification). The 16Gi figure is derived from the documented working set; worth confirming against `kubectl top` once the kubeconfig is refreshed, and trimming if actual steady-state is lower.

GitOps via Flux — no manual apply.