### PR TITLE
feat(litellm): cache embeddings in dragonfly to fix MCP init flakiness

### DIFF
--- a/kubernetes/apps/ai/litellm/instance/proxy.yaml
+++ b/kubernetes/apps/ai/litellm/instance/proxy.yaml
@@ -31,12 +31,9 @@ spec:
   litellmSettings:
     callbacks: ["prometheus"]
     service_callback: ["prometheus_system"]
-    # Chat is near-unique per turn (Redis cache = latency + ~0 hit rate), so scope the cache
-    # to embeddings ONLY. The vmcp-unified optimizer re-embeds the same ~194 tool descriptions
-    # on every MCP session's initialize (otherwise uncached) — a 27-35s iGPU burst that times
-    # out when the embedder is under load or restarting, the root cause of MCP init flakiness.
-    # Caching gives ~100% hit rate after warmup and survives embedder restarts (cache lives in
-    # dragonfly, not the pod). Auth-less dragonfly, the same instance the toolhive backends use.
+    # Cache embeddings only (chat is near-unique per turn, ~0 hit rate). vmcp re-embeds the
+    # same ~194 tool descriptions every MCP initialize; caching turns that into dragonfly hits
+    # that survive embedder restarts, fixing the init timeouts. Auth-less, shared with toolhive.
     cache: true
     cache_params:
       type: redis

--- a/kubernetes/apps/ai/litellm/instance/proxy.yaml
+++ b/kubernetes/apps/ai/litellm/instance/proxy.yaml
@@ -31,7 +31,19 @@ spec:
   litellmSettings:
     callbacks: ["prometheus"]
     service_callback: ["prometheus_system"]
-    cache: false
+    # Chat is near-unique per turn (Redis cache = latency + ~0 hit rate), so scope the cache
+    # to embeddings ONLY. The vmcp-unified optimizer re-embeds the same ~194 tool descriptions
+    # on every MCP session's initialize (otherwise uncached) — a 27-35s iGPU burst that times
+    # out when the embedder is under load or restarting, the root cause of MCP init flakiness.
+    # Caching gives ~100% hit rate after warmup and survives embedder restarts (cache lives in
+    # dragonfly, not the pod). Auth-less dragonfly, the same instance the toolhive backends use.
+    cache: true
+    cache_params:
+      type: redis
+      host: dragonfly.database.svc.cluster.local
+      port: 6379
+      supported_call_types: ["embedding", "aembedding"]
+      ttl: 604800 # 7d; tool descriptions are stable, dragonfly runs cache_mode (LRU)
     drop_params: true
     num_retries: 0
   route:

--- a/kubernetes/apps/ai/litellm/ks.yaml
+++ b/kubernetes/apps/ai/litellm/ks.yaml
@@ -11,7 +11,7 @@ spec:
     - name: litellm-operator
     - name: cloudnative-pg-databases
       namespace: database
-    # Embedding cache backend (litellmSettings.cache_params → dragonfly)
+    # Embedding cache backend
     - name: dragonfly-cluster
       namespace: database
   path: ./kubernetes/apps/ai/litellm/instance

--- a/kubernetes/apps/ai/litellm/ks.yaml
+++ b/kubernetes/apps/ai/litellm/ks.yaml
@@ -11,6 +11,9 @@ spec:
     - name: litellm-operator
     - name: cloudnative-pg-databases
       namespace: database
+    # Embedding cache backend (litellmSettings.cache_params → dragonfly)
+    - name: dragonfly-cluster
+      namespace: database
   path: ./kubernetes/apps/ai/litellm/instance
   prune: true
   sourceRef:


### PR DESCRIPTION
## Problem

The `vmcp-unified` optimizer re-embeds **all ~194 tool descriptions on every MCP session's `initialize`** — embeddings were uncached. On the iGPU embedder that is a 27–35s burst (the timeout was already raised 30s→120s to cope). When the embedder is under load or restarting, the re-embed exceeds even 120s and `initialize` fails — the root cause of the intermittent MCP flakiness.

## Fix

Enable litellm's cache **scoped to embedding calls only**, backed by the existing auth-less **dragonfly** (the same instance the toolhive backends already use):

- The ~194 tool descriptions are byte-identical every session → **near-100% hit rate after warmup**.
- Per-session re-embeds become **sub-ms cache hits**.
- **Survives embedder restarts** — the cache lives in dragonfly, not the embedder pod. This is the property that would have prevented the outage.
- **Chat stays uncached** (`supported_call_types: ["embedding", "aembedding"]`) — chat is near-unique per turn with a ~0 hit rate, so the previous global `cache: false` was correct for chat but incidentally disabled the embedding win.

Also restores the `dragonfly-cluster` `dependsOn` that the instance refactor dropped, since litellm now depends on it at runtime.

## Notes

- `litellmSettings` maps verbatim to litellm's `litellm_settings` (`x-kubernetes-preserve-unknown-fields: true`), so `cache_params` passes through untouched. Verified via `kustomize build`.
- Dragonfly is auth-less (`--cache_mode=true`, no `--requirepass`), so no secret wiring is needed — matches how immich/nextcloud connect.
- First `initialize` after a tool-catalog change is a one-time cache miss (re-embeds once); rare and acceptable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)