### PR TITLE
fix(grafana): show llama-server GPU temps per sensor

### DIFF
--- a/kubernetes/apps/ai/llama-server/app/dashboard/llama-server.json
+++ b/kubernetes/apps/ai/llama-server/app/dashboard/llama-server.json
@@ -1285,8 +1285,8 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "max by (nodename) (node_hwmon_temp_celsius and on (chip, instance) node_hwmon_chip_names{chip_name=\"amdgpu\"})",
-          "legendFormat": "{{nodename}}",
+          "expr": "node_hwmon_temp_celsius and on (chip, instance) node_hwmon_chip_names{chip_name=\"amdgpu\"}",
+          "legendFormat": "{{nodename}} / {{sensor}}",
           "refId": "A"
         }
       ],


### PR DESCRIPTION
## Summary\n- Replace the llama-server GPU temperature panel aggregation with a per-sensor query\n- Update the legend to show `{{nodename}} / {{sensor}}`\n\n## Verification\n- Live Grafana dashboard query still showed the old max-by-node expression before the repo change\n- Prometheus query returned separate series with `sensor` labels (temp1/temp2/temp3) for control-1\n- JSON syntax validated with `python3 -m json.tool`\n- Review: no findings\n\n## Notes\n- Only the GPU temperature panel was changed; other GPU panels were left untouched.