### PR TITLE
fix(sglang): raise startup-probe budget for baked-image cold boot

### DIFF
--- a/kubernetes/apps/ai/sglang/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/sglang/app/helmrelease.yaml
@@ -113,10 +113,14 @@ spec:
                   initialDelaySeconds: 60
                   periodSeconds: 15
                   timeoutSeconds: 5
-                  # ~16 min budget (60×15s + 60s): a warm boot (image cached, Triton cache warm)
-                  # is ~2-3 min; headroom covers a cold Triton recompile after image/kernel changes.
-                  # Image pull time does not count — the probe starts with the container.
-                  failureThreshold: 60
+                  # ~31 min budget (120×15s + 60s): a warm boot (image cached, Triton cache warm)
+                  # is ~2-3 min, but the FIRST boot on a new image can do a full cold Triton recompile
+                  # (the baked env's JIT cache keys differ from the PVC env that seeded /cache/sglang/triton),
+                  # which the old 16-min budget could miss. Critically, a probe-kill (SIGKILL) of a
+                  # mid-load process LEAKS GPU VRAM on this RDNA4 passthrough — that leak is what turned
+                  # a slow first boot into an unrecoverable crash loop during the OCI cutover — so the
+                  # budget must comfortably outlast the worst-case cold compile. Image pull doesn't count.
+                  failureThreshold: 120
               # Liveness OFF: even TCP probes restart a busy-but-alive singleton under long-prefill /
               # thinking load (exit 0 via SIGTERM + kill_process_tree, dropping in-flight work;
               # observed 2026-06-25 HTTP /health, 2026-06-28 TCP). restartPolicy: Always still


### PR DESCRIPTION
Hardens the sglang HelmRelease before retrying the baked-OCI cutover.

**Why:** the first cutover attempt failed not because of the image (proven functionally identical to the working PVC env) but because the first cold boot on the baked image ran long — a cold Triton recompile (the baked env's JIT cache keys differ from the PVC env that seeded `/cache/sglang/triton`) on a momentarily memory-pressured node — missed the 16-min startup probe, and got **SIGKILLed**. On this RDNA4 passthrough, a SIGKILL of a mid-load process **leaks GPU VRAM** the driver doesn't reclaim, which snowballed into an unrecoverable crash loop that blocked even the rollback.

**Fix:** `failureThreshold` 60 → 120 (~16 min → ~31 min budget) so the first cold boot can finish before the probe can kill it — removing the exact leak trigger. Harmless steady-state (readiness is separate; this only affects cold-boot detection). Can be trimmed once the baked Triton cache is warm on the PVC.