### PR TITLE
feat(sglang): cut over to baked OCI image

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -70,16 +70,6 @@
       currentValueTemplate: "main",
       datasourceTemplate: "git-refs"
     },
-    {
-      description: "SGLang release version in sglang-rocm Dockerfile ARG",
-      customType: "regex",
-      managerFilePatterns: ["/docker/sglang-rocm/Dockerfile$/"],
-      matchStrings: [
-        "# renovate: datasource=github-releases depName=sglang-project/sglang\\nARG SGLANG_VERSION=(?<currentValue>\\S+)"
-      ],
-      depNameTemplate: "sglang-project/sglang",
-      datasourceTemplate: "github-releases"
-    }
   ],
   packageRules: [
     // Auto-merge rules
@@ -101,18 +91,16 @@
     },
     // Grouping rules
     {
-      description: "sglang-rocm build inputs (sglang fork version + ROCm base image digest) — one review PR, no automerge; merging triggers the image-builder build workflow",
-      groupName: "sglang-rocm",
-      matchFileNames: ["docker/sglang-rocm/Dockerfile"],
-      automerge: false,
-      addLabels: ["sglang-rocm"]
+      description: "sglang-rdna4 build inputs (fork ref + ROCm base digest + miniforge) — one review PR, no automerge; merging fires the GPU-free build workflow and mints a new image digest",
+      groupName: "sglang-rdna4",
+      matchFileNames: ["docker/sglang-rdna4/Dockerfile"],
+      automerge: false
     },
     {
-      description: "sglang-rocm deployed image digest — review before a HelmRelease rolls a new build",
+      description: "sglang-rdna4 deployed image digest — review before the HelmRelease rolls the serving pod (Recreate on the single GPU)",
       matchDatasources: ["docker"],
-      matchPackageNames: ["ghcr.io/tanguille/sglang-rocm-gfx1201"],
-      automerge: false,
-      addLabels: ["sglang-rocm"]
+      matchPackageNames: ["ghcr.io/tanguille/sglang-rdna4"],
+      automerge: false
     },
     {
       description: "Actions Runner Controller Group",

--- a/docker/sglang-rdna4/README.md
+++ b/docker/sglang-rdna4/README.md
@@ -57,10 +57,11 @@ docs excluded so a README edit can't repush the image) or on manual dispatch
 `docker build docker/sglang-rdna4`. Expect ~15-30 min: the ROCm "complete" base is large and
 the HIP kernels compile.
 
-## Pin by digest, never the tag
+## Pin as tag@digest — the digest is authoritative
 
-Community tags get rebuilt in place (memo `project_ik_llama_image_tags`) — the sglang
-HelmRelease references the **digest**, never the tag:
+The tag gets rebuilt in place (memo `project_ik_llama_image_tags`), so the digest is what pins
+the deployment — but the HelmRelease uses the repo-wide `tag: <tag>@sha256:<digest>` form, NOT a
+bare `@digest`: Renovate's flux manager needs the tag present to issue digest-bump PRs.
 
 ```bash
 skopeo inspect docker://ghcr.io/tanguille/sglang-rdna4:v0.5.14-gfx1201 --format '{{.Digest}}'

--- a/docs/llm-hosting/sglang-oci-cutover.md
+++ b/docs/llm-hosting/sglang-oci-cutover.md
@@ -42,7 +42,7 @@ at image-build time — covered by digest-pinned rollback and the Stage 2 valida
    and every other flag identical. Open as Stage 2 PR.
 3. **Pre-pull** — control-1 is the only node that can run the pod, so Spegel has no peer for
    the first pull and Recreate kills the old pod before pulling: an un-prepulled 47GB fetch is
-   pure downtime. Before merging: `kubectl -n ai run prepull --rm --restart=Never
+   pure downtime. Before merging: `kubectl -n ai run prepull -i --rm --restart=Never
    --image=ghcr.io/tanguille/sglang-rdna4:v0.5.14-gfx1201@sha256:<digest>
    --overrides='{"spec":{"nodeName":"control-1"}}' --command -- true` (or `crictl pull` on the
    node). Repeat for every future digest bump.

--- a/docs/llm-hosting/sglang-oci-cutover.md
+++ b/docs/llm-hosting/sglang-oci-cutover.md
@@ -33,18 +33,27 @@ at image-build time — covered by digest-pinned rollback and the Stage 2 valida
    Watch `gh run watch`. ~15-30 min; serving keeps running throughout. Capture the pushed
    digest from the run summary (`…@sha256:…`). First run may hit hosted-runner disk/RAM
    limits — iterate on the workflow's free-disk-space/swap knobs if so.
-2. **Pin** — set the sglang HelmRelease image to `ghcr.io/tanguille/sglang-rdna4@<digest>`,
-   command path `/cache/sglang/repo-v0514/scripts/launch.sh` → `/opt/rdna4-inference/scripts/launch.sh`,
-   and `CONDA_BASE: /cache/sglang/conda` → `/opt/conda`. Keep the PVC mount (model `/cache/hf` +
-   Triton `/cache/sglang/triton`) and every other flag identical. Open as Stage 2 PR.
-3. **Deploy** — merge Stage 2, watch the pod roll (this restart is the only serving-visible
+2. **Pin** — set the sglang HelmRelease image to `ghcr.io/tanguille/sglang-rdna4` with
+   `tag: v0.5.14-gfx1201@sha256:<digest>` (tag@digest, repo convention: the digest is
+   authoritative — the tag gets rebuilt in place — but the tag must stay so Renovate can bump
+   the digest), command path `/cache/sglang/repo-v0514/scripts/launch.sh` →
+   `/opt/rdna4-inference/scripts/launch.sh`, and drop the `CONDA_BASE` env override (the image
+   bakes `/opt/conda`). Keep the PVC mount (model `/cache/hf` + Triton `/cache/sglang/triton`)
+   and every other flag identical. Open as Stage 2 PR.
+3. **Pre-pull** — control-1 is the only node that can run the pod, so Spegel has no peer for
+   the first pull and Recreate kills the old pod before pulling: an un-prepulled 47GB fetch is
+   pure downtime. Before merging: `kubectl -n ai run prepull --rm --restart=Never
+   --image=ghcr.io/tanguille/sglang-rdna4:v0.5.14-gfx1201@sha256:<digest>
+   --overrides='{"spec":{"nodeName":"control-1"}}' --command -- true` (or `crictl pull` on the
+   node). Repeat for every future digest bump.
+4. **Deploy** — merge Stage 2, watch the pod roll (this restart is the only serving-visible
    moment of the whole cutover). First boot recompiles the Triton JIT cache onto the PVC (the
    startup probe's ~16 min budget covers it). This boot is also the kernel smoke test the
    GPU-free build deferred: a broken build fails the startup probe here. The single GPU forces
    a Recreate rollout (no old pod kept warm), so on failure go straight to **Rollback** below —
    serving is down only for the failed-boot window either way.
-4. **Validate** — `/health` up, a `qwen-3.6` completion with tools+thinking, PPL/needle spot-check, decode tok/s parity with the PVC baseline (≈16 single / ≈99 @conc24).
-5. **Retire** — drop the "Runtime-from-PVC" section from the app README; keep `sglang-env-rebuild.sh`
+5. **Validate** — `/health` up, a `qwen-3.6` completion with tools+thinking, PPL/needle spot-check, decode tok/s parity with the PVC baseline (≈16 single / ≈99 @conc24).
+6. **Retire** — drop the "Runtime-from-PVC" section from the app README; keep `sglang-env-rebuild.sh`
    as the documented PVC-rebuild fallback (the Dockerfile is now primary). The PVC's
    `conda/` + `repo-v0514/` are now dead weight but harmless — clean up later.
 

--- a/kubernetes/apps/ai/sglang/README.md
+++ b/kubernetes/apps/ai/sglang/README.md
@@ -23,7 +23,12 @@ Full benchmarks, the optimization ledger and the engine-selection rationale live
   (127K → 237,446 tokens)**, quality-neutral (PPL 2.1423, needle@124K PASS) — headroom that keeps
   the agent's 124K prefix from evicting under burst.
 
-## ⚠️ Runtime-from-PVC (reproducibility debt)
+## ⚠️ Runtime-from-PVC (superseded — kept as rollback)
+
+> **Superseded by the baked OCI image** (`ghcr.io/tanguille/sglang-rdna4`, see
+> [`docker/sglang-rdna4/README.md`](../../../../docker/sglang-rdna4/README.md)) as of the Stage 2
+> cutover. The PVC env below remains the rollback path; full rewrite of this section pending
+> post-cutover validation (`docs/llm-hosting/sglang-oci-cutover.md` steps 5-6).
 
 The container image is **only the ROCm 7.2.4 runtime base**. The engine runs from the prebuilt
 conda env on the `sglang` PVC at `/cache/sglang`:
@@ -47,9 +52,8 @@ OOM-restarts on the first grammar request):
 5. `qwen3.6_devrole_chat_template.jinja` — remaps the `developer` role and guards historical `<think>`
    blocks (correct `preserve_thinking`, no empty-arg tool-call loop).
 
-**Follow-up (blocked):** bake the env into a versioned OCI image (`docker/sglang-rdna4/`), but the
-cluster can't pull never-cached images (Spegel upstream fall-through broken), so runtime-from-PVC on
-the cached ROCm base is the only path for now.
+**Follow-up (done):** the env is now baked into `ghcr.io/tanguille/sglang-rdna4`
+(`docker/sglang-rdna4/`) — the Spegel blocker that forced runtime-from-PVC is resolved.
 
 ## Performance & bottleneck
 

--- a/kubernetes/apps/ai/sglang/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/sglang/app/helmrelease.yaml
@@ -48,14 +48,14 @@ spec:
         strategy: Recreate
         containers:
           app:
-            # SGLang (mattbucci RDNA4 fork) runs from the prebuilt conda env on the `sglang` PVC at
-            # /cache/sglang — the image is only the ROCm 7.2.4 runtime base. The engine, the native
-            # gfx1201 HIP kernels, the fork source and the bring-up patches all live on the PVC.
-            # See the app README for the PVC inventory, the patches, and the OCI-image follow-up.
+            # SGLang (mattbucci RDNA4 fork) baked into the image: conda env, native gfx1201 HIP
+            # kernels, fork source + TP=1 patches — built GPU-free in CI; build/pin/rollback
+            # mechanics in docker/sglang-rdna4/README.md. Digest is authoritative (the tag gets
+            # rebuilt in place); the tag stays so Renovate can bump the digest.
             image:
-              repository: docker.io/rocm/dev-ubuntu-24.04
-              tag: 7.2.4-complete@sha256:92f309c51b52cef8762867848f1529dee821624f23cd5df38455e819538f762f
-            # Override the dev-image entrypoint with the fork's preset runner. The qwen36-27b preset +
+              repository: ghcr.io/tanguille/sglang-rdna4
+              tag: v0.5.14-gfx1201@sha256:2cb8e979c7ccc2116f95595ddd317cea85fe17390752b4bc264b6e6ac1629b1d
+            # Replace the image entrypoint with the fork's preset runner. The qwen36-27b preset +
             # these flags are the validated single-card config; the perf table, the cache-vs-batch
             # tradeoff and the rejected alternatives (MoE, MTP/spec, fp4 KV) are in the README. Radix
             # cache is ON (MambaRadixCache, no_buffer) for the long-context agent: prefix reuse
@@ -71,7 +71,7 @@ spec:
               - /bin/bash
               - -c
               - >-
-                exec bash /cache/sglang/repo-v0514/scripts/launch.sh qwen36-27b
+                exec bash /opt/rdna4-inference/scripts/launch.sh qwen36-27b
                 --context-length 200000
                 --mem-fraction 0.875
                 --max-running 32
@@ -80,8 +80,8 @@ spec:
                 --port 8000
             env:
               TZ: ${TIMEZONE}
-              # --- launch.sh / common.sh overrides (most gfx1201 env is set by common.sh) ---
-              CONDA_BASE: /cache/sglang/conda
+              # --- launch.sh / common.sh overrides (most gfx1201 env is set by common.sh;
+              # --- CONDA_BASE/ENV_NAME/REPO_DIR come baked from the image) ---
               TP: "1" # single R9700; the fork defaults to 2 (its dual-card box)
               MODEL: mattbucci/Qwen3.6-27B-AWQ # resolved offline from HF_HOME cache
               # Pin every device-visibility var to card 0 (common.sh defaults them to "0,1").
@@ -113,8 +113,9 @@ spec:
                   initialDelaySeconds: 60
                   periodSeconds: 15
                   timeoutSeconds: 5
-                  # ~16 min budget (60×15s + 60s): warm PVC boots in ~2-3 min; headroom covers a
-                  # cold Triton recompile after image/kernel changes.
+                  # ~16 min budget (60×15s + 60s): a warm boot (image cached, Triton cache warm)
+                  # is ~2-3 min; headroom covers a cold Triton recompile after image/kernel changes.
+                  # Image pull time does not count — the probe starts with the container.
                   failureThreshold: 60
               # Liveness OFF: even TCP probes restart a busy-but-alive singleton under long-prefill /
               # thinking load (exit 0 via SIGTERM + kill_process_tree, dropping in-flight work;
@@ -172,10 +173,9 @@ spec:
                 port: 80
 
     persistence:
-      # The `sglang` PVC carries the prebuilt SGLang conda env, fork source, Triton cache and the
-      # Qwen3.6 AWQ model (see pvc.yaml). Rebuildable via scripts/sglang-env-rebuild.sh if lost — it
-      # bakes in the RDNA4/TP=1 fixes the fork's stock setup.sh omits (without them the server crashes
-      # on the first request, or OOM-restarts hours in on the first grammar/json_schema request).
+      # The `sglang` PVC carries the Qwen3.6 AWQ model (/cache/hf), the persisted Triton JIT cache,
+      # and the legacy runtime-from-PVC conda env + fork source — kept as the rollback path for the
+      # baked image (retirement owned by docs/llm-hosting/sglang-oci-cutover.md step 6).
       cache:
         enabled: true
         existingClaim: sglang

--- a/kubernetes/apps/ai/sglang/app/pvc.yaml
+++ b/kubernetes/apps/ai/sglang/app/pvc.yaml
@@ -7,9 +7,9 @@ metadata:
 spec:
   accessModes: ["ReadWriteOnce"]
   storageClassName: openebs-hostpath
-  # Rebuildable runtime cache: the SGLang conda env (/cache/sglang/conda), the patched fork
-  # source, the Triton cache, and the Qwen3.6-27B-AWQ model (~50 GB used). NOT reproducible
-  # from git (runtime-from-PVC — see README); rebuild via the fork's setup.sh if lost.
+  # Model (Qwen3.6-27B-AWQ), persisted Triton JIT cache, and the legacy runtime-from-PVC
+  # conda env + fork source (~50 GB used). The env is rollback-only since the baked-image
+  # cutover (see README); rebuild via scripts/sglang-env-rebuild.sh if lost.
   resources:
     requests:
       storage: 80Gi


### PR DESCRIPTION
## Stage 2 — the cutover

Switches the `sglang` HelmRelease from the **runtime-from-PVC** env (engine hand-built onto the PVC by `sglang-env-rebuild.sh`, image = bare ROCm base) to the **git-reproducible baked image** `ghcr.io/tanguille/sglang-rdna4`.

### What changes
- **Image** → `ghcr.io/tanguille/sglang-rdna4:v0.5.14-gfx1201@sha256:2cb8e979c7ccc2116f95595ddd317cea85fe17390752b4bc264b6e6ac1629b1d` (tag@digest: digest authoritative, tag kept so Renovate can bump it).
- **Launch path** `/cache/sglang/repo-v0514/scripts/launch.sh` → `/opt/rdna4-inference/scripts/launch.sh`.
- **Dropped** the `CONDA_BASE` env override — the image bakes `/opt/conda`.
- Every flag, probe, resource limit, and the PVC mount (model `/cache/hf` + Triton `/cache/sglang/triton`) are **unchanged**.

### Housekeeping in the same PR
- Repoint stale Renovate rules from the dead `sglang-rocm` names to `sglang-rdna4`.
- Add the control-1 **pre-pull** step to the cutover runbook (control-1 is the only eligible node → Spegel has no peer → an un-prepulled 47GB Recreate is pure downtime).
- Reconcile the rollback story across the READMEs and `pvc.yaml`.

### Rollout / rollback
Single GPU forces a **Recreate** rollout — the pod restart is the only serving-visible moment. First boot recompiles the Triton JIT cache onto the PVC (covered by the ~16 min startup probe budget) and is the kernel smoke test the GPU-free build deferred. The image is pre-pulled on control-1 before merge. **Rollback** = revert this commit; the PVC env is still present so Flux redeploys the ROCm-base runtime pod, no rebuild needed.

Image already built, pushed, and locally verified (torch 2.11+rocm7.2 / triton 3.6 / sglang 0.5.14, all three TP=1 patches present).