### PR TITLE
feat(ai): enable SGLang prefix cache for Qwen3.6-27B (v0.5.13)

### DIFF
--- a/docs/sglang-blockers.md
+++ b/docs/sglang-blockers.md
@@ -2,7 +2,7 @@
 
 Tracking what needs to land upstream before SGLang can replace vLLM in production without depending on the mattbucci RDNA4 fork.
 
-**Current approach:** `mattbucci/2x-R9700-RDNA4-GFX1201-sglang-inference` fork (v0.5.12 + 37 patches).
+**Current approach:** `mattbucci/2x-R9700-RDNA4-GFX1201-sglang-inference` fork, **v0.5.13.post1 + 46 patches** (fork HEAD `1034fea`, 2026-06-24), built in place on the `sglang` PVC at `/cache/sglang` (the image is only the ROCm 7.2.4 runtime base). Rebuild recipe — including the RDNA4/TP=1 fixes the fork's `setup.sh` omits — is `docs/sglang-env-rebuild.sh`.
 See `docs/sglang-qwen3.6-rocm-plan.md` for the full build plan and decision record.
 
 ---
@@ -101,6 +101,55 @@ See `docs/sglang-qwen3.6-rocm-plan.md` for the full build plan and decision reco
 
 ---
 
+## Blocker 6 — Prefix cache vs batch on the DeltaNet hybrid (ROCm) — RESOLVED on v0.5.13 (now a tunable tradeoff)
+
+**Status: resolved by the v0.5.13.post1 rebuild.** v0.5.13 ships native **MambaRadixCache**
+(`hybrid_ssm=True`) — DeltaNet/SSM prefix caching on ROCm with **no** `extra_buffer` / FLA-NVIDIA
+gate. The ~124k-token Hermes loop now reuses its cached prefix instead of re-prefilling every turn:
+measured **7.6× TTFT** (cold ~16s → cache-hit ~2.1s; server log `#cached-token: 16384` of 18256),
+which is what stops it tripping `agent.gateway_timeout` / litellm aborts. The earlier StreamingSession
+mitigation is obsolete.
+
+**The cache-vs-batch question is now a config choice, not a blocker:**
+- **cache ON** (`no_buffer` + radix, **prod**): overlap scheduler off, but single-stream ~13.4 tok/s
+  (decode-steps 16) and batch ~34 @conc8 / ~63 @conc16, max_running 16. Chosen — the long-context
+  agent is the primary workload.
+- **cache OFF** (`--disable-radix-cache`): overlap on, batch ~99 @conc32, but every agent turn
+  re-prefills the full context (the original failure). A 97k cold prefill measured **303s** — the
+  cost the cache eliminates.
+- **`extra_buffer`** (overlap on *with* cache): boots on ROCm via a 1-line `is_hip()` patch to the
+  `server_args.py` device assert, but gives **no** batch gain (~35 @conc8) and *worse* single-stream
+  (~12) — RDNA4 dense-DeltaNet decode is compute-bound, so the overlap scheduler has nothing to hide
+  and it halves max_running (→9). Ruled out; we stay on `no_buffer`.
+
+**Required RDNA4/TP=1 patch (NOT in the fork — it targets a dual-card TP=2 box):** the JIT
+`store_cache` kernel aborts at TP=1 (`kvcache.cuh:204: CUDA error: the operation cannot be performed
+in the present state`). Force `can_use_store_cache()->False` (naive torch KV store). A stock
+`setup.sh` rebuild without this crashes on the first request — captured in `docs/sglang-env-rebuild.sh`.
+
+**VRAM ceiling (context vs batch, measured on the 32GB R9700):** weights (~16GB) + fp32 mamba state
+(**6.89GB** @ 48 slots = max_running 16) + KV pool + prefill headroom must fit in 31.9GB. Keeping the
+16 batch slots, the KV pool tops out at **126,854 tokens** @ `--mem-fraction 0.90` (Hermes's 124k just
+fits, 2.88GB prefill headroom; a real 97k prefill validated — correct recall, no OOM). mem 0.95 (179k
+pool) **OOMs** on a ~125k prefill (only 1.26GB activation headroom → CUDA OOM). Full native 262k for a
+single session isn't reachable without dropping batch slots or bf16 mamba state — and bf16 is risky
+(the model ships `mamba_ssm_dtype: float32` for long-context recurrent stability, and the bf16 path is
+NVIDIA-SM100 / FlashInfer-only).
+
+**Upstream references:**
+- SGLang cookbook (Qwen3.6) — extra_buffer "Requires FLA kernel backend (NVIDIA GPUs only)":
+  https://docs.sglang.io/cookbook/autoregressive/Qwen/Qwen3.6
+- HiCache-for-hybrid crash on Qwen3.5/3.6 (Open): https://github.com/sgl-project/sglang/issues/24121
+- Unified Hybrid Radix Cache Refactor roadmap (Open): https://github.com/sgl-project/sglang/issues/20415
+
+**When to revisit:** (1) When #24121 closes — v0.5.13 HiCache could offload mamba/KV state to host RAM
+and ease the cache/batch/context tensions together (enabling bigger batch *and* full context). (2) If a
+future fork rebase relaxes the `no_buffer`→overlap-off constraint, re-test overlap+cache. (3) Re-test
+`extra_buffer` only if a faster RDNA4 GDN decode kernel lands (today it's the scheduler, not the
+kernel, that makes overlap a no-op).
+
+---
+
 ## Summary table
 
 | # | Blocker | Severity | Workaround? | When to recheck |
@@ -110,5 +159,6 @@ See `docs/sglang-qwen3.6-rocm-plan.md` for the full build plan and decision reco
 | 3 | gptq_marlin_repack missing on ROCm | Medium | Yes (Triton AWQ) | N/A (accept Triton path) |
 | 4 | gfx1201 missing from sgl_kernel / AITER | Medium | Yes (mattbucci patches) | Discussion #12600 closed |
 | 5 | No official gfx1201 Docker image | Operational | Yes (custom Dockerfile) | RDNA4 in official ROCm matrix |
+| 6 | Prefix cache on DeltaNet hybrid (ROCm) | **Resolved** (v0.5.13) | MambaRadixCache (cache-on, batch 16/~63) + TP=1 store_cache patch | HiCache #24121 (cache+batch+full-context together) |
 
-**Bottom line:** The mattbucci fork resolves blockers 2–5 today. Blocker 1 (MTP) is the only hard performance gap vs vLLM. Once SGLang ROCm CI shows speculative decoding passing, retest with a single-card configuration on the fork.
+**Bottom line:** The mattbucci fork resolves blockers 2–6 today (v0.5.13.post1). Blocker 6 (prefix cache) is fixed by native MambaRadixCache — cache is ON in prod, which fixes the long-context agent, at a batch cost (~63 @conc16 vs ~99 no-cache) that's the right tradeoff for the agentic workload. Blocker 1 (MTP) remains the single-stream gap vs vLLM but is moot here (spec is net-negative on dense RDNA4). Once #24121 (HiCache-for-hybrid) closes, retest to get cache + higher batch + full context together.

--- a/docs/sglang-env-rebuild.sh
+++ b/docs/sglang-env-rebuild.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Rebuild the SGLang RDNA4 inference env on the `sglang` PVC at /cache/sglang.
+#
+# WHY THIS EXISTS (do NOT just run the fork's stock scripts/setup.sh):
+#   The fork targets a dual-card (TP=2) box; we serve single-card (TP=1). Two
+#   things the stock setup.sh does NOT do are required, or the server crashes:
+#     1. store_cache TP=1 patch — the JIT store_cache kernel aborts at TP=1
+#        ("kvcache.cuh:204: CUDA error: the operation cannot be performed in the
+#        present state"). We force can_use_store_cache()->False so the naive torch
+#        KV store is used. WITHOUT THIS THE SERVER CRASHES ON THE FIRST REQUEST.
+#     2. `pip uninstall kernels` — transformers 5.x pulls a `kernels` package
+#        whose hub-kernels loader crashes `import sglang`.
+#   It also pins ENV_NAME / SGLANG_DIR to PVC paths (the fork's common.sh defaults
+#   now point at the author's ephemeral /data/* paths) and lets setup.sh use its
+#   torch 2.11.0+rocm7.2 stable default (the old 2.12 nightly pin became
+#   unfetchable and faulted with expandable_segments).
+#
+# HOW TO RUN:
+#   Bring serving down first (the build needs the GPU for kernel compiles), then
+#   run this in a pod on the GPU node with the `sglang` PVC mounted at /cache,
+#   using the same ROCm base image as the Deployment, as root:
+#       kubectl scale deploy/sglang -n ai --replicas=0   # (+ suspend Flux; see app)
+#       # launch a builder pod (rocm/dev-ubuntu-24.04:7.2.4-complete) with the PVC
+#       # + squat.ai/dri:1, then inside it:
+#       bash sglang-env-rebuild.sh
+#   Re-point the serving Deployment afterwards (it execs launch.sh from the PVC).
+#
+# NOTE: setup.sh's final verify step hard-codes HIP_VISIBLE_DEVICES=0,1 and errors
+# on a single-GPU pod (ROCR_VISIBLE_DEVICES=0). That error is COSMETIC — the env
+# is already built by then; this script applies the post-build fixes regardless.
+set -uo pipefail
+
+# v0.5.13.post1 + 46 patches (validated 2026-06-24). Bump to rebase onto a newer fork HEAD.
+FORK_REF="${FORK_REF:-1034fea9a803db43c2972cf5f74c64501db0ffd6}"
+
+export ROCM_PATH=/opt/rocm
+export PYTORCH_ROCM_ARCH=gfx1201
+export CONDA_BASE=/cache/sglang/conda
+export ENV_NAME=sglang-triton36-v0513                    # must match the fork common.sh default launch.sh activates
+export REPO_DIR=/cache/sglang/repo
+export SGLANG_DIR=/cache/sglang/repo/components/sglang    # PVC path (common.sh default is the ephemeral /data/sgl-rebase)
+export TRITON_CACHE_DIR=/cache/sglang/triton
+export HF_HOME=/cache/hf
+export RUSTUP_HOME=/opt/rust/rustup CARGO_HOME=/opt/rust/cargo
+export PATH=/opt/rust/cargo/bin:$PATH
+export DEBIAN_FRONTEND=noninteractive
+mkdir -p /cache/sglang "$TRITON_CACHE_DIR"
+
+echo "=== apt deps ==="
+apt-get update -qq
+apt-get install -y -qq --no-install-recommends git curl ca-certificates build-essential python3-pip
+
+echo "=== rust toolchain (build-time, for sglang grpc crate) ==="
+command -v cargo >/dev/null 2>&1 || \
+  curl --proto '=https' --tlsv1.2 -fsSL https://sh.rustup.rs | sh -s -- -y --no-modify-path --profile minimal --default-toolchain stable
+
+echo "=== miniforge -> $CONDA_BASE ==="
+if [ ! -f "$CONDA_BASE/bin/conda" ]; then
+  curl -fsSL "https://github.com/conda-forge/miniforge/releases/download/24.11.3-2/Miniforge3-24.11.3-2-Linux-x86_64.sh" -o /tmp/miniforge.sh
+  bash /tmp/miniforge.sh -b -p "$CONDA_BASE"; rm -f /tmp/miniforge.sh
+fi
+
+echo "=== clone fork @ $FORK_REF -> $REPO_DIR ==="
+[ -d "$REPO_DIR/.git" ] || git clone https://github.com/mattbucci/2x-R9700-RDNA4-GFX1201-sglang-inference.git "$REPO_DIR"
+git -C "$REPO_DIR" fetch origin --depth 200
+git -C "$REPO_DIR" checkout "$FORK_REF"
+
+echo "=== setup.sh (conda env + torch 2.11 stable + triton 3.6 + native gfx1201 kernels) ==="
+cd "$REPO_DIR"
+HIP_VISIBLE_DEVICES=0 ./scripts/setup.sh || echo "(ignoring setup.sh final-verify exit code — see header note)"
+
+echo "=== TP=1 fix: force can_use_store_cache()->False (fall back to naive torch KV store) ==="
+KVC="$SGLANG_DIR/python/sglang/jit_kernel/kvcache.py"
+grep -q 'RDNA4 TP=1' "$KVC" || \
+  sed -i '/^def can_use_store_cache(size: int) -> bool:$/a\    return False  # RDNA4 TP=1: JIT store_cache crashes (kvcache.cuh:204) -> naive torch KV store' "$KVC"
+
+echo "=== drop transformers-5.x 'kernels' pkg (crashes import sglang) ==="
+"$CONDA_BASE/bin/conda" run -n "$ENV_NAME" pip uninstall kernels -y 2>/dev/null || true
+
+echo "=== verify ==="
+"$CONDA_BASE/bin/conda" run -n "$ENV_NAME" python -c "import sglang; print('sglang', sglang.__version__)"
+"$CONDA_BASE/bin/conda" clean -afy || true
+echo "=== REBUILD COMPLETE ==="

--- a/kubernetes/apps/ai/sglang/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/sglang/app/helmrelease.yaml
@@ -57,11 +57,18 @@ spec:
               tag: 7.2.4-complete@sha256:92f309c51b52cef8762867848f1529dee821624f23cd5df38455e819538f762f
             # Override the dev-image entrypoint with the fork's preset runner. The qwen36-27b preset
             # + these flags are the validated single-card config (perf table and the rejected
-            # alternatives — MoE, MTP/EAGLE3/DFlash/ngram, fp4 KV — are in the app README). No-cache
-            # (overlap scheduler ON) is chosen over extra_buffer because batch throughput is the
-            # goal: on RDNA4 prefix-cache and high batch are mutually exclusive. Context 262144 is
-            # the model's native max; the KV pool caps a single full-window request (see configmap),
-            # but typical traffic fits and batch stays intact.
+            # alternatives — MoE, MTP/EAGLE3/DFlash/ngram, fp4 KV, extra_buffer — are in the app
+            # README). Radix cache is ON (native MambaRadixCache, no_buffer): the long-context Hermes
+            # agent re-prefills its growing context every turn, so prefix reuse (cold→cache-hit ~7.6×
+            # TTFT) is what keeps it from timing out — the primary workload. The cost is batch: cache
+            # forces overlap off and halves max_running (32→~16), so aggregate decode is ~34 tok/s
+            # @conc8 vs ~99 no-cache. extra_buffer (overlap on) does NOT recover it — RDNA4 decode is
+            # compute-bound, so overlap gives ~0 (see README). chunked-prefill 8192 is the preset
+            # recommendation (faster long prefills). decode-steps 16 overrides the preset's safety
+            # default of 8 (which existed only because 32 crashed thinking): 16 is thinking-stable here
+            # and lifts single-stream decode ~18% (11.4→13.4 tok/s) with no batch/KV cost. Context
+            # 262144 is the model's native max; the KV pool caps a single full-window request (see
+            # configmap), but typical traffic fits.
             command:
               - /bin/bash
               - -c
@@ -70,7 +77,8 @@ spec:
                 --context-length 262144
                 --mem-fraction 0.90
                 --max-running 32
-                --chunked-prefill 4096
+                --decode-steps 16
+                --chunked-prefill 8192
                 --port 8000
             env:
               TZ: ${TIMEZONE}
@@ -86,11 +94,14 @@ spec:
               HF_HOME: /cache/hf
               HF_HUB_OFFLINE: "1"
               TRITON_CACHE_DIR: /cache/sglang/triton # persisted JIT cache on the PVC
-              PYTORCH_HIP_ALLOC_CONF: "" # torch-2.12 on RDNA4 faults with expandable_segments
-              # Appended after the preset's flags (last-wins): no-cache batch mode, mamba slots to
-              # match max-running (extra_buffer-free), and the drop-in served model name so litellm
-              # /karakeep keep calling `qwen-3.6` unchanged.
-              EXTRA_ARGS: "--disable-radix-cache --max-mamba-cache-size 32 --served-model-name qwen-3.6"
+              # No PYTORCH_HIP_ALLOC_CONF override: the old "" was a torch-2.12-nightly workaround
+              # (it faulted with expandable_segments). The env is now torch 2.11.0+rocm7.2 stable,
+              # where common.sh's expandable_segments:True is validated clean on gfx1201.
+              # Appended after the preset's flags (last-wins): cache ON (no --disable-radix-cache),
+              # mamba slots 48 > max-running so cached prefix states have headroom beyond running
+              # requests, and the drop-in served model name so litellm/karakeep keep calling
+              # `qwen-3.6` unchanged.
+              EXTRA_ARGS: "--max-mamba-cache-size 48 --served-model-name qwen-3.6"
             probes:
               startup: &probeBase
                 enabled: true
@@ -147,7 +158,7 @@ spec:
         annotations:
           gethomepage.dev/enabled: "true"
           gethomepage.dev/name: sglang
-          gethomepage.dev/description: Qwen3.6-27B SGLang inference (RDNA4, TP=1, ~99 tok/s batch)
+          gethomepage.dev/description: Qwen3.6-27B SGLang inference (RDNA4, TP=1, prefix-cache on, ~63 tok/s @conc16)
           gethomepage.dev/group: Models
           gethomepage.dev/icon: mdi-brain
         hostnames:
@@ -162,7 +173,9 @@ spec:
 
     persistence:
       # The `sglang` PVC carries the prebuilt SGLang conda env, fork source, Triton cache and the
-      # Qwen3.6 AWQ model (see pvc.yaml). Rebuildable via the fork's setup.sh if lost.
+      # Qwen3.6 AWQ model (see pvc.yaml). Rebuildable via docs/sglang-env-rebuild.sh if lost — it bakes
+      # in the RDNA4/TP=1 store_cache fix the fork's stock setup.sh omits (without it the server
+      # crashes on the first request).
       cache:
         enabled: true
         existingClaim: sglang


### PR DESCRIPTION
## What

Rebuilds the RDNA4 SGLang env to mattbucci fork **v0.5.13.post1** (HEAD `1034fea`, torch 2.11 stable) and turns on the native **MambaRadixCache** prefix cache — fixing the long-context Hermes agent.

## Why

The Hermes agent re-prefills its growing ~124K context every turn. Cold prefill is ~300s, which tripped litellm timeouts / aborts (`num_aborted_requests`). With the cache the prefix is reused — **7.6× TTFT** (cold ~16s → cache-hit ~2.1s; server log `#cached-token: 16384` of 18256).

## Config (`helmrelease.yaml`)

| change | from → to | why |
|---|---|---|
| radix cache | off → **on** (`no_buffer` MambaRadixCache) | the fix — prefix reuse for the agent |
| `--max-mamba-cache-size` | 32 → 48 | cache headroom beyond the 16 running slots |
| `--chunked-prefill` | 4096 → 8192 | preset recommendation, faster long prefills |
| `--decode-steps` | 8 → 16 | +18% single-stream, thinking-stable (validated) |
| `PYTORCH_HIP_ALLOC_CONF` | drop `""` | stale torch-2.12 workaround; env is torch 2.11 stable |

## Validated (live, on the `sglang` PVC env)

- correctness: thinking ✓, tool-calling ✓, 4/4 long thinking-stress ✓ (0 crashes)
- prefix cache: 7.6× TTFT, `#cached-token: 16384`
- single-stream **13.4 tok/s** · batch **34 @conc8 / 63 @conc16** · 0 errors
- **97K cold prefill**: correct recall, no OOM @ mem 0.90

## Tradeoff (intentional)

Cache forces the overlap scheduler off → batch ~63 @conc16 (vs ~99 no-cache) — the right call for the agent-primary workload. `extra_buffer` (overlap *with* cache) was ruled out: no batch gain on compute-bound RDNA4 decode, and it halves `max_running`. Keeping 16 batch slots caps the KV pool at **126,854 tokens** @ `mem-fraction 0.90` (Hermes's 124K fits; mem 0.95 OOMs on a real prefill). Full 262K single-session isn't reachable on 32GB without dropping batch slots.

## Durability

- `docs/sglang-env-rebuild.sh` — reproducible rebuild recipe including the RDNA4/TP=1 `store_cache` fix the fork's `setup.sh` omits (without it the server crashes on first inference).
- `docs/sglang-blockers.md` — Blocker 6 reclassified **resolved** (now a tunable tradeoff, not a blocker).

## Deploy note

The env is already rebuilt on the `sglang` PVC; Flux is currently suspended (ks + HR, `reconcile: disabled`). On merge, the cutover is: un-suspend Flux → the Deployment recreates and boots v0.5.13 cache-on from the PVC. (Pending — not done in this PR.)
