### PR TITLE
feat(ai): deploy qwen3-embedding alongside llama-embeddings (cutover step 1)

### DIFF
--- a/kubernetes/apps/ai/kustomization.yaml
+++ b/kubernetes/apps/ai/kustomization.yaml
@@ -14,14 +14,15 @@ resources:
   #   2. change litellm/ks.yaml and memini/ks.yaml dependsOn back to llama-server
   #   3. change litellm/app/configmap.yaml api_base back to http://llama-server.ai.svc.cluster.local/v1
   # - ./llama-server/ks.yaml
-  # CUTOVER (single swap): comment ./llama-embeddings, uncomment ./llmkube/models-ks.yaml,
-  # and repoint memini (app/helmrelease.yaml MEMINI_EMBED_BASE_URL ->
-  # http://qwen3-embedding.ai.svc.cluster.local:8080/v1; ks.yaml dependsOn
-  # llama-embeddings -> llmkube-models). The iGPU advertises squat.ai/dri count:1,
-  # so the old and new embedding pods cannot co-reside — swap, never run both.
+  # CUTOVER (validate-first, in progress): qwen3-embedding runs alongside
+  # llama-embeddings while the iGPU device count is temporarily 2
+  # (kube-system/generic-device-plugin). Once validated, PR B repoints memini
+  # (MEMINI_EMBED_BASE_URL -> http://qwen3-embedding.ai.svc.cluster.local:8080/v1,
+  # memini/ks.yaml dependsOn llama-embeddings -> llmkube-models), removes
+  # ./llama-embeddings, and drops the iGPU count back to 1.
   - ./llama-embeddings/ks.yaml
   - ./llmkube/ks.yaml # operator only; safe alongside llama-embeddings
-  # - ./llmkube/models-ks.yaml # qwen3-embedding — uncomment at cutover
+  - ./llmkube/models-ks.yaml # qwen3-embedding (validate alongside llama-embeddings)
   - ./open-webui/ks.yaml
   - ./opencode/ks.yaml
   - ./odysseus/ks.yaml

--- a/kubernetes/apps/kube-system/generic-device-plugin/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/generic-device-plugin/app/helmrelease.yaml
@@ -42,6 +42,9 @@ spec:
                 memory: 16Mi
               limits:
                 memory: 64Mi
+      # count is temporarily 2 for the llama-embeddings -> llmkube embedding
+      # cutover (validate both on the iGPU); revert to 1 once qwen3-embedding
+      # is live and llama-embeddings is removed.
       generic-device-plugin-igpu:
         type: daemonset
         pod:
@@ -56,7 +59,7 @@ spec:
               - |
                 name: dri
                 groups:
-                  - count: 1
+                  - count: 2
                     paths:
                       - path: /dev/dri
             securityContext: *devicePluginSecurityContext


### PR DESCRIPTION
## What

Cutover **step 1 of 2** (validate-first) from `llama-embeddings` to the llmkube `qwen3-embedding` InferenceService.

- Temporarily raise the iGPU `generic-device-plugin` device count `1 → 2` so both embedding pods fit on the single iGPU.
- Enable the `llmkube-models` Kustomization → deploys the `qwen3-embedding` InferenceService.
- `memini` stays on `llama-embeddings` (untouched); nothing deleted.

## Why validate-first

The `qwen3-embedding` path hasn't served a request yet (model download, iGPU `/dev/dri` access, `--embeddings`/`--pooling`/`--alias`). Running it alongside the old one confirms it serves `/v1/embeddings` before deleting the only working embedding.

## After merge

Verify the `qwen3-embedding` pod is Ready on the iGPU and `/v1/embeddings` returns a 1024-dim vector. Then **PR B** repoints memini (`MEMINI_EMBED_BASE_URL -> http://qwen3-embedding.ai.svc.cluster.local:8080/v1`, `memini/ks.yaml` `dependsOn` -> `llmkube-models`), removes `llama-embeddings`, and reverts the iGPU count to 1.
