### PR TITLE
fix(llama-server): shrink embedding batch sizes to fit GPU co-residency

### DIFF
--- a/kubernetes/apps/ai/llama-server/app/config/models.ini
+++ b/kubernetes/apps/ai/llama-server/app/config/models.ini
@@ -48,14 +48,20 @@ top-p = 0.95
 min-p = 0.0
 
 [qwen3-embedding]
-; Dormant (embeddings run on TEI today); resident alongside chat via --models-max 2,
-; ready for a litellm embedding route later.
+; GPU embeddings resident alongside chat via --models-max 2 (offloads TEI's ~14s CPU-ONNX
+; init floor). The R9700 is near-full once qwen-3.6 holds its 256K q8 KV cache, so the batch
+; sizes below are sized for co-residency, NOT throughput: an 8192 micro-batch forces a large
+; load-time compute buffer that can't be allocated in the slim free-VRAM headroom (the 0.6B
+; model otherwise hangs in "loading"). 2048 shrinks that buffer (and the KV) so it fits as the
+; 2nd resident instance. 2048 also caps per-pass input length — ample for semantic/tool-search
+; embeddings; raise it (or free more VRAM by lowering qwen-3.6's KV to q5_1) if longer inputs
+; are needed. See PR adding this.
 hf-repo = Qwen/Qwen3-Embedding-0.6B-GGUF
 hf-file = Qwen3-Embedding-0.6B-f16.gguf
 embeddings = true
 pooling = last
 n-gpu-layers = 99
-ctx-size = 8192
-batch-size = 8192
-ubatch-size = 8192
+ctx-size = 2048
+batch-size = 2048
+ubatch-size = 2048
 threads = 4


### PR DESCRIPTION
## Problem

`qwen3-embedding` (Qwen3-Embedding-0.6B) never comes up alongside the chat model. Live router state shows it stuck in `status: loading` indefinitely while `qwen-3.6` stays `loaded` and is never evicted — the signature of a **blocked VRAM allocation**, not a download or eviction issue (`need_download: false`, the GGUF is cached).

Root cause: the R9700 (32 GB) is near-full once `qwen-3.6` holds its **256K `q8_0` KV cache**. The embedding preset is launched with `--batch-size 8192 --ubatch-size 8192 --ctx-size 8192`, and that 8192 micro-batch forces a large **load-time compute buffer** that can't be allocated in the slim free-VRAM headroom — so a 0.6B model that should load in seconds hangs forever.

## Fix

Size the embedding preset for **co-residency, not throughput**: drop `ctx-size` / `batch-size` / `ubatch-size` from `8192` → `2048`. That shrinks the load-time compute buffer (and KV) enough for the embedding model to load as the second resident instance under `--models-max 2`.

`2048` caps per-pass input length, which is ample for semantic / tool-search embeddings. This change is isolated to the dormant `[qwen3-embedding]` preset — **no impact on `qwen-3.6` chat serving**.

## If this isn't enough

If the embedding model still fails to load (i.e. free VRAM is below even the 0.6B weights, not just the buffer), the next lever is to free real VRAM on the chat side by lowering `qwen-3.6` KV `q8_0` → `q5_1` (symmetric K/V; the Hadamard rotation already compiled into the deployed build keeps q5 near-lossless). Documented in the config comment; not applied here to keep the change minimal and avoid touching the production chat model.

## Verification

After merge: Flux reconciles → reloader restarts the pod → confirm via the router that `qwen3-embedding` reaches `status: loaded` alongside `qwen-3.6` (e.g. `GET /v1/models`), then issue a test `/v1/embeddings` request.

Note: diagnosed via the gateway because cluster `kubectl` access is currently CA-broken (stale `talosconfig`); the pod log was not directly inspected, so the VRAM-OOM root cause is inferred from router state with high confidence.