### PR TITLE
perf(llama-server): re-enable MTP, keep parallel=4 (favour single-session)

### DIFF
--- a/kubernetes/apps/ai/llama-server/app/config/models.ini
+++ b/kubernetes/apps/ai/llama-server/app/config/models.ini
@@ -17,10 +17,11 @@ kv-unified = true
 
 [qwen-3.6]
 ; 27B config: full 256K ctx + q8 KV + all experts on the 32 GB GPU. ~33 tok/s single-session.
-; MTP speculative decoding is OFF on purpose: it gives ~1.42x single-stream but does NOT batch
-; across slots — with parallel=4 each slot ran its own draft+verify and thrashed, dropping
-; aggregate concurrent throughput below the single-stream rate. Dropping it lets continuous
-; batching actually scale the 4 slots. (Trade: single-session ~34 -> ~33; concurrency wins.)
+; MTP speculative decoding is ON: it only degrades when MULTIPLE slots decode at once (each
+; slot drafts+verifies independently — llama.cpp doesn't batch speculation across sequences),
+; but a lone request gets the full ~1.6x MTP speedup. So this favours the common single-session
+; case (~33 tok/s) while parallel=4 + kv-unified still serve concurrent requests simultaneously
+; (lower aggregate during overlap). Drop spec-type for sustained multi-user throughput instead.
 hf-repo = unsloth/Qwen3.6-27B-MTP-GGUF
 hf-file = Qwen3.6-27B-UD-Q4_K_XL.gguf
 n-gpu-layers = 99
@@ -31,6 +32,8 @@ image-min-tokens = 1024 # Qwen-VL grounding degrades below 1024 image tokens (lo
 ctx-size = 262144
 cache-type-k = q8_0
 cache-type-v = q8_0
+spec-type = draft-mtp # MTP self-speculative decoding (n-max 3 = sweep optimum, ~1.6x single-stream)
+spec-draft-n-max = 3
 cache-ram = 8192 # host-RAM prompt cache: agentic prefix reuse, 7.5x warm TTFT
 ctx-checkpoints = 32
 ; Unsloth thinking-mode sampling defaults.


### PR DESCRIPTION
Reverts the MTP removal (#3258) while keeping the unified-KV batching (#3257). Rationale: MTP only degrades under *simultaneous* multi-slot decode; a lone request keeps the full ~1.6x speedup (~33 vs ~20 tok/s single-session). parallel=4 + kv-unified still serve concurrent requests at once (lower aggregate only during actual overlap). Optimises the common single-session case. Drop spec-type again if sustained multi-user throughput becomes the priority.