### PR TITLE
perf(llama-server): drop MTP so 4-way batching scales

### DIFF
--- a/kubernetes/apps/ai/llama-server/app/config/models.ini
+++ b/kubernetes/apps/ai/llama-server/app/config/models.ini
@@ -16,7 +16,11 @@ parallel = 4
 kv-unified = true
 
 [qwen-3.6]
-; Proven 27B-MTP config (~34 tok/s): full 256K ctx + q8 KV + all experts on the 32 GB GPU.
+; 27B config: full 256K ctx + q8 KV + all experts on the 32 GB GPU. ~33 tok/s single-session.
+; MTP speculative decoding is OFF on purpose: it gives ~1.42x single-stream but does NOT batch
+; across slots — with parallel=4 each slot ran its own draft+verify and thrashed, dropping
+; aggregate concurrent throughput below the single-stream rate. Dropping it lets continuous
+; batching actually scale the 4 slots. (Trade: single-session ~34 -> ~33; concurrency wins.)
 hf-repo = unsloth/Qwen3.6-27B-MTP-GGUF
 hf-file = Qwen3.6-27B-UD-Q4_K_XL.gguf
 n-gpu-layers = 99
@@ -27,8 +31,6 @@ image-min-tokens = 1024 # Qwen-VL grounding degrades below 1024 image tokens (lo
 ctx-size = 262144
 cache-type-k = q8_0
 cache-type-v = q8_0
-spec-type = draft-mtp # MTP self-speculative decoding (n-max 3 = sweep optimum, 1.42x)
-spec-draft-n-max = 3
 cache-ram = 8192 # host-RAM prompt cache: agentic prefix reuse, 7.5x warm TTFT
 ctx-checkpoints = 32
 ; Unsloth thinking-mode sampling defaults.


### PR DESCRIPTION
Follow-up to the unified-KV batching change. Live benchmarking showed 4 concurrent sessions gave **lower** aggregate throughput (~10.8 tok/s) than a single stream (~33 tok/s) — speculative decoding (`spec-type=draft-mtp`) doesn't batch across slots, so each of the 4 slots ran its own draft+verify and thrashed.

Removing MTP lets continuous batching actually scale the slots. Trade-off: single-session ~34 → ~33 tok/s; concurrent throughput should rise substantially.

`parallel=4` + `kv-unified=true` retained (logs confirm all 4 slots see the full 262144 ctx). Will re-benchmark single + 4-concurrent after rollout.