### PR TITLE
perf(ai/llama-server): deeper MTP draft (n-max=4) + gfx1201 prefill build workaround

### DIFF
--- a/docker/llama-cpp-rocm/Dockerfile
+++ b/docker/llama-cpp-rocm/Dockerfile
@@ -8,9 +8,10 @@
 # install ROCm 7.13 from APT in the build stage and copy just the runtime libs + llama.cpp
 # binaries into a slim final image.
 #
-# Structure follows the official llama.cpp .devops/rocm.Dockerfile, plus two gfx1201 wins: the
-# gfx120X-tuned ROCm 7.13 above, and ROCWMMA flash-attn OFF (slower on gfx12, #15021). We build a
-# single gfx1201 target and slim the runtime to only the needed libs.
+# Structure follows the official llama.cpp .devops/rocm.Dockerfile, plus three gfx1201 wins: the
+# gfx120X-tuned ROCm 7.13 above, ROCWMMA flash-attn OFF (slower on gfx12, #15021), and the LLVM
+# unroll-threshold workaround on the HIP build below. We build a single gfx1201 target and slim
+# the runtime to only the needed libs.
 #
 # 2026 best-practices: multi-stage, digest-pinned bases, OCI labels, minimal runtime (no build
 # toolchain). The image defaults to a non-root user; the k8s deploy overrides to root for ROCm
@@ -64,6 +65,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # keep it OFF. OpenSSL ON so the server can fetch GGUFs via -hf into the model-cache PVC.
 ARG GGML_HIP_ROCWMMA_FATTN=OFF
 ARG AMDGPU_TARGETS=gfx1201
+# gfx1201 prefill win: the ROCm-7.x LLVM loop-unroll regression (llvm#147700, ggml #19984) ~halves
+# gfx12 prompt processing. Restore the pre-regression local unroll threshold; set to "" once a ROCm
+# release folds in the LLVM fix.
+ARG CMAKE_HIP_FLAGS="-mllvm --amdgpu-unroll-threshold-local=600"
 # Latest llama.cpp release; Renovate bumps this tag.
 # renovate: datasource=github-releases depName=ggml-org/llama.cpp versioning=regex:^b(?<patch>\d+)$
 ARG LLAMA_CPP_VERSION=b9626
@@ -83,6 +88,7 @@ RUN git clone --depth 1 --branch "${LLAMA_CPP_VERSION}" https://github.com/ggml-
         -DAMDGPU_TARGETS="${AMDGPU_TARGETS}" \
         -DGPU_TARGETS="${AMDGPU_TARGETS}" \
         -DGGML_HIP_ROCWMMA_FATTN="${GGML_HIP_ROCWMMA_FATTN}" \
+        -DCMAKE_HIP_FLAGS="${CMAKE_HIP_FLAGS}" \
         -DLLAMA_OPENSSL=ON \
         -DLLAMA_BUILD_TESTS=OFF \
         -DCMAKE_PREFIX_PATH="${ROCM_PATH}" \
@@ -118,6 +124,8 @@ FROM docker.io/library/ubuntu:26.04@sha256:f3d28607ddd78734bb7f71f117f3c6706c666
 # gcc runtime (libstdc++/atomic/gcc_s/gomp), openssl (HTTPS for -hf; llama.cpp uses cpp-httplib,
 # not libcurl, since b95xx), numa, ca-certs.
 RUN apt-get update \
+    # Refresh all base-image packages to their latest patched versions on top of the pinned digest.
+    && apt-get upgrade -y \
     && apt-get install -y --no-install-recommends \
         libgomp1 libstdc++6 libatomic1 libgcc-s1 libssl3 libnuma1 ca-certificates \
     && rm -rf /var/lib/apt/lists/* \

--- a/kubernetes/apps/ai/llama-server/app/config/models.ini
+++ b/kubernetes/apps/ai/llama-server/app/config/models.ini
@@ -19,7 +19,9 @@ parallel = 2
 kv-unified = true
 
 [qwen-3.6]
-; 27B config: full 256K ctx + q8 KV + all experts on the 32 GB GPU. ~37 tok/s single-session.
+; 27B config: full 256K ctx + q8 KV on the 32 GB GPU. ~37 tok/s single-session. Qwen3.6 is
+; parameter-dense but HYBRID-attention (GatedDeltaNet + gated attn, ~16/64 KV-bearing layers) —
+; that small KV-layer count is why a full 256K q8 KV cache fits in 32 GiB.
 ; MTP speculative decoding is ON: a lone request gets the full ~1.5x speedup (37 vs 24 tok/s
 ; measured with spec off). llama.cpp doesn't batch speculation across sequences, so MTP only
 ; degrades under simultaneous multi-slot decode — capped to 2-way by parallel=2 above. Drop
@@ -35,8 +37,8 @@ image-min-tokens = 1024 # Qwen-VL grounding degrades below 1024 image tokens (lo
 ctx-size = 262144
 cache-type-k = q8_0
 cache-type-v = q8_0
-spec-type = draft-mtp # MTP self-speculative decoding (n-max 3 = sweep optimum, ~1.6x single-stream)
-spec-draft-n-max = 3
+spec-type = draft-mtp # MTP self-speculative decoding, ~1.6x single-stream
+spec-draft-n-max = 4 # 2026-06-15 sweep: +15% single-stream vs n3, best 2-conc retention
 cache-ram = 8192 # host-RAM prompt cache: agentic prefix reuse, 7.5x warm TTFT
 ctx-checkpoints = 32
 ; Unsloth thinking-mode sampling defaults.


### PR DESCRIPTION
## What

Three changes for the Qwen3.6-27B llama.cpp serving stack on the R9700 (gfx1201): a measured MTP tuning win, a gfx1201 prefill build workaround, and a runtime dependency refresh.

### 1. `models.ini`: MTP `spec-draft-n-max` 3 → 4 (measured)

A live spec-draft × concurrency sweep on 2026-06-15 (`parallel=2`, MTP on) found deeper speculation beats the previous `n-max=3`:

| n-max | single-stream TG | 2-conc per-req |
|---|---|---|
| 3 (was) | 36.7 | — |
| **4** | **42.3 (+15%)** | **22.6** (best) |
| 5 | 43.3 (+18%) | 20.2 |

`n=4` captures nearly all the single-stream gain with the best concurrency retention, at zero VRAM cost. The `n=3` baseline was re-measured in the **same sweep window** (36.7), so the delta is not GPU-contention skew. Also corrects a misleading comment: Qwen3.6-27B is parameter-dense but **hybrid-attention** (GatedDeltaNet + gated attention, ~16/64 KV-bearing layers), not MoE — which is why a full 256K q8 KV cache fits in 32 GiB.

### 2. `Dockerfile`: gfx1201 LLVM unroll-threshold workaround

Adds `-DCMAKE_HIP_FLAGS="-mllvm --amdgpu-unroll-threshold-local=600"` (as an `ARG`, beside the other gfx1201 build tunables) to work around the ROCm-7.x LLVM loop-unroll regression (llvm#147700, ggml #19984) that ~halves gfx12 prefill.

> ⚠️ **Unverified until the image is rebuilt.** The prefill win is conditional on the 7.13 gfx120X base still carrying the regression — its tuned hipBLASLt may already sidestep it. Validate PP before/after on the first build; if it is a no-op, set the ARG to `""`. Worst case the flag is benign.

### 3. `Dockerfile`: `apt-get upgrade -y` in the runtime stage

Refreshes the slim runtime image's base packages to the latest patched versions on top of the pinned digest, in the same RUN layer as the apt-lists cleanup (no cache bloat).

## Reviewed

Ran `/simplify` over the diff before opening — folded the HIP flag into an `ARG` (matching the existing `GGML_HIP_ROCWMMA_FATTN` / `AMDGPU_TARGETS` convention so it is toggleable and droppable) and trimmed the new comments.
