### PR TITLE
perf(llama-server): parallel=2 — measured sweet spot with MTP

### DIFF
--- a/kubernetes/apps/ai/llama-server/app/config/models.ini
+++ b/kubernetes/apps/ai/llama-server/app/config/models.ini
@@ -8,20 +8,23 @@ jinja = true
 flash-attn = auto
 metrics = true
 slots = true
-; Up to 4 concurrent sessions via continuous batching. kv-unified shares one 256K KV pool
-; across slots instead of statically splitting it (256K/4) — so a lone session still gets the
-; full 256K at full speed, and slots only contend when several are large at once. Setting
-; --parallel explicitly disables unified by default, hence the explicit kv-unified = true.
-parallel = 4
+; 2 concurrent slots via continuous batching. parallel=2 (not 4) is the measured sweet spot WITH
+; MTP on: MTP speculation contends when multiple slots decode at once, so capping at 2 keeps that
+; thrash 2-way and QUEUES any excess instead of letting 4 requests collapse together. Measured on
+; the shared R9700 (live transcode contention): single TG ~37, 2-conc agg ~27, 4-conc per-request
+; ~20 tok/s — vs parallel=4+MTP where 4-conc per-request dropped to ~11. kv-unified shares one
+; 256K KV pool across slots (vs static 256K/2 split), so a lone session still gets the full 256K;
+; setting --parallel explicitly disables unified by default, hence the explicit kv-unified = true.
+parallel = 2
 kv-unified = true
 
 [qwen-3.6]
-; 27B config: full 256K ctx + q8 KV + all experts on the 32 GB GPU. ~33 tok/s single-session.
-; MTP speculative decoding is ON: it only degrades when MULTIPLE slots decode at once (each
-; slot drafts+verifies independently — llama.cpp doesn't batch speculation across sequences),
-; but a lone request gets the full ~1.6x MTP speedup. So this favours the common single-session
-; case (~33 tok/s) while parallel=4 + kv-unified still serve concurrent requests simultaneously
-; (lower aggregate during overlap). Drop spec-type for sustained multi-user throughput instead.
+; 27B config: full 256K ctx + q8 KV + all experts on the 32 GB GPU. ~37 tok/s single-session.
+; MTP speculative decoding is ON: a lone request gets the full ~1.5x speedup (37 vs 24 tok/s
+; measured with spec off). llama.cpp doesn't batch speculation across sequences, so MTP only
+; degrades under simultaneous multi-slot decode — capped to 2-way by parallel=2 above. Drop
+; spec-type only if sustained 4+ user aggregate throughput ever outweighs single-session latency
+; (measured: spec-off parallel=4 gives ~28 agg at 4-conc but single-session falls to ~24).
 hf-repo = unsloth/Qwen3.6-27B-MTP-GGUF
 hf-file = Qwen3.6-27B-UD-Q4_K_XL.gguf
 n-gpu-layers = 99


### PR DESCRIPTION
Live config sweep on the shared R9700 (median of multiple runs, under real media-transcode contention) across MTP on/off and parallel 2/4:

| config | single TG | 2-conc agg | 4-conc agg | 4-conc per-req |
|---|---|---|---|---|
| MTP on, parallel=4 | 39.0 | 25.2 | 23.7 | 10.9 |
| MTP off, parallel=4 | 24.3 | 26.9 | **28.2** | 14.5 |
| **MTP on, parallel=2** | 36.5 | **26.8** | 25.0 | **19.8** |

`parallel=2` + MTP is the all-rounder: keeps the ~1.5x single-session MTP speedup (37 vs 24), best 2-concurrent aggregate, and ~2x better 4-concurrent per-request latency than parallel=4 (it queues excess instead of letting 4 requests thrash speculation). Only MTP-off/parallel=4 beats it on raw 4-way aggregate (+13%), at a 34% single-session cost — a bad trade for mostly-1-2-session use. kv-unified retained (full 256K for a lone session).