### PR TITLE
fix(llama-server): lower qwen-3.6 KV to q5_1 to free VRAM for embeddings

### DIFF
--- a/kubernetes/apps/ai/llama-server/app/config/models.ini
+++ b/kubernetes/apps/ai/llama-server/app/config/models.ini
@@ -19,9 +19,10 @@ parallel = 2
 kv-unified = true
 
 [qwen-3.6]
-; 27B config: full 256K ctx + q8 KV on the 32 GB GPU. ~37 tok/s single-session. Qwen3.6 is
+; 27B config: full 256K ctx + q5_1 KV on the 32 GB GPU. ~37 tok/s single-session. Qwen3.6 is
 ; parameter-dense but HYBRID-attention (GatedDeltaNet + gated attn, ~16/64 KV-bearing layers) —
-; that small KV-layer count is why a full 256K q8 KV cache fits in 32 GiB.
+; that small KV-layer count is why a full 256K KV cache fits in 32 GiB (q8 fit too, but q5_1
+; frees ~3 GiB so qwen3-embedding can be GPU-resident alongside chat — see cache-type below).
 ; MTP speculative decoding is ON: a lone request gets the full ~1.5x speedup (37 vs 24 tok/s
 ; measured with spec off). llama.cpp doesn't batch speculation across sequences, so MTP only
 ; degrades under simultaneous multi-slot decode — capped to 2-way by parallel=2 above. Drop
@@ -35,8 +36,14 @@ no-mmap = true # mmap re-faults the 18Gi weights from the cache PVC (130s+ cold 
 flash-attn = on
 image-min-tokens = 1024 # Qwen-VL grounding degrades below 1024 image tokens (load_hparams warning)
 ctx-size = 262144
-cache-type-k = q8_0
-cache-type-v = q8_0
+# q5_1 (down from q8_0) frees ~3 GiB of KV so qwen3-embedding fits GPU-resident alongside chat
+# (--models-max 2); it was hung in "loading" at q8 for lack of headroom. K and V MUST match type
+# to stay on the fused HIP flash-attn path (asymmetric silently falls back to a slow/CPU path).
+# Quality stays near-q8: the Hadamard activation rotation (llama.cpp #21038) is compiled into this
+# build and default-on for quantized KV, so it absorbs most of the q5 error. Revert to q8_0 (and
+# trim ctx-size instead) if long-context reasoning quality ever regresses.
+cache-type-k = q5_1
+cache-type-v = q5_1
 spec-type = draft-mtp # MTP self-speculative decoding, ~1.6x single-stream
 spec-draft-n-max = 4 # 2026-06-15 sweep: +15% single-stream vs n3, best 2-conc retention
 cache-ram = 8192 # host-RAM prompt cache: agentic prefix reuse, 7.5x warm TTFT


### PR DESCRIPTION
## Why

Follow-up to #3291. That PR shrank the embedding preset's batch sizes (8192→2048), but `qwen3-embedding` **still hangs in `status: loading`** — verified live after the merge deployed (launch args confirm `ctx/batch/ubatch=2048`, yet the model never reaches `loaded` while `qwen-3.6` stays up). Shrinking the load buffer 4× changed nothing, so the bottleneck is **raw VRAM headroom**, not the buffer: qwen-3.6's 256K `q8_0` KV cache leaves less free VRAM than even the 0.6B embedding model (~1.5 GB) needs.

## Change

Lower qwen-3.6 KV `cache-type-k`/`-v` from `q8_0` → **`q5_1`** (symmetric). This frees ~3 GiB — comfortably more than the embedding model needs — while keeping the **full 256K context**.

- **K and V stay the same type** so we remain on the fused HIP flash-attention path; asymmetric K/V silently falls back to a slow/CPU path.
- **Quality stays close to q8**: the Hadamard activation rotation (llama.cpp #21038, commit `744c0c7`) is already compiled into the deployed `b9626` build and is default-on for quantized KV — it absorbs most of the q5 quantization error. Small, likely-imperceptible loss vs q8; the only at-risk case is reasoning at near-256K context.
- `q5_1` is the most conservative sub-q8 symmetric step (next options down are q5_0 → q4_1 → q4_0), deliberately not going lower.

**Revert path:** if long-context reasoning quality ever regresses, go back to `q8_0` and trim `ctx-size` instead (lossless, costs context). Documented inline.

## Verification

After merge → Flux reconcile → pod restart: confirm `qwen3-embedding` reaches `status: loaded` alongside `qwen-3.6` via `GET /v1/models`, then a test `/v1/embeddings` call. Also spot-check chat PP+TG is unchanged (the Hadamard rotation was already active at q8, so no new TG penalty expected).

(Diagnosed via the gateway; cluster `kubectl` is currently CA-broken.)