### PR TITLE
feat(kube-system): add downflate app for Talos image pre-pulling

### DIFF
--- a/kubernetes/apps/kube-system/downflate/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/downflate/app/helmrelease.yaml
@@ -1,0 +1,94 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: downflate
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  interval: 1h
+  values:
+    controllers:
+      downflate:
+        replicas: 1
+        strategy: RollingUpdate
+        annotations:
+          reloader.stakater.com/auto: "true"
+
+        pod:
+          topologySpreadConstraints:
+            - maxSkew: 1
+              topologyKey: kubernetes.io/hostname
+              whenUnsatisfiable: ScheduleAnyway
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: downflate
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
+            fsGroupChangePolicy: "OnRootMismatch"
+
+        containers:
+          app:
+            image:
+              repository: ghcr.io/home-operations/downflate
+              tag: main
+            env:
+              DOWNFLATE_REPO: github://tanguille/cluster
+              DOWNFLATE_TALOSCONFIG: /var/run/secrets/talos.dev/talosconfig
+              DOWNFLATE_CLUSTER_PATH: kubernetes
+              DOWNFLATE_LOG_LEVEL: info
+            envFrom:
+              - secretRef:
+                  name: "{{ .Release.Name }}-secret"
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /healthz
+                    port: &port 8080
+                  initialDelaySeconds: 0
+                  periodSeconds: 10
+                  timeoutSeconds: 1
+                  failureThreshold: 3
+              readiness: *probes
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 10m
+                memory: 32Mi
+              limits:
+                cpu: 500m
+                memory: 128Mi
+
+    persistence:
+      talos:
+        type: secret
+        name: "{{ .Release.Name }}"
+        defaultMode: 0o400
+        globalMounts:
+          - path: /var/run/secrets/talos.dev
+
+    service:
+      app:
+        controller: downflate
+        ports:
+          http:
+            port: *port
+
+    route:
+      app:
+        hostnames:
+          - "{{ .Release.Name }}.${SECRET_DOMAIN}"
+        parentRefs:
+          - name: envoy-external
+            namespace: network

--- a/kubernetes/apps/kube-system/downflate/app/kustomization.yaml
+++ b/kubernetes/apps/kube-system/downflate/app/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - helmrelease.yaml
+  - secret.sops.yaml
+  - talos-sa.yaml

--- a/kubernetes/apps/kube-system/downflate/app/secret.sops.yaml
+++ b/kubernetes/apps/kube-system/downflate/app/secret.sops.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: downflate-secret
+stringData:
+  DOWNFLATE_TOKEN: ENC[AES256_GCM,data:TIVcgE1bE54fnx1swZX3aCC/sJUZaA==,iv:WuR2l7cDilwpvs2g7qhiXLyP2zXCGT/lHGGL7rutHrU=,tag:knZvSay/tBIhiHOGHFyqqg==,type:str]
+  DOWNFLATE_WEBHOOK_SECRET: ENC[AES256_GCM,data:uDWZElPLHHwIVJeR/KbuxxIievmuvQ==,iv:1bSMnAIJ7lIcs4jN+MIiaTfcvgc9fGbMUQ6ZtglyYJQ=,tag:wkV+hcta2k2019DhelNFPg==,type:str]
+sops:
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA5Zjk1eDRCRXZja2ZJaGx2
+        YjVnb3MxWGN2R203NHkvMG1xcFVUY05FcjF3CnZWWWl5V2svbmNrT2JTRnNmdHp2
+        Y0JOTUJqKytqdUJBcElqOWN0VzJFaWcKLS0tIFVTRjNHZklOQlRHQ3pSektnTDhO
+        T255RUFUOVR2WFdtNWtHeW9DYzFSencKZauC4fR0vQl3uaUiV9I9hdelrF2IaT4Y
+        8PVXC8YuyJASpYlRXHiVeY/GoiPHArqg7qjgQGRtN04TC0oie/p9Nw==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age12gul5m0dg9nn2gk69uvzwdxyluh5xt02m8wvyg9hn7c93nz7xehswmdenq
+  encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-06-18T18:55:52Z"
+  mac: ENC[AES256_GCM,data:LMvpuCaTlzYQaS4pDiAbM+QXKd4PiCL3krJ4OuxUUIjPjqlOkjWPu8Gx7ondvXqm+40gleaG/AQJYep41lkGv0g21HJPwjUhoxCdUXN1m8GKxieI1hwd7neX31XO+SIEzXIhMpAr6np1lWuTxGi1zLztcgrnW+jbIa6PruQGvow=,iv:T3H2l4ZL+RB2220JZQLrRi+p98HC+PoQ/nVl+Cdr1SM=,tag:GttzrlMVTR/FkBiQ0sRUPg==,type:str]
+  mac_only_encrypted: true
+  version: 3.13.1

--- a/kubernetes/apps/kube-system/downflate/app/talos-sa.yaml
+++ b/kubernetes/apps/kube-system/downflate/app/talos-sa.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: talos.dev/v1alpha1
+kind: ServiceAccount
+metadata:
+  name: downflate
+spec:
+  roles: ["os:admin"]

--- a/kubernetes/apps/kube-system/downflate/ks.yaml
+++ b/kubernetes/apps/kube-system/downflate/ks.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: downflate
+spec:
+  dependsOn:
+    - name: spegel
+  interval: 1h
+  path: ./kubernetes/apps/kube-system/downflate/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: kube-system
+  wait: false

--- a/kubernetes/apps/kube-system/kustomization.yaml
+++ b/kubernetes/apps/kube-system/kustomization.yaml
@@ -14,4 +14,5 @@ resources:
   - ./metrics-server/ks.yaml
   - ./reloader/ks.yaml
   - ./snapshot-controller/ks.yaml
+  - ./downflate/ks.yaml
   - ./spegel/ks.yaml


### PR DESCRIPTION
## Description

Add [downflate](https://github.com/home-operations/downflate) — a Go webhook server that pre-pulls container images onto Talos nodes before a PR merges.

Downflate listens for GitHub webhooks (PR opened/synchronized), reads the PR diff to detect new/changed container images in `kubernetes/`, and calls the Talos `ImageService.Pull` API on all cluster nodes.

## Files

| File | Purpose |
|------|---------|
| `kubernetes/apps/kube-system/downflate/ks.yaml` | Flux Kustomization (depends on spegel) |
| `kubernetes/apps/kube-system/downflate/app/helmrelease.yaml` | app-template HelmRelease |
| `kubernetes/apps/kube-system/downflate/app/talos-sa.yaml` | Talos ServiceAccount (`os:admin` role) |
| `kubernetes/apps/kube-system/downflate/app/secret.sops.yaml` | SOPS-encrypted secret (placeholder values) |
| `kubernetes/apps/kube-system/kustomization.yaml` | Wire into kube-system |

## Pre-merge

- [ ] Replace placeholder `DOWNFLATE_TOKEN` / `DOWNFLATE_WEBHOOK_SECRET` with real values:
  ```bash
  sops edit kubernetes/apps/kube-system/downflate/app/secret.sops.yaml
  ```
