### PR TITLE
feat(ai): add memini

### DIFF
--- a/kubernetes/apps/ai/kustomization.yaml
+++ b/kubernetes/apps/ai/kustomization.yaml
@@ -8,6 +8,7 @@ components:
 resources:
   - ./hermes/ks.yaml
   - ./litellm/ks.yaml
+  - ./memini/ks.yaml
   - ./llama-server/ks.yaml # serves qwen-3.6 on the R9700 (llama.cpp/ROCm gfx1201 + MTP)
   - ./open-webui/ks.yaml
   - ./opencode/ks.yaml

--- a/kubernetes/apps/ai/memini/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/memini/app/helmrelease.yaml
@@ -18,7 +18,6 @@ spec:
 
     controllers:
       main:
-        type: deployment
         annotations:
           reloader.stakater.com/auto: "true"
 
@@ -29,13 +28,13 @@ spec:
               tag: 18
             envFrom:
               - secretRef:
-                  name: memini-secret
+                  name: &secret memini-secret
 
         containers:
           main:
             envFrom:
               - secretRef:
-                  name: memini-secret
+                  name: *secret
             env:
               TZ: ${TIMEZONE}
               MEMINI_BACKEND: "postgres"
@@ -50,7 +49,7 @@ spec:
               MEMINI_POSTGRES_DSN:
                 valueFrom:
                   secretKeyRef:
-                    name: memini-secret
+                    name: *secret
                     key: MEMINI_POSTGRES_DSN
               MEMINI_UI_ENABLED: "true"
 

--- a/kubernetes/apps/ai/memini/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/memini/app/helmrelease.yaml
@@ -1,0 +1,86 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app memini
+spec:
+  interval: 30m
+  chartRef:
+    kind: OCIRepository
+    name: memini
+
+  values:
+    defaultPodOptions:
+      securityContext:
+        fsGroup: 65532
+        fsGroupChangePolicy: OnRootMismatch
+
+    controllers:
+      main:
+        annotations:
+          reloader.stakater.com/auto: "true"
+
+        containers:
+          main:
+            env:
+              TZ: ${TIMEZONE}
+              MEMINI_BACKEND: "sqlite"
+              MEMINI_LOG_LEVEL: "info"
+              MEMINI_LOG_FORMAT: "json"
+              MEMINI_DEFAULT_NAMESPACE: "default"
+              MEMINI_NAMESPACE_HEADER: "X-Memini-Namespace"
+              MEMINI_SWEEP_INTERVAL: "1h"
+              MEMINI_EMBED_BASE_URL: "http://llama-server.ai.svc.cluster.local/v1"
+              MEMINI_EMBED_MODEL: "qwen3-embedding"
+              MEMINI_EMBED_DIMS: "1024"
+              MEMINI_SQLITE_PATH: "/data/memini.db"
+              MEMINI_UI_ENABLED: "true"
+
+            resources:
+              requests:
+                cpu: 50m
+                memory: 128Mi
+              limits:
+                cpu: 1
+                memory: 512Mi
+
+    service:
+      main:
+        controller: main
+        ports:
+          http:
+            port: 8080
+
+    route:
+      main:
+        enabled: false
+      internal:
+        enabled: true
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+        hostnames:
+          - "{{ .Release.Name }}.${SECRET_DOMAIN}"
+        rules:
+          - backendRefs:
+              - identifier: main
+                port: http
+
+    persistence:
+      data:
+        enabled: true
+        type: persistentVolumeClaim
+        accessMode: ReadWriteOnce
+        size: 5Gi
+        globalMounts:
+          - path: /data
+
+    serviceMonitor:
+      main:
+        enabled: true
+        endpoints:
+          - port: http
+            path: /metrics
+            interval: 30s
+            scrapeTimeout: 10s

--- a/kubernetes/apps/ai/memini/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/memini/app/helmrelease.yaml
@@ -18,14 +18,27 @@ spec:
 
     controllers:
       main:
+        type: deployment
         annotations:
           reloader.stakater.com/auto: "true"
 
+        initContainers:
+          init-db:
+            image:
+              repository: ghcr.io/home-operations/postgres-init
+              tag: 18
+            envFrom:
+              - secretRef:
+                  name: memini-secret
+
         containers:
           main:
+            envFrom:
+              - secretRef:
+                  name: memini-secret
             env:
               TZ: ${TIMEZONE}
-              MEMINI_BACKEND: "sqlite"
+              MEMINI_BACKEND: "postgres"
               MEMINI_LOG_LEVEL: "info"
               MEMINI_LOG_FORMAT: "json"
               MEMINI_DEFAULT_NAMESPACE: "default"
@@ -34,7 +47,11 @@ spec:
               MEMINI_EMBED_BASE_URL: "http://llama-server.ai.svc.cluster.local/v1"
               MEMINI_EMBED_MODEL: "qwen3-embedding"
               MEMINI_EMBED_DIMS: "1024"
-              MEMINI_SQLITE_PATH: "/data/memini.db"
+              MEMINI_POSTGRES_DSN:
+                valueFrom:
+                  secretKeyRef:
+                    name: memini-secret
+                    key: MEMINI_POSTGRES_DSN
               MEMINI_UI_ENABLED: "true"
 
             resources:
@@ -69,12 +86,9 @@ spec:
 
     persistence:
       data:
-        enabled: true
-        type: persistentVolumeClaim
+        enabled: false
         accessMode: ReadWriteOnce
-        size: 5Gi
-        globalMounts:
-          - path: /data
+        size: 1Gi
 
     serviceMonitor:
       main:

--- a/kubernetes/apps/ai/memini/app/kustomization.yaml
+++ b/kubernetes/apps/ai/memini/app/kustomization.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ocirepository.yaml
+  - helmrelease.yaml

--- a/kubernetes/apps/ai/memini/app/kustomization.yaml
+++ b/kubernetes/apps/ai/memini/app/kustomization.yaml
@@ -6,3 +6,4 @@ kind: Kustomization
 resources:
   - ocirepository.yaml
   - helmrelease.yaml
+  - secret.sops.yaml

--- a/kubernetes/apps/ai/memini/app/ocirepository.yaml
+++ b/kubernetes/apps/ai/memini/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: memini
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: v0.3.1
+  url: oci://registry.erwanleboucher.dev/eleboucher/charts/memini

--- a/kubernetes/apps/ai/memini/app/secret.sops.yaml
+++ b/kubernetes/apps/ai/memini/app/secret.sops.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: memini-secret
+stringData:
+    # Superuser credentials — paste the password from cloudnative-pg-secret here:
+    INIT_POSTGRES_SUPER_PASS: "REPLACE_WITH_SUPERUSER_PASSWORD"
+    # App credentials (auto-generated):
+    INIT_POSTGRES_USER: "memini"
+    INIT_POSTGRES_PASS: "44WXSa5iRtAjJ2jZSP030NsTk5MyhqZy"
+    INIT_POSTGRES_HOST: "pgbouncer-rw.database.svc.cluster.local"
+    INIT_POSTGRES_DBNAME: "memini"
+    # Full DSN for memini (matches the user/pass above):
+    MEMINI_POSTGRES_DSN: "postgres://memini:44WXSa5iRtAjJ2jZSP030NsTk5MyhqZy@pgbouncer-rw.database.svc.cluster.local:5432/memini?sslmode=disable"

--- a/kubernetes/apps/ai/memini/app/secret.sops.yaml
+++ b/kubernetes/apps/ai/memini/app/secret.sops.yaml
@@ -3,12 +3,25 @@ kind: Secret
 metadata:
     name: memini-secret
 stringData:
-    # Superuser credentials — paste the password from cloudnative-pg-secret here:
-    INIT_POSTGRES_SUPER_PASS: "REPLACE_WITH_SUPERUSER_PASSWORD"
-    # App credentials (auto-generated):
-    INIT_POSTGRES_USER: "memini"
-    INIT_POSTGRES_PASS: "44WXSa5iRtAjJ2jZSP030NsTk5MyhqZy"
-    INIT_POSTGRES_HOST: "pgbouncer-rw.database.svc.cluster.local"
-    INIT_POSTGRES_DBNAME: "memini"
-    # Full DSN for memini (matches the user/pass above):
-    MEMINI_POSTGRES_DSN: "postgres://memini:44WXSa5iRtAjJ2jZSP030NsTk5MyhqZy@pgbouncer-rw.database.svc.cluster.local:5432/memini?sslmode=disable"
+    INIT_POSTGRES_SUPER_PASS: ENC[AES256_GCM,data:w9VOyIWmplw=,iv:1+QNZJMFHvXtrxigtWlAUbRaSOCygjOCuXJIAt9EpaI=,tag:7OL/2GGSI45i+gNB6PYSUw==,type:str]
+    INIT_POSTGRES_USER: ENC[AES256_GCM,data:bIz1UWQ9,iv:gTC5yIg8QVviHEi9wmS6+hHeQrQnFFmyoJcxg3tuWYM=,tag:6Ox9JvNIoDEwNQQOT7gUGA==,type:str]
+    INIT_POSTGRES_PASS: ENC[AES256_GCM,data:dYEB1znVPT8=,iv:jTRBKmHhRDAkEs9xz7flsjiEm45hWpIHzsIfrtSvUc0=,tag:6MxJI16OEbhfEYP6RJPYCA==,type:str]
+    INIT_POSTGRES_HOST: ENC[AES256_GCM,data:+sAK515gOtTjPyXpQJV46mIdkHOcyOI0+Cq8TERJJZxujWyspPsG,iv:wLX2lDXxwifdwl/9uYipg/CZxCGAGSizyV3HbnnDorc=,tag:ErVW/5pspGAjiuJpfEipcA==,type:str]
+    INIT_POSTGRES_DBNAME: ENC[AES256_GCM,data:irylD58X,iv:vLe22O8wDhsMmRVVH1LknGt0igJqVc4S66N41AsY+os=,tag:3kTqhQTzPgtopudMSJejmw==,type:str]
+    MEMINI_POSTGRES_DSN: ENC[AES256_GCM,data:xUjESeMAWCv1cYaLpNwF4/ck7paOId4v/zQJ7hn64qnpQxA79duOwivGlGj4uP4Ly4SDR9u2jz4c73/17/ISwxmdfOuJXtoc9EJ+3SfO7gDIavaaYjVr0OwpWlUK3A==,iv:E7WjMOAAk2joUGJAkaZRSXE28pURsln8VL1el2HufAA=,tag:Fm02Cz76UmGwWv5tkhoX3Q==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB6L09TSWg2UndIbWFDeCtW
+            ajcyMHU1N2p4ZlRKZTVDcjIrTloxQmVkc3dnCjUwR0pNZnJ2MDNsRHhGMDlwNm5K
+            ZHBiWmU2UFhGZ2ZrM2lZTld4T3h3ZW8KLS0tIHZic2hPbUNqUURqdkt5V3ZoYWxa
+            V3UzeXVRQXZUOEd5UU90WHA0SmhHT1EKaH9nTGz5QMsESuVAQuoNeAC36MR0wWH5
+            0aIXBGl9lJoPz+j9eUMy39mNcjljJ49nyMXIz1UDC8EY0zLZfy0RMQ==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age12gul5m0dg9nn2gk69uvzwdxyluh5xt02m8wvyg9hn7c93nz7xehswmdenq
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-06-14T20:29:52Z"
+    mac: ENC[AES256_GCM,data:B78LDbhabWy7/qbb7yeDRvvNwIaoXFtAIr1qIhv20ox7kWqDy+DzpLX7V+2ZAUPPSh6AHyP2KrkU62NpNpNjCfMS9dEinp9aP4ow8UOmnHVQqBsQti1t5n8vX56anTXLZ3bKNX0TGUU+Vqa9PxAoAb8hAfCf0Vb3nfWdxsP3wk0=,iv:YVIB+J4TLVhkeDBeV29RpPg9YxM4X4Mt5PtFhBVdkK0=,tag:Bqb7qyqV84+UdPICLGHqhg==,type:str]
+    mac_only_encrypted: true
+    version: 3.13.1

--- a/kubernetes/apps/ai/memini/ks.yaml
+++ b/kubernetes/apps/ai/memini/ks.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app memini
+  namespace: &namespace ai
+spec:
+  targetNamespace: *namespace
+  interval: 30m
+  path: ./kubernetes/apps/ai/memini/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false


### PR DESCRIPTION
Deploy memini (AI memory service) to the ai namespace.

- **Chart:** `oci://registry.erwanleboucher.dev/eleboucher/charts/memini` v0.3.1
- **Backend:** postgres (deployment, CNPG cluster via pgbouncer-rw)
- **DB init:** `postgres-init` init container creates database and role
- **Embeddings:** llama-server `qwen3-embedding` (1024 dims)
- **Route:** internal via envoy-internal at memini.${SECRET_DOMAIN}
- **Monitoring:** ServiceMonitor enabled for Prometheus