### PR TITLE
feat(ai): add qwen3.5-2b offload model on llmkube (iGPU/Vulkan)

### DIFF
--- a/kubernetes/apps/ai/litellm/app/configmap.yaml
+++ b/kubernetes/apps/ai/litellm/app/configmap.yaml
@@ -46,6 +46,21 @@ data:
           max_input_tokens: 262144
           max_output_tokens: 8192
 
+      # Qwen3.5-2B on LLMKube (iGPU / Vulkan, control-2) — small fast offload model
+      # for easy tasks (classification, extraction, short rewrites). GDN hybrid,
+      # measured ~43 tok/s decode / ~513 tok/s prefill on the Radeon 660M.
+      - model_name: qwen3.5-2b
+        litellm_params:
+          model: openai/qwen3.5-2b
+          api_base: http://qwen35-2b.ai.svc.cluster.local:8080/v1
+          api_key: os.environ/LLAMA_SERVER_API_KEY
+          timeout: 300
+          num_retries: 0
+        model_info:
+          mode: chat
+          max_input_tokens: 16384
+          max_output_tokens: 4096
+
       # Qwen3-Embedding-0.6B on LLMKube (iGPU / Vulkan). model_info.mode routes
       # /v1/embeddings here instead of chat (LLMKube #866 / litellm embedding mode).
       - model_name: qwen3-embedding

--- a/kubernetes/apps/ai/llmkube/models/kustomization.yaml
+++ b/kubernetes/apps/ai/llmkube/models/kustomization.yaml
@@ -4,3 +4,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./qwen3-embedding.yaml
+  - ./qwen35-2b.yaml

--- a/kubernetes/apps/ai/llmkube/models/qwen35-2b.yaml
+++ b/kubernetes/apps/ai/llmkube/models/qwen35-2b.yaml
@@ -1,0 +1,83 @@
+---
+apiVersion: inference.llmkube.dev/v1alpha1
+kind: Model
+metadata:
+  name: qwen35-2b
+spec:
+  source: https://huggingface.co/unsloth/Qwen3.5-2B-GGUF/resolve/main/Qwen3.5-2B-Q4_K_M.gguf
+  format: gguf
+  # Q4_K_M (~1.18 GiB) is the speed/quality sweet spot on the RDNA2 iGPU
+  # (measured 43 tok/s decode, 513 tok/s prefill); Q8 would ~double the footprint
+  # for marginal gain on easy offload tasks.
+  quantization: Q4_K_M
+  hardware:
+    accelerator: vulkan
+    gpu:
+      enabled: true
+      count: 1
+      vendor: amd
+      runtime: vulkan
+      layers: -1
+      resourceName: squat.ai/dri
+---
+apiVersion: inference.llmkube.dev/v1alpha1
+kind: InferenceService
+metadata:
+  name: qwen35-2b
+spec:
+  modelRef: qwen35-2b
+  # Current server-vulkan digest — newer than the embedding pin, which predates
+  # Qwen3.5's GDN (Gated Delta Networks) architecture. Verified to load `qwen35`
+  # and run GDN fully on Vulkan (no CPU fallback). Tracked by the llmkube-models
+  # Renovate customManager (.renovaterc.json5).
+  image: ghcr.io/ggml-org/llama.cpp:server-vulkan@sha256:dba48720a7fead3ae2a2a678e82a8db88bf5120db286cdf48c8461ad2c2d855b
+  parallelSlots: 2 # Vulkan warmup hangs at parallel=1 (llama.cpp #24307)
+  contextSize: 16384 # GDN keeps KV tiny, so long ctx is cheap; 16K is plenty for offload
+  extraArgs:
+    - "--jinja" # use the model's chat template (correct Qwen3.5 formatting + tool calls)
+    - "--alias"
+    - "qwen3.5-2b" # served model name litellm sends in /v1/chat/completions
+    - "--metrics" # expose Prometheus /metrics (off by default in llama-server)
+
+  # Free squat.ai/dri slot lives on control-2 (embeddings hold control-3's), so
+  # amd.com/igpu lands this on control-2's iGPU with no manual pin.
+  nodeSelector:
+    amd.com/igpu: "true"
+
+  # Render/video host groups for /dev/dri — the documented Vulkan-runtime path.
+  podSecurityContext:
+    runAsUser: 0
+    runAsGroup: 0
+    supplementalGroups:
+      - 44
+      - 226
+
+  # Probe /health rather than the operator-default chat-completions path so the
+  # pod isn't marked unready while the model is still loading.
+  probeOverrides:
+    startup:
+      httpGet: &healthProbe
+        path: /health
+        port: 8080
+      initialDelaySeconds: 10
+      periodSeconds: 10
+      timeoutSeconds: 5
+      failureThreshold: 15
+    readiness:
+      httpGet: *healthProbe
+      initialDelaySeconds: 10
+      timeoutSeconds: 3
+    liveness:
+      httpGet: *healthProbe
+      initialDelaySeconds: 30
+      periodSeconds: 30
+      timeoutSeconds: 5
+
+  resources:
+    cpu: "500m" # inference is on the iGPU; CPU only tokenises/schedules/samples
+    # ~2.4 GiB resident; requested low (no limit set by llmkube) so it schedules
+    # on control-2's tight request budget and bursts into its real free RAM.
+    memory: 1536Mi
+    gpu: 1
+    gpuMemory: 3Gi
+  # endpoint omitted — operator defaults to a ClusterIP Service on :8080.


### PR DESCRIPTION
## What

Adds **Qwen3.5-2B** as a small, fast text model on the otherwise-idle **control-2 iGPU**, for offloading easy tasks (classification, extraction, short rewrites) off the dGPU 27B. Served via llmkube (llama.cpp `server-vulkan`) and exposed through litellm as `qwen3.5-2b` (chat).

## Why this model / placement

- **Benchmarked on the actual Radeon 660M** (RDNA2/gfx1035) via `llama-bench`: **~43 tok/s decode, ~513 tok/s prefill** at Q4_K_M.
- Qwen3.5-2B is a **GDN (Gated Delta Networks) hybrid** — linear-attention layers keep the KV cache tiny, so resident footprint is ~2.4 GiB (weights 1.18 GiB). Confirmed it loads `qwen35` and runs **fully on Vulkan** (no CPU fallback).
- The free `squat.ai/dri` slot is on control-2 (embeddings hold control-3's), so `nodeSelector: amd.com/igpu` lands it there with no reshuffle and no GPU contention.
- Image pinned to a **current `server-vulkan` digest** — the embedding pod's pin predates Qwen3.5's GDN arch.

## Notes

- Text-only as configured. The model *is* multimodal, but vision needs the separate `mmproj` projector via `--mmproj` (a follow-up — llmkube's Model CR downloads a single GGUF).
- Memory requested low (`1536Mi`, no limit) so it schedules on control-2's tight request budget and bursts into real free RAM.

## Validation (post-merge)
- [ ] `qwen35-2b` pod Running on control-2
- [ ] `/v1/chat/completions` via litellm `qwen3.5-2b` returns text