### PR TITLE
feat(network): add 3d printer external service

### DIFF
--- a/kubernetes/apps/network/external-service/centauri-carbon/endpointslice.yaml
+++ b/kubernetes/apps/network/external-service/centauri-carbon/endpointslice.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  name: external-centauri-carbon
+  labels:
+    kubernetes.io/service-name: external-centauri-carbon
+addressType: IPv4
+endpoints:
+  - addresses:
+      - 192.168.0.95
+ports:
+  - port: 80
+    name: http
+    protocol: TCP

--- a/kubernetes/apps/network/external-service/centauri-carbon/httproute.yaml
+++ b/kubernetes/apps/network/external-service/centauri-carbon/httproute.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: external-service-httproute-centauri-carbon
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/name: Centauri Carbon
+    gethomepage.dev/description: 3D printer web UI
+    gethomepage.dev/group: External
+    gethomepage.dev/icon: mdi:printer-3d
+    # external target — no pods to health-check
+    gethomepage.dev/pod-selector: ""
+spec:
+  parentRefs:
+    - name: envoy-internal
+      namespace: network
+
+  hostnames:
+    - cc.${SECRET_DOMAIN}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: external-centauri-carbon
+          port: 80

--- a/kubernetes/apps/network/external-service/centauri-carbon/kustomization.yaml
+++ b/kubernetes/apps/network/external-service/centauri-carbon/kustomization.yaml
@@ -3,13 +3,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./arm
-  - ./avr
-  - ./centauri-carbon
-  - ./homeassistant
-  - ./ipmi
-  - ./ntopg
-  - ./opnsense
-  - ./scrutiny
-  - ./truenas
-  - ./vaultwarden
+  - service.yaml
+  - endpointslice.yaml
+  - httproute.yaml

--- a/kubernetes/apps/network/external-service/centauri-carbon/service.yaml
+++ b/kubernetes/apps/network/external-service/centauri-carbon/service.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: external-centauri-carbon
+spec:
+  ports:
+    - port: 80
+      targetPort: 80
+      name: http
+  clusterIP: None
+  type: ClusterIP


### PR DESCRIPTION
## Summary
- add cc external-service manifests for the 3D printer at 192.168.0.95
- expose it internally at cc.${SECRET_DOMAIN} through envoy-internal
- add homepage metadata for the external target

## Validation
- git diff --check
- bash .agents/skills/pr-review/scripts/validate-pr.sh (warnings: kustomize and shellcheck not installed in local shell; repo-wide pre-existing naming/security warnings; new expected hardcoded external IP warning for 192.168.0.95)