### PR TITLE
fix(smtp-relay): fix crashloop - add ALLOW_EMPTY_SENDER_DOMAINS

### DIFF
--- a/kubernetes/apps/network/smtp-relay/app/helmrelease.yaml
+++ b/kubernetes/apps/network/smtp-relay/app/helmrelease.yaml
@@ -22,9 +22,10 @@ spec:
               tag: 5.1.0-alpine
             env:
               RELAY_HOST: smtp.gmail.com:587
-              MYNETWORKS: "10.0.0.0/8;172.16.0.0/12;192.168.0.0/16"
+              POSTFIX_mynetworks: "10.0.0.0/8;172.16.0.0/12;192.168.0.0/16"
               MYHOSTNAME: "smtp-relay.network.svc.cluster.local"
-              MESSAGE_SIZE_LIMIT: "52428800"
+              POSTFIX_message_size_limit: "52428800"
+              ALLOW_EMPTY_SENDER_DOMAINS: "true"
               RELAY_USERNAME:
                 valueFrom:
                   secretKeyRef:


### PR DESCRIPTION
## Fixes CrashLoopBackOff

The Postfix 5.x image requires `ALLOWED_SENDER_DOMAINS` or `ALLOW_EMPTY_SENDER_DOMAINS` to start. Also fixed deprecated env vars:

| Before | After |
|--------|-------|
| `MYNETWORKS` (deprecated) | `POSTFIX_mynetworks` |
| `MESSAGE_SIZE_LIMIT` (deprecated) | `POSTFIX_message_size_limit` |
| *(missing)* | `ALLOW_EMPTY_SENDER_DOMAINS=true` |

## Post-merge

Once merged, Flux will auto-rollout the fix.