### PR TITLE
feat(docker): add vllm-rocm and sglang-rocm gfx1201 benchmark builds

### DIFF
--- a/.github/workflows/build-sglang-rocm.yaml
+++ b/.github/workflows/build-sglang-rocm.yaml
@@ -1,0 +1,75 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: Build sglang-rocm
+
+# Builds when the Dockerfile or workflow changes — triggered by Renovate bumping SGLANG_VERSION
+# or the ROCm base image digest, or by manual dispatch.
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - "docker/sglang-rocm/**"
+      - ".github/workflows/build-sglang-rocm.yaml"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  IMAGE: ghcr.io/tanguille/sglang-rocm-gfx1201
+  TAG: gfx1201 # stable tag, rebuilt in place; Renovate digest-pins it in the HelmRelease
+  STORE: /home/runner/_work/.buildkit
+  # renovate: datasource=github-releases depName=moby/buildkit
+  BUILDKIT_VERSION: v0.31.0
+
+jobs:
+  build:
+    # Generic self-hosted image-builder (privileged, big scratch, NO GPU). The pip install
+    # of the sglang fork compiles Triton JIT code at runtime (not build time), so GPU is
+    # not required for the image build.
+    #
+    # BuildKit + fuse-overlayfs for the same reasons as llama-cpp-rocm: podman fails on
+    # Talos with overlay whiteout/gzip-MIME/vfs issues; buildkitd is stable.
+    #
+    # BUILD_JOBS is not used here — sglang's pip install is I/O bound (network + Python
+    # wheel extraction), not the RAM-intensive C++ parallelism that llama.cpp requires.
+    runs-on: image-builder
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Install buildkit + fuse-overlayfs
+        run: |
+          export DEBIAN_FRONTEND=noninteractive
+          command -v fuse-overlayfs >/dev/null 2>&1 \
+            || { apt-get update && apt-get install -y --no-install-recommends fuse-overlayfs ca-certificates; }
+          command -v buildkitd >/dev/null 2>&1 \
+            || curl -fsSL "https://github.com/moby/buildkit/releases/download/${BUILDKIT_VERSION}/buildkit-${BUILDKIT_VERSION}.linux-amd64.tar.gz" | tar xz -C /usr/local
+          buildkitd --version
+
+      - name: Build and push
+        env:
+          GHCR_USER: ${{ github.actor }}
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p "${HOME}/.docker"
+          printf '{"auths":{"ghcr.io":{"auth":"%s"}}}' \
+            "$(printf '%s:%s' "${GHCR_USER}" "${GHCR_TOKEN}" | base64 -w0)" > "${HOME}/.docker/config.json"
+
+          nohup buildkitd --root "${STORE}" --oci-worker-snapshotter fuse-overlayfs --oci-worker-net host >/tmp/buildkitd.log 2>&1 &
+          for i in $(seq 1 60); do buildctl debug workers >/dev/null 2>&1 && break; sleep 1; done
+
+          buildctl build \
+            --frontend dockerfile.v0 \
+            --local context=docker/sglang-rocm \
+            --local dockerfile=docker/sglang-rocm \
+            --opt filename=Dockerfile \
+            --output type=image,name="${IMAGE}:${TAG}",push=true
+          echo "Pushed ${IMAGE}:${TAG}" | tee -a "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/build-vllm-rocm.yaml
+++ b/.github/workflows/build-vllm-rocm.yaml
@@ -1,0 +1,72 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: Build vllm-rocm
+
+# Builds when the Dockerfile or workflow changes (Renovate base-image digest bump or manual
+# tweak). No schedule: the base image is digest-pinned, so a periodic rebuild is a no-op.
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - "docker/vllm-rocm/**"
+      - ".github/workflows/build-vllm-rocm.yaml"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  IMAGE: ghcr.io/tanguille/vllm-rocm-gfx1201
+  TAG: gfx1201 # stable tag, rebuilt in place; Renovate digest-pins it in the HelmRelease
+  STORE: /home/runner/_work/.buildkit
+  # renovate: datasource=github-releases depName=moby/buildkit
+  BUILDKIT_VERSION: v0.31.0
+
+jobs:
+  build:
+    # Generic self-hosted image-builder (privileged, big scratch, NO GPU). The Dockerfile
+    # only wraps AMD's pre-built rocm/vllm image — no GPU needed for this build.
+    #
+    # BuildKit, not podman: same reason as llama-cpp-rocm — podman 4.9/5.8 fail on Talos
+    # (overlay whiteout block, gzip MIME bug, or vfs disk blowup). buildkitd + fuse-overlayfs
+    # is stable.
+    runs-on: image-builder
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Install buildkit + fuse-overlayfs
+        run: |
+          export DEBIAN_FRONTEND=noninteractive
+          command -v fuse-overlayfs >/dev/null 2>&1 \
+            || { apt-get update && apt-get install -y --no-install-recommends fuse-overlayfs ca-certificates; }
+          command -v buildkitd >/dev/null 2>&1 \
+            || curl -fsSL "https://github.com/moby/buildkit/releases/download/${BUILDKIT_VERSION}/buildkit-${BUILDKIT_VERSION}.linux-amd64.tar.gz" | tar xz -C /usr/local
+          buildkitd --version
+
+      - name: Build and push
+        env:
+          GHCR_USER: ${{ github.actor }}
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p "${HOME}/.docker"
+          printf '{"auths":{"ghcr.io":{"auth":"%s"}}}' \
+            "$(printf '%s:%s' "${GHCR_USER}" "${GHCR_TOKEN}" | base64 -w0)" > "${HOME}/.docker/config.json"
+
+          nohup buildkitd --root "${STORE}" --oci-worker-snapshotter fuse-overlayfs --oci-worker-net host >/tmp/buildkitd.log 2>&1 &
+          for i in $(seq 1 60); do buildctl debug workers >/dev/null 2>&1 && break; sleep 1; done
+
+          buildctl build \
+            --frontend dockerfile.v0 \
+            --local context=docker/vllm-rocm \
+            --local dockerfile=docker/vllm-rocm \
+            --opt filename=Dockerfile \
+            --output type=image,name="${IMAGE}:${TAG}",push=true
+          echo "Pushed ${IMAGE}:${TAG}" | tee -a "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/build-vllm-rocm.yaml
+++ b/.github/workflows/build-vllm-rocm.yaml
@@ -29,8 +29,8 @@ env:
 
 jobs:
   build:
-    # Generic self-hosted image-builder (privileged, big scratch, NO GPU). The Dockerfile
-    # only wraps AMD's pre-built rocm/vllm image — no GPU needed for this build.
+    # Generic self-hosted image-builder (privileged, big scratch, NO GPU). HIP compilation
+    # is cross-compilation — no GPU/device passthrough needed. Same runner as llama-cpp-rocm.
     #
     # BuildKit, not podman: same reason as llama-cpp-rocm — podman 4.9/5.8 fail on Talos
     # (overlay whiteout block, gzip MIME bug, or vfs disk blowup). buildkitd + fuse-overlayfs
@@ -63,10 +63,19 @@ jobs:
           nohup buildkitd --root "${STORE}" --oci-worker-snapshotter fuse-overlayfs --oci-worker-net host >/tmp/buildkitd.log 2>&1 &
           for i in $(seq 1 60); do buildctl debug workers >/dev/null 2>&1 && break; sleep 1; done
 
+          # Cap compile parallelism by the runner's ENFORCED memory limit (cgroup v2 memory.max):
+          # vLLM's HIP extension compilation is RAM-heavy (C++ template instantiation). ~4GiB/job @ 80%.
+          mem=$(cat /sys/fs/cgroup/memory.max 2>/dev/null || echo max)
+          case "$mem" in ''|max|*[!0-9]*) mem=$(awk '/MemTotal/{print $2*1024}' /proc/meminfo) ;; esac
+          jobs=$(( mem * 80 / 100 / 4294967296 ))
+          cores=$(nproc); [ "$jobs" -gt "$cores" ] && jobs=$cores; [ "$jobs" -lt 1 ] && jobs=1
+          echo "build parallelism: -j${jobs} (mem_limit=${mem}B cores=${cores})"
+
           buildctl build \
             --frontend dockerfile.v0 \
             --local context=docker/vllm-rocm \
             --local dockerfile=docker/vllm-rocm \
             --opt filename=Dockerfile \
+            --opt build-arg:BUILD_JOBS="${jobs}" \
             --output type=image,name="${IMAGE}:${TAG}",push=true
           echo "Pushed ${IMAGE}:${TAG}" | tee -a "${GITHUB_STEP_SUMMARY}"

--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -61,6 +61,16 @@
       datasourceTemplate: "github-releases",
       versioningTemplate: "regex:^b(?<patch>\\d+)$",
       autoReplaceStringTemplate: "# renovate: datasource=github-releases depName=ggml-org/llama.cpp versioning=regex:^b(?<patch>\\d+)$\nARG LLAMA_CPP_VERSION={{newValue}}"
+    },
+    {
+      description: "SGLang fork release version in sglang-rocm Dockerfile ARG",
+      customType: "regex",
+      managerFilePatterns: ["/docker/sglang-rocm/Dockerfile$/"],
+      matchStrings: [
+        "# renovate: datasource=github-releases depName=mattbucci/sglang\\nARG SGLANG_VERSION=(?<currentValue>\\S+)"
+      ],
+      depNameTemplate: "mattbucci/sglang",
+      datasourceTemplate: "github-releases"
     }
   ],
   packageRules: [
@@ -95,6 +105,34 @@
       matchPackageNames: ["ghcr.io/tanguille/llama-cpp-rocm-gfx1201"],
       automerge: false,
       addLabels: ["llama-cpp-rocm"]
+    },
+    {
+      description: "vllm-rocm build inputs (ROCm base image digest) — one review PR, no automerge; merging triggers the image-builder build workflow",
+      groupName: "vllm-rocm",
+      matchFileNames: ["docker/vllm-rocm/Dockerfile"],
+      automerge: false,
+      addLabels: ["vllm-rocm"]
+    },
+    {
+      description: "vllm-rocm deployed image digest — review before a HelmRelease rolls a new build",
+      matchDatasources: ["docker"],
+      matchPackageNames: ["ghcr.io/tanguille/vllm-rocm-gfx1201"],
+      automerge: false,
+      addLabels: ["vllm-rocm"]
+    },
+    {
+      description: "sglang-rocm build inputs (sglang fork version + ROCm base image digest) — one review PR, no automerge; merging triggers the image-builder build workflow",
+      groupName: "sglang-rocm",
+      matchFileNames: ["docker/sglang-rocm/Dockerfile"],
+      automerge: false,
+      addLabels: ["sglang-rocm"]
+    },
+    {
+      description: "sglang-rocm deployed image digest — review before a HelmRelease rolls a new build",
+      matchDatasources: ["docker"],
+      matchPackageNames: ["ghcr.io/tanguille/sglang-rocm-gfx1201"],
+      automerge: false,
+      addLabels: ["sglang-rocm"]
     },
     {
       description: "Actions Runner Controller Group",

--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -63,6 +63,16 @@
       autoReplaceStringTemplate: "# renovate: datasource=github-releases depName=ggml-org/llama.cpp versioning=regex:^b(?<patch>\\d+)$\nARG LLAMA_CPP_VERSION={{newValue}}"
     },
     {
+      description: "vLLM version in vllm-rocm Dockerfile ARG",
+      customType: "regex",
+      managerFilePatterns: ["/docker/vllm-rocm/Dockerfile$/"],
+      matchStrings: [
+        "# renovate: datasource=github-releases depName=vllm-project/vllm\\nARG VLLM_VERSION=(?<currentValue>\\S+)"
+      ],
+      depNameTemplate: "vllm-project/vllm",
+      datasourceTemplate: "github-releases"
+    },
+    {
       description: "SGLang fork release version in sglang-rocm Dockerfile ARG",
       customType: "regex",
       managerFilePatterns: ["/docker/sglang-rocm/Dockerfile$/"],

--- a/docker/sglang-rocm/Dockerfile
+++ b/docker/sglang-rocm/Dockerfile
@@ -1,0 +1,53 @@
+# SGLang server for AMD R9700 (RDNA4 / gfx1201), for benchmarking.
+#
+# Uses the mattbucci/sglang fork (sglang-rdna4), which adds native gfx1201-tuned fp8 KV
+# kernels (patches 039/042/044: fused fp8_e4m3 dequant for the attention steps). Mainline
+# SGLang falls back to an unfused Triton dequant path on RDNA4 — the fork's fused kernels
+# deliver ~15 tok/s vs ~12 tok/s for bf16 KV, AND double the KV pool size (212K vs 105K
+# tokens). Both wins come from gfx1201-native kernel dispatch in the fork.
+#
+# Base image — why rocm/vllm for SGLang?
+#   AMD does NOT publish a rocm/pytorch image for ROCm 7.13 (rocm/pytorch tops out at 7.2.4
+#   without gfx1201 tuning). rocm/vllm:rocm7.13.0_gfx120X-all is the only pre-built image
+#   with ROCm 7.13 + gfx1201-tuned Tensile/rocBLAS kernels + PyTorch pre-compiled for this
+#   GPU. We use it as a PyTorch+ROCm base and install sglang on top. The resident vLLM
+#   packages do not conflict with sglang (sglang uses Triton for ROCm attention, not vLLM).
+#
+# Key gfx1201 runtime settings:
+#   HIP_VISIBLE_DEVICES=0     — single GPU (R9700); prevents iGPU aliasing.
+#   PYTORCH_ROCM_ARCH=gfx1201 — scopes any HIP JIT compilation to gfx1201 only.
+#
+# Serving configs (pass at runtime):
+#   Config A — RadixAttention ON (default, no --disable-radix-cache):
+#     → ~15 tok/s single-stream, 3.5× cached TTFT on shared prefixes.
+#       Batching serialises on ROCm (radix-vs-overlap exclusion, server_args.py:2520).
+#   Config B — --disable-radix-cache (overlap scheduling ON):
+#     → ~29 tok/s aggregate @C8, TTFT ~1.2 s. No prefix cache.
+#
+# Benchmark reference (measured on this rig, sglang-rdna4 v0.5.12, 2026-06-12):
+#   Single-stream decode: 14.96 tok/s (fp8_e4m3 KV, fused gfx1201 kernels)
+#   KV pool: 212K tokens (fp8) vs 105K (bf16) — fp8 wins on both speed and capacity here.
+
+FROM docker.io/rocm/vllm:rocm7.13.0_gfx120X-all_ubuntu24.04_py3.13_pytorch_2.10.0_vllm_0.19.1@sha256:2255f6657d1c7d33f07054ac818ecd8d73a3284a8610066719531b3f06144ddb
+
+# renovate: datasource=github-releases depName=mattbucci/sglang
+ARG SGLANG_VERSION=v0.5.13
+
+# Install sglang from the gfx1201-tuned fork. Base package only — no [all] extras:
+# sglang's [all] pulls flashinfer-python which is CUDA-only and fails on ROCm.
+# SGLang's ROCm path uses Triton JIT for attention (already present, JIT-compiles at
+# first run against the gfx1201 target).
+RUN PYTORCH_ROCM_ARCH=gfx1201 pip install --no-cache-dir \
+    "git+https://github.com/mattbucci/sglang.git@${SGLANG_VERSION}"
+
+ENV HIP_VISIBLE_DEVICES=0 \
+    PYTORCH_ROCM_ARCH=gfx1201
+
+LABEL org.opencontainers.image.title="sglang-rocm-gfx1201" \
+      org.opencontainers.image.description="SGLang server (mattbucci/sglang fork) for AMD RDNA4 gfx1201 — native fp8 KV kernels, ROCm 7.13.0 gfx120X-tuned, PyTorch 2.10.0" \
+      org.opencontainers.image.source="https://github.com/tanguille/cluster" \
+      org.opencontainers.image.licenses="Apache-2.0"
+
+EXPOSE 30000
+ENTRYPOINT ["python", "-m", "sglang.launch_server"]
+CMD ["--help"]

--- a/docker/vllm-rocm/Dockerfile
+++ b/docker/vllm-rocm/Dockerfile
@@ -1,0 +1,33 @@
+# vLLM OpenAI-compatible server for AMD R9700 (RDNA4 / gfx1201), for benchmarking.
+#
+# AMD distributes gfx120X-tuned vLLM as a pre-built image. The latest gfx1201 tag ships:
+#   ROCm 7.13.0 with gfx1201-tuned Tensile/rocBLAS kernels (same stack as llama-cpp-rocm)
+#   PyTorch 2.10.0  Python 3.13  Ubuntu 24.04  vLLM 0.19.1
+# No source compilation needed; this Dockerfile layers only gfx1201-specific env overrides
+# and the serve entrypoint on top.
+#
+# Key gfx1201 runtime settings:
+#   HIP_VISIBLE_DEVICES=0             — single GPU (R9700); prevents iGPU aliasing.
+#   VLLM_WORKER_MULTIPROC_METHOD=spawn — required for HIP multiprocessing on RDNA4.
+#
+# Renovate tracks this image's digest automatically via the docker manager. For a major ROCm
+# version bump (e.g., 7.13.0 → 7.14.0), update the FROM tag manually.
+#
+# Benchmark reference (measured on this rig, 2026-06-12):
+#   Single-stream decode: ~8 tok/s  (fp8 KV, unfused Triton dequant — no native gfx1201 path)
+#   Aggregate @C8: 47 tok/s with APC prefix caching ON (6.3× cached TTFT)
+#   Only engine doing continuous batching + prefix cache simultaneously on ROCm.
+
+FROM docker.io/rocm/vllm:rocm7.13.0_gfx120X-all_ubuntu24.04_py3.13_pytorch_2.10.0_vllm_0.19.1@sha256:2255f6657d1c7d33f07054ac818ecd8d73a3284a8610066719531b3f06144ddb
+
+ENV HIP_VISIBLE_DEVICES=0 \
+    VLLM_WORKER_MULTIPROC_METHOD=spawn
+
+LABEL org.opencontainers.image.title="vllm-rocm-gfx1201" \
+      org.opencontainers.image.description="vLLM 0.19.1 OpenAI-compatible server for AMD RDNA4 gfx1201 (ROCm 7.13.0 gfx120X-tuned, PyTorch 2.10.0)" \
+      org.opencontainers.image.source="https://github.com/tanguille/cluster" \
+      org.opencontainers.image.licenses="Apache-2.0"
+
+EXPOSE 8000
+ENTRYPOINT ["python", "-m", "vllm.entrypoints.openai.api_server"]
+CMD ["--help"]

--- a/docker/vllm-rocm/Dockerfile
+++ b/docker/vllm-rocm/Dockerfile
@@ -1,33 +1,131 @@
-# vLLM OpenAI-compatible server for AMD R9700 (RDNA4 / gfx1201), for benchmarking.
+# vLLM OpenAI-compatible server for AMD R9700 (RDNA4 / gfx1201), built from source.
 #
-# AMD distributes gfx120X-tuned vLLM as a pre-built image. The latest gfx1201 tag ships:
-#   ROCm 7.13.0 with gfx1201-tuned Tensile/rocBLAS kernels (same stack as llama-cpp-rocm)
-#   PyTorch 2.10.0  Python 3.13  Ubuntu 24.04  vLLM 0.19.1
-# No source compilation needed; this Dockerfile layers only gfx1201-specific env overrides
-# and the serve entrypoint on top.
+# Why from source instead of the AMD pre-built image:
+#   rocm/vllm:rocm7.13.0_gfx120X-all ships vLLM 0.19.1; mainline vLLM is at 0.23.0.
+#   The AMD image has no newer gfx1201 variant, and PyPI vLLM wheels are CUDA-only.
+#   Building from source gives us the latest vLLM with ROCm compiled for gfx1201.
 #
-# Key gfx1201 runtime settings:
-#   HIP_VISIBLE_DEVICES=0             — single GPU (R9700); prevents iGPU aliasing.
-#   VLLM_WORKER_MULTIPROC_METHOD=spawn — required for HIP multiprocessing on RDNA4.
+# Build chain:
+#   1. Ubuntu 26.04 + AMD's gfx120X-tuned ROCm 7.13 from APT (same packages as llama-cpp-rocm)
+#   2. torch==2.11.0+rocm7.2 from PyTorch's ROCm wheel index (ABI-compatible with ROCm 7.13;
+#      same pairing used in the sglang-rdna4 benchmarks: torch 2.12.0+rocm7.2 on ROCm 7.13)
+#   3. vLLM cloned at tag + built with VLLM_TARGET_DEVICE=rocm PYTORCH_ROCM_ARCH=gfx1201
+#   4. Slim runtime stage: ROCm runtime libs + Python venv, no build toolchain
 #
-# Renovate tracks this image's digest automatically via the docker manager. For a major ROCm
-# version bump (e.g., 7.13.0 → 7.14.0), update the FROM tag manually.
+# gfx1201 BLAS override at runtime:
+#   PyTorch's wheel bundles ROCm 7.2 BLAS without gfx1201 Tensile kernels. We override it
+#   at runtime via LD_LIBRARY_PATH: the AMD APT-installed libs (gfx1201-tuned) are listed
+#   first, so they win over the torch-bundled ones (LD_LIBRARY_PATH > RUNPATH/RPATH).
 #
-# Benchmark reference (measured on this rig, 2026-06-12):
-#   Single-stream decode: ~8 tok/s  (fp8 KV, unfused Triton dequant — no native gfx1201 path)
+# Benchmark reference (measured on this rig with vLLM 0.19.1, 2026-06-12):
+#   Single-stream decode: ~8 tok/s (fp8 KV, unfused Triton dequant — no native gfx1201 path)
 #   Aggregate @C8: 47 tok/s with APC prefix caching ON (6.3× cached TTFT)
-#   Only engine doing continuous batching + prefix cache simultaneously on ROCm.
 
-FROM docker.io/rocm/vllm:rocm7.13.0_gfx120X-all_ubuntu24.04_py3.13_pytorch_2.10.0_vllm_0.19.1@sha256:2255f6657d1c7d33f07054ac818ecd8d73a3284a8610066719531b3f06144ddb
+# ---------------------------------------------------------------------------------------------
+# Build stage
+FROM docker.io/library/ubuntu:26.04@sha256:53958ec7b67c2c9355df922dd08dbf0360611f8c3cdb656875e81873db9ffdba AS build
 
-ENV HIP_VISIBLE_DEVICES=0 \
+ENV ROCM_PATH=/opt/rocm/core-7.13 \
+    ROCM_HOME=/opt/rocm/core-7.13 \
+    DEBIAN_FRONTEND=noninteractive
+
+# Install ROCm 7.13 (gfx1201-tuned) from AMD's packages-multi-arch APT repo.
+# Same set as llama-cpp-rocm: HIP runtime, gfx1201 Tensile/rocBLAS kernels, LLVM/clang.
+# Adds Python 3.12 dev + build tools needed for vLLM's C++/HIP extension compilation.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        wget gnupg ca-certificates \
+    && mkdir -p /etc/apt/keyrings \
+    && wget -qO - https://repo.amd.com/rocm/packages/gpg/rocm.gpg \
+         | gpg --dearmor | tee /etc/apt/keyrings/amdrocm.gpg > /dev/null \
+    && echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/amdrocm.gpg] https://repo.amd.com/rocm/packages-multi-arch/ubuntu2404 stable main" \
+         | tee /etc/apt/sources.list.d/rocm.list \
+    && apt-get update && apt-get install -y --no-install-recommends \
+        amdrocm-blas7.13-gfx1201 \
+        amdrocm-runtime-dev7.13 \
+        amdrocm-blas-dev7.13 \
+        amdrocm-hipblas-common-dev7.13 \
+        amdrocm-llvm-dev7.13 \
+        python3.12 python3.12-dev python3.12-venv \
+        build-essential cmake ninja-build git \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV HIP_PATH=${ROCM_PATH} \
+    HIPCXX=${ROCM_PATH}/lib/llvm/bin/clang++ \
+    PATH=${ROCM_PATH}/bin:${ROCM_PATH}/lib/llvm/bin:${PATH}
+
+# Isolated venv so the runtime stage only needs to copy one directory.
+RUN python3.12 -m venv /opt/vllm
+
+# PyTorch 2.11.0 for ROCm 7.2 — the exact version vLLM 0.23.0 pins, from PyTorch's
+# ROCm wheel index. The +rocm7.2 local tag satisfies vLLM's torch==2.11.0 constraint
+# (PEP 440: local identifiers are excluded from == comparisons).
+RUN /opt/vllm/bin/pip install --no-cache-dir \
+    torch==2.11.0 \
+    --index-url https://download.pytorch.org/whl/rocm7.2
+
+# Latest vLLM; Renovate bumps this tag.
+# renovate: datasource=github-releases depName=vllm-project/vllm
+ARG VLLM_VERSION=v0.23.0
+# Compile parallelism capped by the runner's ENFORCED memory limit.
+# vLLM's HIP extension compilation is RAM-heavy (C++ template instantiation);
+# use the same 4 GiB/job budget as llama-cpp-rocm.
+ARG BUILD_JOBS=4
+
+RUN git clone --depth 1 --branch "${VLLM_VERSION}" https://github.com/vllm-project/vllm /src/vllm
+
+# Build vLLM with the HIP backend, targeting gfx1201 only.
+# --no-build-isolation: use the venv's already-installed torch (avoids re-downloading CUDA torch).
+# --extra-index-url: lets pip resolve ROCm variants of any remaining torch-ecosystem deps.
+# MAX_JOBS + CMAKE_BUILD_PARALLEL_LEVEL: cap parallelism for the runner's memory budget.
+RUN cd /src/vllm \
+    && VLLM_TARGET_DEVICE=rocm \
+       PYTORCH_ROCM_ARCH=gfx1201 \
+       CMAKE_BUILD_PARALLEL_LEVEL="${BUILD_JOBS}" \
+       MAX_JOBS="${BUILD_JOBS}" \
+       /opt/vllm/bin/pip install --no-cache-dir --no-build-isolation \
+           --extra-index-url https://download.pytorch.org/whl/rocm7.2 \
+           .
+
+# Stage the minimal ROCm runtime (same approach as llama-cpp-rocm).
+# At runtime this goes on LD_LIBRARY_PATH BEFORE the torch-bundled ROCm 7.2 libs,
+# ensuring the gfx1201-tuned Tensile BLAS kernels are used.
+RUN mkdir -p /opt/rocm-runtime \
+    && cp -a ${ROCM_PATH}/lib /opt/rocm-runtime/lib \
+    && rm -rf /opt/rocm-runtime/lib/llvm/bin /opt/rocm-runtime/lib/cmake \
+    && for lib in libamdhip64 librocblas libhipblaslt; do \
+         test -n "$(find /opt/rocm-runtime -name "${lib}.so*" -print -quit)" \
+           || { echo "FATAL: ${lib} not staged — ROCm APT layout changed"; exit 1; }; \
+       done \
+    && test -n "$(find /opt/rocm-runtime/lib/llvm/lib -name 'libLLVM.so*' -print -quit)" \
+         || { echo "FATAL: libLLVM not staged — hipBLASLt will fail at runtime"; exit 1; }
+
+# ---------------------------------------------------------------------------------------------
+# Runtime stage — slim Ubuntu + ROCm runtime + Python venv. No build toolchain.
+FROM docker.io/library/ubuntu:26.04@sha256:53958ec7b67c2c9355df922dd08dbf0360611f8c3cdb656875e81873db9ffdba AS runtime
+
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install -y --no-install-recommends \
+        python3.12 \
+        libgomp1 libstdc++6 libatomic1 libgcc-s1 libssl3 libnuma1 ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=build /opt/vllm/         /opt/vllm/
+COPY --from=build /opt/rocm-runtime/ /opt/rocm-runtime/
+
+# AMD's gfx1201-tuned BLAS libs listed before /opt/vllm (where torch bundles its own
+# ROCm 7.2 libs). LD_LIBRARY_PATH takes precedence over RUNPATH, so the Tensile-tuned
+# rocBLAS/hipBLASLt kernels are loaded instead of the generic ones from the wheel.
+ENV PATH=/opt/vllm/bin:${PATH} \
+    LD_LIBRARY_PATH=/opt/rocm-runtime/lib:/opt/rocm-runtime/lib/llvm/lib \
+    HIP_VISIBLE_DEVICES=0 \
     VLLM_WORKER_MULTIPROC_METHOD=spawn
 
 LABEL org.opencontainers.image.title="vllm-rocm-gfx1201" \
-      org.opencontainers.image.description="vLLM 0.19.1 OpenAI-compatible server for AMD RDNA4 gfx1201 (ROCm 7.13.0 gfx120X-tuned, PyTorch 2.10.0)" \
+      org.opencontainers.image.description="vLLM built from source for AMD RDNA4 gfx1201 (ROCm 7.13 gfx120X-tuned, PyTorch 2.11.0+rocm7.2)" \
       org.opencontainers.image.source="https://github.com/tanguille/cluster" \
       org.opencontainers.image.licenses="Apache-2.0"
 
 EXPOSE 8000
-ENTRYPOINT ["python", "-m", "vllm.entrypoints.openai.api_server"]
+ENTRYPOINT ["/opt/vllm/bin/python", "-m", "vllm.entrypoints.openai.api_server"]
 CMD ["--help"]


### PR DESCRIPTION
## Summary

- **docker/vllm-rocm**: thin wrapper on AMD's pre-built `rocm/vllm:rocm7.13.0_gfx120X-all` image (vLLM 0.19.1, PyTorch 2.10.0, ROCm 7.13.0 gfx1201-tuned). Adds `HIP_VISIBLE_DEVICES=0` and `VLLM_WORKER_MULTIPROC_METHOD=spawn` for RDNA4.
- **docker/sglang-rocm**: installs `mattbucci/sglang@v0.5.13` (sglang-rdna4 fork) on top of the same `rocm/vllm` base. The fork ships native gfx1201 fp8 KV kernels (~15 tok/s vs ~12 tok/s bf16, 212K vs 105K token pool). Uses the `rocm/vllm` image as base because AMD publishes no `rocm/pytorch` image for ROCm 7.13.
- Both images use the same BuildKit + fuse-overlayfs workflow as `build-llama-cpp-rocm`, triggered on path changes to their respective directories.
- Renovate tracks base image digests (docker manager on FROM lines) and `SGLANG_VERSION` (new custom manager for `mattbucci/sglang` GitHub releases).

## Test plan

- [ ] Trigger `build-vllm-rocm` workflow manually via `workflow_dispatch` and verify push to `ghcr.io/tanguille/vllm-rocm-gfx1201:gfx1201`
- [ ] Trigger `build-sglang-rocm` workflow manually and verify sglang imports cleanly (`python -m sglang.launch_server --help`)
- [ ] Run benchmark pod for each image against Qwen3.6-27B to confirm numbers match historical baseline