### PR TITLE
feat(llama-server): migrate Qwen3.6 to 35B-A3B MoE

### DIFF
--- a/docker/llama-cpp-rocm/Dockerfile
+++ b/docker/llama-cpp-rocm/Dockerfile
@@ -1,4 +1,4 @@
-# llama.cpp server for AMD R9700 (RDNA4 / gfx1201), serving Qwen3.6-27B GGUF + MTP.
+# llama.cpp server for AMD R9700 (RDNA4 / gfx1201), serving Qwen3.6-35B-A3B MoE GGUF + MTP.
 #
 # Why a custom image: upstream ghcr.io/ggml-org/llama.cpp:server-rocm ships ROCm 7.2.1, whose
 # rocBLAS/hipBLASLt are NOT gfx1201-tuned -> ~18 tok/s. AMD's gfx120X-tuned ROCm (7.13) doubles

--- a/docker/llama-cpp-rocm/README.md
+++ b/docker/llama-cpp-rocm/README.md
@@ -1,18 +1,19 @@
 # llama-cpp-rocm-gfx1201
 
 Custom **llama.cpp server** image for the AMD **R9700 (RDNA4 / gfx1201)**, serving
-Qwen3.6-27B GGUF with **MTP** (multi-token prediction). Image:
+Qwen3.6-35B-A3B MoE GGUF with **MTP** (multi-token prediction). Image:
 `ghcr.io/tanguille/llama-cpp-rocm-gfx1201:gfx1201`.
 
 ## Why custom
 
 Upstream `ghcr.io/ggml-org/llama.cpp:server-rocm` ships **ROCm 7.2.1**, whose rocBLAS/hipBLASLt
 are not gfx1201-tuned → **~18 tok/s**. AMD's **gfx120X-tuned ROCm 7.13** (TheRock) doubles decode
-to **~34 tok/s**. That tuned stack only ships inside AMD's `rocm/vllm` gfx120X image, so we use it
-as the **build base** and copy just the runtime libs + llama.cpp binaries into a slim final image
-(multi-stage — the vllm/pytorch payload stays in the build stage). Measured on this rig:
-`UD-Q4_K_XL` + q8_0 KV + `--spec-type draft-mtp --spec-draft-n-max 3` → **34 tok/s**, prefix
-cache 7.5× warm TTFT. See [`docs/sglang-rdna4-benchmarks.md`](../../docs/sglang-rdna4-benchmarks.md).
+to **~34 tok/s** (measured on the prior 27B dense model). AMD now publishes the tuned gfx1201
+libraries as per-arch APT packages, so the Dockerfile installs ROCm 7.13 in the build stage and
+copies just the runtime libs + llama.cpp binaries into a slim final image. Current model is
+**Qwen3.6-35B-A3B MoE** (UD-Q3_K_XL, ~16.0 GiB) — MoE's ~3B active params/token give faster
+decode than the prior 27B dense model. See
+[`docs/sglang-rdna4-benchmarks.md`](../../docs/sglang-rdna4-benchmarks.md).
 
 ## Build
 
@@ -21,16 +22,16 @@ GPU-less (HIP **cross-compile**) — runs on the generic `image-builder` self-ho
 on Dockerfile changes / weekly / manual dispatch. Renovate bumps:
 
 - `LLAMA_CPP_VERSION` (`datasource=github-releases ggml-org/llama.cpp`)
-- `ROCM_BUILD_IMAGE` digest (`datasource=docker rocm/vllm`)
+- `ROCM_VERSION` (`datasource=docker rocm/vllm`; signal-only, package names are bumped by hand)
 
-## Runtime flags (set in the HelmRelease)
+## Runtime flags (set in `models.ini`, mounted by the HelmRelease)
 
 ```
--ngl 99 --fit off --no-mmap -fa 1 -ctk q8_0 -ctv q8_0 -c <ctx> -np <slots>
---spec-type draft-mtp --spec-draft-n-max 3
+-ngl 99 --fit off --no-mmap -fa 1 -ctk q4_0 -ctv q4_0 -c 262144 -np 1
+--spec-type draft-mtp --spec-draft-n-max 2
 ```
 
-- `--no-mmap` is **required**: mmap re-faults the 18 GB weights from the PVC on cold cache,
+- `--no-mmap` is **required**: mmap re-faults the ~16 GB weights from the PVC on cold cache,
   pushing load from 11 s to 130 s+.
 - `--fit off`: we pin `-ngl`/`-c` explicitly; the auto-fit step hangs on this model.
 - gfx1201 GPU access: the `squat.ai/dri` device plugin provides `/dev/dri` + `/dev/kfd` (no manual

--- a/kubernetes/apps/ai/llama-server/app/config/models.ini
+++ b/kubernetes/apps/ai/llama-server/app/config/models.ini
@@ -8,33 +8,32 @@ jinja = true
 flash-attn = auto
 metrics = true
 slots = true
-; 2 concurrent slots via continuous batching. parallel=2 (not 4) is the measured sweet spot WITH
-; MTP on: MTP speculation contends when multiple slots decode at once, so capping at 2 keeps that
-; thrash 2-way and QUEUES any excess instead of letting 4 requests collapse together. Measured on
-; the shared R9700 (live transcode contention): single TG ~37, 2-conc agg ~27, 4-conc per-request
-; ~20 tok/s — vs parallel=4+MTP where 4-conc per-request dropped to ~11. kv-unified shares one
-; 256K KV pool across slots (vs static 256K/2 split), so a lone session still gets the full 256K;
-; setting --parallel explicitly disables unified by default, hence the explicit kv-unified = true.
-parallel = 2
+; MTP currently requires a single llama.cpp server slot: Unsloth's 35B-A3B model card says
+; `-np > 1` is not yet supported with MTP. Keep parallel=1 for correctness; if multi-user
+; aggregate throughput becomes more important than single-stream latency, benchmark parallel=2–4
+; with spec-type/spec-draft-n-max disabled instead.
+; kv-unified stays explicit so the full 256K KV pool remains available to the single hot slot.
+parallel = 1
 kv-unified = true
 
 [qwen-3.6]
-; 27B config: full 256K ctx + q4_0 KV on the 32 GB GPU. ~37 tok/s single-session. Qwen3.6 is
-; parameter-dense but HYBRID-attention (GatedDeltaNet + gated attn, ~16/64 KV-bearing layers) —
-; that small KV-layer count is why a full 256K KV cache fits in 32 GiB (q8 fit too, but q4_0
-; frees ~6 GiB so qwen3-embedding can be GPU-resident alongside chat — see cache-type below).
-; MTP speculative decoding is ON: a lone request gets the full ~1.5x speedup (37 vs 24 tok/s
-; measured with spec off). llama.cpp doesn't batch speculation across sequences, so MTP only
-; degrades under simultaneous multi-slot decode — capped to 2-way by parallel=2 above. Drop
-; spec-type only if sustained 4+ user aggregate throughput ever outweighs single-session latency
-; (measured: spec-off parallel=4 gives ~28 agg at 4-conc but single-session falls to ~24).
-hf-repo = unsloth/Qwen3.6-27B-MTP-GGUF
-hf-file = Qwen3.6-27B-UD-Q4_K_XL.gguf
+; 35B-A3B MoE config: 40-layer architecture with 10 full-attention KV-bearing layers and ~3B
+; active params/token — much lighter decode than 27B dense (~16.7 GiB full weights per token).
+; UD-Q3_K_XL (~16.0 GiB) achieves weight parity with the prior 27B UD-Q4_K_XL (~16.7 GiB) while
+; the KV layer count drops from ~16 to ~10, freeing VRAM for one extra concurrent slot.
+; Q4 was avoided: UD-Q4_K_XL (~21.3 GiB) requires ~24 GiB on its own, leaving insufficient
+; headroom for qwen3-embedding co-residency + 256K KV on 32 GB.
+; MTP speculative decoding is ON: MoE's smaller draft head uses spec-draft-n-max=2 (Unsloth's
+; recommendation for 35B-A3B MTP instead of 27B's n=4). Re-sweep n=1–3 after deploy.
+; llama.cpp does not support MTP with `-np > 1` yet, so this preset intentionally keeps a single
+; server slot until upstream lifts that restriction.
+hf-repo = unsloth/Qwen3.6-35B-A3B-MTP-GGUF
+hf-file = Qwen3.6-35B-A3B-UD-Q3_K_XL.gguf
 n-gpu-layers = 99
 fit = off # auto-fit hangs on this model (MTP ctx + q8 KV); pin ngl/ctx instead
-no-mmap = true # mmap re-faults the 18Gi weights from the cache PVC (130s+ cold load)
+no-mmap = true # mmap re-faults the 16Gi weights from the cache PVC (130s+ cold load)
 flash-attn = on
-; mmproj-BF16 (~889 MiB) defaults to GPU alongside the 27B stack, eating VRAM + encode compute
+; mmproj-BF16 (~889 MiB) defaults to GPU alongside the 35B stack, eating VRAM + encode compute
 ; buffers (~1–5 GiB per image). CPU offload keeps vision available but frees GPU headroom for
 ; chat KV + qwen3-embedding co-residency; image prefill is slower (acceptable — rare vs text).
 no-mmproj-offload = true
@@ -50,8 +49,8 @@ ctx-size = 262144
 # the q4 error. If quality regresses, revert to q8_0 and trim ctx-size instead (lossless).
 cache-type-k = q4_0
 cache-type-v = q4_0
-spec-type = draft-mtp # MTP self-speculative decoding, ~1.6x single-stream
-spec-draft-n-max = 4 # 2026-06-15 sweep: +15% single-stream vs n3, best 2-conc retention
+spec-type = draft-mtp # MTP self-speculative decoding
+spec-draft-n-max = 2 # 2026-06-18 initial deploy: Unsloth's MoE recommendation; re-sweep 1–3
 ; Host-RAM prompt cache for agentic prefix reuse (~7.5x warm TTFT). Sized to fit inside the
 ; 28Gi pod limit alongside no-mmap load buffers and the embedding preset — do not raise without
 ; bumping helmrelease memory limits (8192 MiB here + ~8Gi other host RAM ≈ needs >16Gi limit).

--- a/kubernetes/apps/ai/llama-server/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/llama-server/app/helmrelease.yaml
@@ -60,7 +60,7 @@ spec:
               - --port
               - "8080"
               # Router mode: per-model serving lives in /app/models.ini (mounted below).
-              # --models-max 2 keeps both presets (27B chat + 0.6B embedding) resident.
+              # --models-max 2 keeps both presets (35B-A3B MoE chat + 0.6B embedding) resident.
               - --models-preset
               - /app/models.ini
               - --models-max
@@ -79,7 +79,7 @@ spec:
                   periodSeconds: 10
                   timeoutSeconds: 5
                   # Router /health is up at process start (models load lazily) — cover start only.
-                  # 30×10s + 10s = ~310s budget: comfortably clears the 130s+ cold load of the 18Gi
+                  # 30×10s + 10s = ~310s budget: comfortably clears the 130s+ cold load of the 16Gi
                   # weights (no-mmap read from the hostpath PVC) so a slow load never CrashLoops.
                   failureThreshold: 30
               liveness:


### PR DESCRIPTION
## Summary
- switch llama-server chat preset from Qwen3.6-27B MTP to Qwen3.6-35B-A3B MoE MTP
- use UD-Q3_K_XL with q4_0 KV and MTP draft depth 2
- keep llama.cpp MTP at parallel=1 because Unsloth documents -np > 1 as unsupported with MTP
- update llama-cpp ROCm README and comments for the 35B-A3B migration

## Validation
- git diff --check
- bash .agents/skills/pr-review/scripts/validate-pr.sh (warnings only; kustomize/shellcheck unavailable in shell)

## Review notes
- Reviewed by oracle subagent; addressed blocking MTP + parallel>1 finding before commit.
