### PR TITLE
fix(ai): move llmkube modelCache to cephfs RWX for multi-node serving

### DIFF
--- a/kubernetes/apps/ai/llmkube/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/llmkube/app/helmrelease.yaml
@@ -57,17 +57,21 @@ spec:
           inference:
             enabled: true
 
-    # Persistent model cache on ceph-block (rook RBD, RWO). REQUIRES llmkube
-    # >= 0.8.21: with a PVC cache the operator injects a model-cache-prep init
-    # that chowns /models, and 0.8.20 regressed it to run as non-root (uid 100)
-    # → "Operation not permitted" → Init CrashLoop on ANY storage class (it was
-    # never a storage issue; ceph-block failed identically to openebs-hostpath).
-    # 0.8.21 runs that prep as root again (upstream #888). RWO is sufficient —
-    # the model-downloader init and llama-server share one pod pinned to a single
-    # iGPU node. Survives restarts so the ~1.2Gi f16 model isn't re-downloaded.
+    # Persistent model cache on ceph-filesystem (CephFS, RWX). It's a SINGLE
+    # shared PVC mounted by the controller-manager and every InferenceService,
+    # which land on different iGPU nodes (qwen3-embedding on control-3, qwen35-2b
+    # on control-2) — so it must be RWX: an RWO volume multi-attach-errors across
+    # nodes. The cache is cold (write-once on download, read-once at model load,
+    # then idle — weights live in VRAM), so CephFS network latency never touches
+    # the inference path; only a few seconds of extra cold-start read.
+    # REQUIRES llmkube >= 0.8.21: with a PVC cache the operator injects a
+    # model-cache-prep init that chowns /models; 0.8.20 regressed it to non-root
+    # (uid 100) → "Operation not permitted" → CrashLoop. 0.8.21 runs it as root
+    # (upstream #888), so the chown succeeds on CephFS (fsGroupPolicy: None) too.
+    # Survives restarts so the ~1.2Gi models aren't re-downloaded each time.
     modelCache:
       enabled: true
-      size: 3Gi # ~1.2Gi f16 model + HF metadata
-      storageClass: ceph-block
-      accessMode: ReadWriteOnce
+      size: 6Gi # shared by embedding + qwen35-2b (~1.2Gi each) + HF metadata
+      storageClass: ceph-filesystem
+      accessMode: ReadWriteMany
       mountPath: /models

--- a/kubernetes/apps/ai/llmkube/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/llmkube/app/helmrelease.yaml
@@ -68,10 +68,7 @@ spec:
     # model-cache-prep init that chowns /models; 0.8.20 regressed it to non-root
     # (uid 100) → "Operation not permitted" → CrashLoop. 0.8.21 runs it as root
     # (upstream #888), so the chown succeeds on CephFS (fsGroupPolicy: None) too.
-    # Survives restarts so the ~1.2Gi models aren't re-downloaded each time.
     modelCache:
-      enabled: true
-      size: 6Gi # shared by embedding + qwen35-2b (~1.2Gi each) + HF metadata
+      size: 4Gi # ~1.2Gi each for embedding + qwen35-2b + headroom (default 100Gi)
       storageClass: ceph-filesystem
       accessMode: ReadWriteMany
-      mountPath: /models

--- a/kubernetes/apps/ai/llmkube/ks.yaml
+++ b/kubernetes/apps/ai/llmkube/ks.yaml
@@ -14,10 +14,10 @@ spec:
     name: flux-system
     namespace: flux-system
   targetNamespace: *namespace
-  # Gate the embedding model (llmkube-models) on the operator being installed: the
+  # Gate the models (llmkube-models) on the operator being installed: the
   # HelmRelease only reports Ready once its CRDs are applied and the controller is
-  # up. Targeted healthCheck rather than spec.wait, so perService model-cache PVCs
-  # (WaitForFirstConsumer) don't deadlock readiness.
+  # up. Targeted healthCheck rather than spec.wait so readiness keys on just the
+  # CRD-providing HelmRelease, not a blanket wait across all rendered resources.
   healthChecks:
     - apiVersion: helm.toolkit.fluxcd.io/v2
       kind: HelmRelease


### PR DESCRIPTION
## What

Switches the shared `llmkube-model-cache` from **ceph-block / RWO** to **ceph-filesystem / RWX** (and 3Gi → 6Gi).

## Why

The cache is a **single shared PVC** mounted by the controller-manager and *every* InferenceService. With two models now on **different iGPU nodes** (`qwen3-embedding` on control-3, `qwen35-2b` on control-2), the RWO volume can't attach across nodes — `qwen35-2b` hit `FailedAttachVolume` / Multi-Attach. RWX (CephFS) lets the one volume attach on both nodes.

The cache is **cold** — write-once on download, read-once at model load, then idle (weights live in VRAM) — so CephFS network latency never touches the inference path; only a few seconds of extra cold-start read. `ceph-filesystem`/`ReadWriteMany` is the established cluster RWX idiom (immich, p2pool).

Bumped to 6Gi since two ~1.2 GiB models now share it. Works because llmkube ≥ 0.8.21 runs `model-cache-prep` as root, so the chown succeeds on CephFS.

## ⚠️ Post-merge: PVC must be recreated (storageClass/accessMode are immutable)
1. `flux suspend helmrelease llmkube -n ai`
2. scale controller-manager + both InferenceService deployments to 0 (release the RWO PVC) — **brief embeddings downtime**
3. delete the old `llmkube-model-cache` PVC
4. `flux resume` + reconcile → Helm recreates it as CephFS/RWX; both models redownload into the shared cache

## Validation (post-merge)
- [ ] PVC `llmkube-model-cache` Bound, RWX, ceph-filesystem
- [ ] `qwen3-embedding` Ready (control-3), `qwen35-2b` Ready (control-2) — no Multi-Attach
- [ ] text via litellm `qwen3.5-2b` works