### PR TITLE
fix(security): prevent crowdsec agent crash loop on container restart

### DIFF
--- a/kubernetes/apps/security/crowdsec/app/helmrelease.yaml
+++ b/kubernetes/apps/security/crowdsec/app/helmrelease.yaml
@@ -100,7 +100,7 @@ spec:
       agent_config.yaml.local: |-
         api:
           client:
-            unregister_on_exit: true
+            unregister_on_exit: false
       appsec_config.yaml.local: |-
         api:
           client:
@@ -143,6 +143,16 @@ spec:
         serviceMonitor:
           enabled: true
     agent:
+      startupProbe:
+        httpGet:
+          path: /metrics
+          port: metrics
+          scheme: HTTP
+        initialDelaySeconds: 30
+        periodSeconds: 10
+        successThreshold: 1
+        timeoutSeconds: 5
+        failureThreshold: 60
       resources:
         requests:
           cpu: 100m


### PR DESCRIPTION
## Problem

The crowdsec agent DaemonSet repeatedly enters CrashLoopBackOff on specific nodes. Deleting the pod always recovers it, but the crash returns.

**Root cause:** The init container (`wait-for-lapi-and-register`) runs only once per pod lifecycle — not on individual container restarts. With `unregister_on_exit: true`, when the container is killed (startup probe timeout, SIGKILL), it inconsistently deregisters the machine from LAPI. The emptyDir at `/tmp_config` still holds credentials for the now-deregistered machine. On the next container restart, the agent tries to authenticate with stale credentials, LAPI rejects them, the agent exits before the metrics port (`:6060`) opens, the startup probe fails, and the cycle repeats.

Deleting the pod resets the emptyDir and re-runs the init container, which re-registers with LAPI and writes fresh credentials — hence it always fixes the issue.

## Fix

- **`unregister_on_exit: false`**: Machine registration persists across container restarts, so the emptyDir credentials remain valid. Orphaned registrations from deleted pods are harmless with `auto_registration` enabled.
- **Startup probe tuning**: `initialDelaySeconds: 30` (agent typically takes ~40s to reach "Starting processing data") + `failureThreshold: 60` (10 min total tolerance, up from 5 min) as defense-in-depth against transient slowness.