### PR TITLE
perf(toolhive): scale embedding capacity to cut optimizer init latency

### DIFF
--- a/kubernetes/apps/ai/toolhive/config/embeddingserver.yaml
+++ b/kubernetes/apps/ai/toolhive/config/embeddingserver.yaml
@@ -5,8 +5,13 @@ metadata:
   name: toolhive-embeddings
   namespace: ai
 spec:
-  replicas: 1
-  # TEI's default --max-client-batch-size of 32 splits the unified vmcp's 187-tool embedding
+  # The vmcp optimizer re-embeds all ~194 tools on EVERY new client session (toolhive 0.30.0
+  # has no embed cache — UpsertTools does an unconditional INSERT OR REPLACE per session), so
+  # overlapping client sessions pile up on the embedder. The measured pain is queue_time, not
+  # inference (bge-small is ~tens of ms/query); 2 replicas behind the Service absorb the
+  # concurrency that previously drove per-session init to ~16s.
+  replicas: 2
+  # TEI's default --max-client-batch-size of 32 splits the unified vmcp's 194-tool embedding
   # upsert into 6 sequential round trips (~5-7s each = 32-38s total), exceeding vmcp's ~30s
   # response-write deadline — clients saw initialize hang forever. One big batch + more CPU
   # brings per-session indexing down to ~1-5s.
@@ -20,7 +25,9 @@ spec:
       cpu: 250m
       memory: 512Mi
     limits:
-      cpu: "4"
+      # 8 of the node's 12 cores: a single 194-tool upsert finishes faster, and concurrent
+      # sessions spread across the 2 replicas don't starve each other on CPU.
+      cpu: "8"
       memory: 2Gi
   modelCache:
     enabled: true

--- a/kubernetes/apps/ai/toolhive/config/virtualmcpservers.yaml
+++ b/kubernetes/apps/ai/toolhive/config/virtualmcpservers.yaml
@@ -145,7 +145,10 @@ metadata:
   name: unified
   namespace: ai
 spec:
-  replicas: 2
+  # Single replica on purpose: the optimizer's tool index is in-memory per-pod, so a session
+  # that lands on a second replica triggers a full re-embed (lazyInjectSessionTools). One
+  # replica eliminates that cross-pod double-embed. Trade-off: no HA on this gateway.
+  replicas: 1
   podTemplateSpec:
     spec:
       containers:


### PR DESCRIPTION
The vmcp optimizer re-embeds all ~194 tools on every new client session (toolhive 0.30.0 has no embed cache), and with 2 unified replicas a session that migrates across pods re-embeds again. Overlapping sessions queued on a single CPU-bound TEI, driving initialize to ~16s (dominated by queue_time, not inference).

- toolhive-embeddings: replicas 1->2, cpu limit 4->8 to absorb concurrency
- unified vmcp: replicas 2->1 to eliminate the cross-pod double-embed