### PR TITLE
fix(sglang): request 18Gi to match measured steady-state, stop control-1 overcommit

### DIFF
--- a/kubernetes/apps/ai/sglang/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/sglang/app/helmrelease.yaml
@@ -146,7 +146,10 @@ spec:
             resources:
               requests:
                 cpu: 2
-                memory: 10Gi
+                # Measured steady-state host RAM is ~17Gi (cgroup memory.current), not 10Gi —
+                # under-requesting let the scheduler overcommit control-1 and OOM-cascade its
+                # neighbours. Reserve realistically; limit stays 32Gi (see below, do not trim).
+                memory: 18Gi
                 squat.ai/dri: &dri 1 # extended resource: request must equal limit
               limits:
                 cpu: 12


### PR DESCRIPTION
## Problem

sglang requests **10Gi** of memory but its host-RAM working set sits at **~17Gi** (measured via cgroup `memory.current`). The scheduler therefore treated ~7Gi of control-1 as free and overcommitted the node, which drove the `SystemOOM` cascade that OOM-killed neighbouring pods (cert-manager, cloudnative-pg, etc.) during the recent incident.

## Fix

Raise the memory **request** to 18Gi so the scheduler reserves realistically and stops overcommitting control-1. Because sglang then uses ~its request rather than 70% over it, its `oom_score` also drops — so it's no longer the kernel's preferred victim.

**The limit is deliberately left at 32Gi.** The existing inline comment documents that `28Gi` and `16Gi` both OOM-killed sglang mid-load and leak GPU VRAM that needs a hypervisor cold-cycle to reclaim — so the ceiling must not be trimmed. This change only corrects the request (a reservation, not a ceiling), so it carries no OOM risk.

## Notes

- Rolling the Deployment triggers a **graceful** sglang restart (~1 min inference blip); graceful shutdown reclaims VRAM cleanly (unlike the OOM-kill path the comment warns about).
- This protects **control-1** (the node that actually cascaded). control-3's separate saturation is pod-density, not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)