### PR TITLE
feat(network): add smtp-relay and switch nextcloud to internal relay

### DIFF
--- a/kubernetes/apps/default/nextcloud/app/helmrelease.yaml
+++ b/kubernetes/apps/default/nextcloud/app/helmrelease.yaml
@@ -82,9 +82,6 @@ spec:
         secretName: nextcloud-secret
         usernameKey: NEXTCLOUD_USERNAME
         passwordKey: NEXTCLOUD_PASSWORD
-        smtpUsernameKey: SMTP_USERNAME
-        smtpPasswordKey: SMTP_PASSWORD
-        smtpHostKey: SMTP_HOST
 
       host: nextcloud.${SECRET_DOMAIN}
       containerPort: 80
@@ -92,12 +89,12 @@ spec:
       mail:
         enabled: true
         fromAddress: ${FROM_ADDRESS}
-        domain: gmail.com
+        domain: ${SECRET_DOMAIN}
         smtp:
-          host: ${SMTP_HOST}
-          port: 465
-          authtype: LOGIN
-          secure: starttls
+          host: smtp-relay.network.svc.cluster.local
+          port: 25
+          authtype: NONE
+          secure: none
 
       # Security context - allow root for entrypoint, then drops to www-data
       securityContext:

--- a/kubernetes/apps/network/kustomization.yaml
+++ b/kubernetes/apps/network/kustomization.yaml
@@ -11,3 +11,4 @@ resources:
   - ./envoy-gateway/ks.yaml
   - ./external-service/ks.yaml
   - ./k8s-gateway/ks.yaml
+  - ./smtp-relay/ks.yaml

--- a/kubernetes/apps/network/smtp-relay/app/helmrelease.yaml
+++ b/kubernetes/apps/network/smtp-relay/app/helmrelease.yaml
@@ -1,0 +1,79 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: smtp-relay
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  interval: 1h
+  values:
+    controllers:
+      smtp-relay:
+        strategy: Recreate
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: docker.io/boky/postfix
+              tag: 5.1.0-alpine
+            env:
+              RELAY_HOST: smtp.gmail.com:587
+              MYNETWORKS: "10.0.0.0/8;172.16.0.0/12;192.168.0.0/16"
+              MYHOSTNAME: "smtp-relay.network.svc.cluster.local"
+              MESSAGE_SIZE_LIMIT: "52428800"
+              RELAY_USERNAME:
+                valueFrom:
+                  secretKeyRef:
+                    name: smtp-relay-secret
+                    key: RELAY_USERNAME
+              RELAY_PASSWORD:
+                valueFrom:
+                  secretKeyRef:
+                    name: smtp-relay-secret
+                    key: RELAY_PASSWORD
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket:
+                    port: &smtpPort 25
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket:
+                    port: *smtpPort
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket:
+                    port: *smtpPort
+                  initialDelaySeconds: 5
+                  periodSeconds: 5
+                  failureThreshold: 30
+            resources:
+              requests:
+                cpu: 10m
+                memory: 32Mi
+              limits:
+                cpu: 500m
+                memory: 128Mi
+
+    service:
+      app:
+        ports:
+          smtp:
+            port: *smtpPort

--- a/kubernetes/apps/network/smtp-relay/app/kustomization.yaml
+++ b/kubernetes/apps/network/smtp-relay/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrelease.yaml
+  - secret.sops.yaml

--- a/kubernetes/apps/network/smtp-relay/app/secret.sops.yaml
+++ b/kubernetes/apps/network/smtp-relay/app/secret.sops.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: smtp-relay-secret
+stringData:
+  RELAY_USERNAME: ENC[AES256_GCM,data:XyG/z3XdQA4DGJYUmfmyKH7p6+w=,iv:JCcQwXy5TXizTrtEXjjxcLjWvaVZs05JYQbakJfLCZc=,tag:YkX8Vgl65N8QoNKhy9M02Q==,type:str]
+  RELAY_PASSWORD: ENC[AES256_GCM,data:Ao0MME77pnFdwoikLW2Xfy0SiU5Qe/Y=,iv:/ZT/oixb0qnQRp+rOw9LAyeb7LYghEbK1k95naFOuMk=,tag:LnT0nImAW5ItpClXXyRBLw==,type:str]
+sops:
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBtVkdhRm4zWCtGSWJybmgv
+        MFNySVdBRnZacXJGNzh1Q2t0UnJnci9XTG5BCjI0ZkU0dnkzMkw5dTB4ajJpT0VM
+        dk9VUE1UcUpyNVI0VmhtYk1aaTBBL2cKLS0tIG14dzE2TEt0TDBVVzBJRkJsS2pn
+        NWh2QW96elhjMC9iVDNxTGJxYzEvbTAKbd1ij4B/oySTM2NWuK0zog+WfuojRGX5
+        6XSD6RWCUEn2blOJ6OHL3jf4mXBQBS+MVCwzRSmHrv1inHmcxUZZhw==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age12gul5m0dg9nn2gk69uvzwdxyluh5xt02m8wvyg9hn7c93nz7xehswmdenq
+  encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-06-15T18:13:37Z"
+  mac: ENC[AES256_GCM,data:/ChOA4B8ANP5ehMrvYjxGmRqnxAwSNMb3G8KNbP+iactAJjXj8DhwXwtsVCEiSNa9d+zMHcoU783b0y5oRNjyGE/qaXDRBsRVK7AeI7Z7nScxWptHnzggL3F+quRd2I/wUG/5nXlm/PK3xPEoSQvJwCY1uFz4xTHfe60UWMtPLw=,iv:q1gcDUvA5XpdO5r8DEco26icfDpa9EVqrC47UYCjeCU=,tag:jsON8ODbNqEmJolH1kjkYw==,type:str]
+  mac_only_encrypted: true
+  version: 3.13.1

--- a/kubernetes/apps/network/smtp-relay/ks.yaml
+++ b/kubernetes/apps/network/smtp-relay/ks.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: smtp-relay
+  namespace: &namespace network
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/network/smtp-relay/app
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  wait: false


### PR DESCRIPTION
## Summary

Deploys a Postfix-based SMTP relay to the `network` namespace so Gmail SMTP credentials are configured once and reused by all services.

## Changes

### New: `kubernetes/apps/network/smtp-relay/`
- **`boky/postfix:5.1.0-alpine`** as a null-client relay
- Relays through Gmail SMTP (`smtp.gmail.com:587`) with STARTTLS
- Internal address: `smtp-relay.network.svc.cluster.local:25`
- No auth required from cluster-internal clients
- SOPS-encrypted secret for Gmail credentials (needs real values filled in)

### Updated: `kubernetes/apps/default/nextcloud/app/helmrelease.yaml`
- Switched from direct Gmail SMTP (port 465, TLS, LOGIN) to the internal relay (port 25, no auth, no TLS)
- Removed `smtpHostKey`/`smtpUsernameKey`/`smtpPasswordKey` references to the old secret

## Post-merge steps

1. Decrypt and fill in your Gmail App Password:
   ```bash
   sops kubernetes/apps/network/smtp-relay/app/secret.sops.yaml
   ```
2. Other services can use `smtp-relay.network.svc.cluster.local:25` with no auth