### PR TITLE
perf(vllm): increase max-num-seqs to 16, trim cuda graph capture sizes

### DIFF
--- a/kubernetes/apps/ai/vllm/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/vllm/app/helmrelease.yaml
@@ -101,8 +101,10 @@ spec:
             env:
               TZ: ${TIMEZONE}
               HF_HOME: /cache/hf # model weights on the cache PVC (~27 GB on first start)
-              # Triton JIT cache — persisted so restarts skip autotuning (~8-10 min saved).
+              # Triton JIT cache + vLLM AOT compile cache — persisted so restarts skip recompilation.
               TRITON_CACHE_DIR: /cache/triton
+              # AOT compiled functions default to /root/.cache (ephemeral); redirect to PVC.
+              VLLM_CACHE_ROOT: /cache/vllm
               HIP_VISIBLE_DEVICES: "0"
               PYTORCH_ROCM_ARCH: gfx1201
               # AITER ops hang on gfx1201 with this vLLM build.

--- a/kubernetes/apps/ai/vllm/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/vllm/app/helmrelease.yaml
@@ -74,7 +74,7 @@ spec:
               - --max-model-len
               - "234320"
               - --max-num-seqs
-              - "8"
+              - "16"
               # MTP caps this at 2048 by default (vLLM warns it's suboptimal); bump for draft-slot headroom.
               - --max-num-batched-tokens
               - "8192"
@@ -97,7 +97,7 @@ spec:
               # Persist AOT compile artifacts (~5 min/restart). Fused norm/quant passes (EXP-011)
               # shrink activation buffers ~0.5 GiB, which 234K ctx needs; not on by default.
               - --compilation-config
-              - '{"cache_dir": "/cache/compile", "custom_ops": ["none"], "pass_config": {"fuse_norm_quant": true, "fuse_act_quant": true}}'
+              - '{"cache_dir": "/cache/compile", "custom_ops": ["none"], "cudagraph_capture_sizes": [1, 2, 4, 8, 16, 32, 48, 64, 80], "pass_config": {"fuse_norm_quant": true, "fuse_act_quant": true}}'
             env:
               TZ: ${TIMEZONE}
               HF_HOME: /cache/hf # model weights on the cache PVC (~27 GB on first start)
@@ -160,7 +160,7 @@ spec:
         annotations:
           gethomepage.dev/enabled: "true"
           gethomepage.dev/name: vllm
-          gethomepage.dev/description: Qwen3.6-27B vLLM inference (kyuz0/ROCm, RDNA4, MTP×4, 234K ctx)
+          gethomepage.dev/description: Qwen3.6-27B vLLM inference (kyuz0/ROCm, RDNA4, MTP×4, 234K ctx, 16 seqs)
           gethomepage.dev/group: Models
           gethomepage.dev/icon: mdi-brain
         hostnames:


### PR DESCRIPTION
## Changes

- **`max_num_seqs 8→16`** — the KV pool (~284K token slots at fp8) is shared dynamically across all sequences. Long sessions use more of the pool; many short sessions share it efficiently. Preemption (request abort) only occurs if total active KV usage exceeds the pool simultaneously. With 34+ requests queuing under real traffic, this directly improves throughput.

- **`cudagraph_capture_sizes: [1,2,4,8,16,32,48,64,80]`** — 9 sizes instead of the default 13. With `spec_tokens=4` and `max_num_seqs=16`, the maximum tokens in a single forward pass is `16 × (4 draft + 1 verify) = 80`. Intermediate sizes 24/40/56/72 add compile/capture time without covering distinct shapes. Reduces cold start time.

## Verify

Benchmark PP+TG tok/s at C=1, C=8, C=16 after deploy to confirm throughput gain vs EXP-016b baseline (C=8 agg 126.1 tok/s).