### PR TITLE
perf(llama-server): up to 4 concurrent sessions via unified KV cache

### DIFF
--- a/kubernetes/apps/ai/llama-server/app/config/models.ini
+++ b/kubernetes/apps/ai/llama-server/app/config/models.ini
@@ -8,7 +8,12 @@ jinja = true
 flash-attn = auto
 metrics = true
 slots = true
-parallel = 1
+; Up to 4 concurrent sessions via continuous batching. kv-unified shares one 256K KV pool
+; across slots instead of statically splitting it (256K/4) — so a lone session still gets the
+; full 256K at full speed, and slots only contend when several are large at once. Setting
+; --parallel explicitly disables unified by default, hence the explicit kv-unified = true.
+parallel = 4
+kv-unified = true
 
 [qwen-3.6]
 ; Proven 27B-MTP config (~34 tok/s): full 256K ctx + q8 KV + all experts on the 32 GB GPU.


### PR DESCRIPTION
Sets `parallel=4` with `kv-unified=true` in models.ini.

Unified KV shares one 256K KV pool across slots rather than statically partitioning it (256K/4). A lone session keeps the **full 256K context at full speed**; slots only contend when several sessions are large simultaneously. No extra VRAM (same ctx-size).

Note: setting `--parallel` explicitly disables unified-by-default, so `kv-unified=true` is forced on — otherwise single-session context would drop to 64K.

Validate after rollout: confirm single-session PP+TG is unchanged (~34 tok/s decode), then fire concurrent requests to see aggregate throughput rise.