### PR TITLE
fix(docker): switch vllm-rocm to Ubuntu 26.04 + Python 3.13; fix build deps

### DIFF
--- a/docker/vllm-rocm/Dockerfile
+++ b/docker/vllm-rocm/Dockerfile
@@ -5,13 +5,14 @@
 #   The AMD image has no newer gfx1201 variant, and PyPI vLLM wheels are CUDA-only.
 #   Building from source gives us the latest vLLM with ROCm compiled for gfx1201.
 #
-# Why Ubuntu 24.04 (not 26.04 like llama-cpp-rocm):
-#   AMD's packages-multi-arch APT repo targets ubuntu2404 and only contains ROCm packages.
-#   Ubuntu 26.04 ships Python 3.13+, so python3.12 is unavailable there without a third-party
-#   source. Ubuntu 24.04 has python3.12 natively and matches AMD's build targets.
+# Ubuntu 26.04 + Python 3.13:
+#   AMD's packages-multi-arch APT repo is published under "ubuntu2404" but contains only
+#   C libraries (ROCm runtime, BLAS, LLVM) — no Python. These install fine on Ubuntu 26.04
+#   since they have no Ubuntu-version-specific Python deps. Ubuntu 26.04 ships Python 3.13
+#   natively, and torch==2.11.0+rocm7.2 is available as a cp313 wheel from PyTorch's index.
 #
 # Build chain:
-#   1. Ubuntu 24.04 + AMD's gfx120X-tuned ROCm 7.13 from APT (same packages as llama-cpp-rocm)
+#   1. Ubuntu 26.04 + AMD's gfx120X-tuned ROCm 7.13 from APT (same packages as llama-cpp-rocm)
 #   2. torch==2.11.0+rocm7.2 from PyTorch's ROCm wheel index (ABI-compatible with ROCm 7.13;
 #      same pairing used in the sglang-rdna4 benchmarks: torch 2.12.0+rocm7.2 on ROCm 7.13)
 #   3. vLLM cloned at tag + built with VLLM_TARGET_DEVICE=rocm PYTORCH_ROCM_ARCH=gfx1201
@@ -28,7 +29,7 @@
 
 # ---------------------------------------------------------------------------------------------
 # Build stage
-FROM docker.io/library/ubuntu:24.04@sha256:023f8a753c22258c9fe2d0005a7d28258038da7d620e9f93e9ad78aa266f9f11 AS build
+FROM docker.io/library/ubuntu:26.04@sha256:6fee4abc5fe6a21f40022199b2d5063eb591743c80d3d2f5fadf620a98cbae0d AS build
 
 ENV ROCM_PATH=/opt/rocm/core-7.13 \
     ROCM_HOME=/opt/rocm/core-7.13 \
@@ -36,7 +37,7 @@ ENV ROCM_PATH=/opt/rocm/core-7.13 \
 
 # Install ROCm 7.13 (gfx1201-tuned) from AMD's packages-multi-arch APT repo.
 # Same set as llama-cpp-rocm: HIP runtime, gfx1201 Tensile/rocBLAS kernels, LLVM/clang.
-# Python 3.12 is native on Ubuntu 24.04; python3.12-venv provides the venv module.
+# Python 3.13 is native on Ubuntu 26.04; python3.13-venv provides the venv module.
 RUN apt-get update && apt-get install -y --no-install-recommends \
         wget gnupg ca-certificates \
     && mkdir -p /etc/apt/keyrings \
@@ -50,7 +51,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         amdrocm-blas-dev7.13 \
         amdrocm-hipblas-common-dev7.13 \
         amdrocm-llvm-dev7.13 \
-        python3.12 python3.12-dev python3.12-venv \
+        python3.13 python3.13-dev python3.13-venv \
         build-essential cmake ninja-build git \
     && rm -rf /var/lib/apt/lists/*
 
@@ -59,7 +60,12 @@ ENV HIP_PATH=${ROCM_PATH} \
     PATH=${ROCM_PATH}/bin:${ROCM_PATH}/lib/llvm/bin:${PATH}
 
 # Isolated venv so the runtime stage only needs to copy one directory.
-RUN python3.12 -m venv /opt/vllm
+RUN python3.13 -m venv /opt/vllm
+
+# Build-time base packages: packaging + setuptools are needed by vLLM's pyproject.toml
+# when building with --no-build-isolation (pip skips the isolated build env, so any
+# build-system requirement must already be in the venv).
+RUN /opt/vllm/bin/pip install --no-cache-dir packaging setuptools wheel numpy
 
 # PyTorch 2.11.0 for ROCm 7.2 — the exact version vLLM 0.23.0 pins, from PyTorch's
 # ROCm wheel index. The +rocm7.2 local tag satisfies vLLM's torch==2.11.0 constraint
@@ -106,25 +112,14 @@ RUN mkdir -p /opt/rocm-runtime \
          || { echo "FATAL: libLLVM not staged — hipBLASLt will fail at runtime"; exit 1; }
 
 # ---------------------------------------------------------------------------------------------
-# Runtime stage — slim Ubuntu 24.04 + ROCm runtime + Python venv. No build toolchain.
-FROM docker.io/library/ubuntu:24.04@sha256:023f8a753c22258c9fe2d0005a7d28258038da7d620e9f93e9ad78aa266f9f11 AS runtime
+# Runtime stage — slim Ubuntu 26.04 + ROCm runtime + Python venv. No build toolchain.
+FROM docker.io/library/ubuntu:26.04@sha256:6fee4abc5fe6a21f40022199b2d5063eb591743c80d3d2f5fadf620a98cbae0d AS runtime
 
-ENV DEBIAN_FRONTEND=noninteractive
-
-# Ubuntu 26.04 ships Python 3.13+; python3.12 is only in the AMD packages-multi-arch repo
-# (ubuntu2404-targeted). We add the same repo here — not for ROCm libs (those are COPY'd from
-# the build stage) but purely to install a python3.12 that matches the build-stage venv.
-RUN apt-get update && apt-get install -y --no-install-recommends \
-        wget gnupg ca-certificates \
-    && mkdir -p /etc/apt/keyrings \
-    && wget -qO - https://repo.amd.com/rocm/packages/gpg/rocm.gpg \
-         | gpg --dearmor | tee /etc/apt/keyrings/amdrocm.gpg > /dev/null \
-    && echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/amdrocm.gpg] https://repo.amd.com/rocm/packages-multi-arch/ubuntu2404 stable main" \
-         | tee /etc/apt/sources.list.d/rocm.list \
-    && apt-get update \
+RUN apt-get update \
     && apt-get upgrade -y \
     && apt-get install -y --no-install-recommends \
-        python3.12 libgomp1 libstdc++6 libatomic1 libgcc-s1 libssl3 libnuma1 \
+        python3.13 \
+        libgomp1 libstdc++6 libatomic1 libgcc-s1 libssl3 libnuma1 ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=build /opt/vllm/         /opt/vllm/


### PR DESCRIPTION
## Summary

- Bumps both Dockerfile stages to `ubuntu:26.04` (addresses Renovate PR #3390, supersedes it — close #3390)
- Switches `python3.12` → `python3.13` throughout; AMD ROCm packages are pure C libraries that install from the `ubuntu2404` repo regardless of Ubuntu version
- `torch==2.11.0+rocm7.2` ships `cp313` wheels so the venv build works unchanged
- Adds `packaging setuptools wheel numpy` before the vLLM from-source build to satisfy `--no-build-isolation`: pip skips the isolated build env, so pyproject.toml build-system deps must already be in the venv (previous failure: `ModuleNotFoundError: No module named 'packaging'`)

## Test plan

- [ ] CI build completes successfully (HIP compilation of vLLM extensions)
- [ ] Runtime stage starts `vllm serve --help` without import errors

Closes #3390