### PR TITLE
feat(odysseus): deploy self-hosted AI workspace

### DIFF
--- a/kubernetes/apps/ai/kustomization.yaml
+++ b/kubernetes/apps/ai/kustomization.yaml
@@ -11,4 +11,5 @@ resources:
   - ./llama-server/ks.yaml # serves qwen-3.6 on the R9700 (llama.cpp/ROCm gfx1201 + MTP)
   - ./open-webui/ks.yaml
   - ./opencode/ks.yaml
+  - ./odysseus/ks.yaml
   - ./toolhive/ks.yaml

--- a/kubernetes/apps/ai/odysseus/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/odysseus/app/helmrelease.yaml
@@ -1,0 +1,87 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app odysseus
+spec:
+  interval: 30m
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+
+  values:
+    controllers:
+      app:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: ghcr.io/pewdiepie-archdaemon/odysseus
+              tag: 1.0.0-dev.9d7a3d6
+            env:
+              TZ: ${TIMEZONE}
+              APP_BIND: "0.0.0.0"
+              APP_PORT: "7000"
+              AUTH_ENABLED: "true"
+              SECURE_COOKIES: "true"
+              SEARXNG_INSTANCE: "http://searxng.default.svc.cluster.local:8080"
+            probes:
+              liveness: &probes
+                enabled: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: &port 7000
+                  initialDelaySeconds: 30
+                  periodSeconds: 30
+                  timeoutSeconds: 10
+                  failureThreshold: 5
+              readiness:
+                enabled: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: *port
+                  initialDelaySeconds: 15
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 6
+            resources:
+              requests:
+                cpu: 100m
+                memory: 256Mi
+              limits:
+                cpu: 2
+                memory: 2Gi
+
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+
+    service:
+      app:
+        ports:
+          http:
+            port: *port
+
+    route:
+      app:
+        annotations:
+          gethomepage.dev/enabled: "true"
+          gethomepage.dev/name: Odysseus
+          gethomepage.dev/description: Self-hosted AI workspace
+          gethomepage.dev/group: AI
+          gethomepage.dev/icon: odysseus.png
+        hostnames:
+          - "odysseus.${SECRET_DOMAIN}"
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+
+    persistence:
+      data:
+        existingClaim: *app
+        globalMounts:
+          - path: /app/data

--- a/kubernetes/apps/ai/odysseus/app/kustomization.yaml
+++ b/kubernetes/apps/ai/odysseus/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/SchemaStore/schemastore/master/src/schemas/json/kustomization.json
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrelease.yaml

--- a/kubernetes/apps/ai/odysseus/ks.yaml
+++ b/kubernetes/apps/ai/odysseus/ks.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app odysseus
+  namespace: &namespace ai
+spec:
+  interval: 10m
+  path: ./kubernetes/apps/ai/odysseus/app
+  targetNamespace: *namespace
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  components:
+    - ../../../../components/volsync
+  postBuild:
+    substitute:
+      APP: *app
+      VOLSYNC_CAPACITY: 10Gi


### PR DESCRIPTION
## Summary

Deploy [Odysseus](https://github.com/pewdiepie-archdaemon/odysseus) — a self-hosted AI workspace (ChatGPT/Claude-like UI with chat, agents, memory, deep research, documents, email, calendar) to the Kubernetes cluster via FluxCD GitOps.

## Changes

- **New Flux Kustomization** with Volsync backup support (10Gi)
- **New HelmRelease** (app-template) — single container, port 7000
- **Route** at `odysseus.${SECRET_DOMAIN}` via `envoy-internal`
- **Persistence** at `/app/data` (10Gi, ceph-block, Volsync-managed)
- Points at existing **SearXNG** instance (`searxng.default.svc.cluster.local:8080`) for web search
- Registered in **`ai`** namespace alongside opencode

## Decisions

| Decision | Choice |
|---|---|
| Namespace | `ai` |
| Iteration | Single container (no bundled companions) |
| Image | `ghcr.io/pewdiepie-archdaemon/odysseus:1.0.0-dev.9d7a3d6` |
| Hostname | `odysseus.${SECRET_DOMAIN}` |
| Persistence | Single PVC, 10Gi, Volsync |
| Envoy route | `envoy-internal` (internal access)