### PR TITLE
fix(memory): raise limits below measured peak to stop OOM-kills

### DIFF
--- a/kubernetes/apps/ai/litellm/instance/proxy.yaml
+++ b/kubernetes/apps/ai/litellm/instance/proxy.yaml
@@ -74,4 +74,4 @@ spec:
       memory: 512Mi
     limits:
       cpu: 2
-      memory: 2Gi
+      memory: 5Gi

--- a/kubernetes/apps/observability/grafana/instance/grafana.yaml
+++ b/kubernetes/apps/observability/grafana/instance/grafana.yaml
@@ -54,7 +54,7 @@ spec:
                   memory: 256Mi
                 limits:
                   cpu: 100m
-                  memory: 1Gi
+                  memory: 2Gi
               env:
                 - name: GF_SECURITY_ADMIN_PASSWORD
                   valueFrom:

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -97,7 +97,7 @@ spec:
             cpu: "200m"
             memory: "512Mi"
           limits:
-            memory: "2Gi"
+            memory: "4Gi"
       storage:
         useAllNodes: false
         useAllDevices: false

--- a/kubernetes/apps/web3/monero/p2pool/helmrelease.yaml
+++ b/kubernetes/apps/web3/monero/p2pool/helmrelease.yaml
@@ -60,7 +60,7 @@ spec:
                 memory: 550Mi
               limits:
                 cpu: 500m
-                memory: 1Gi
+                memory: 2Gi
             probes:
               liveness:
                 enabled: true


### PR DESCRIPTION
Four workloads had memory **limits below their measured 3-day peak**, so the kernel cgroup-OOM-killed them on load (litellm was confirmed crashlooping with exit 137, which broke the DB/MCP path during the incident):

| workload | peak | limit | new limit |
|---|---|---|---|
| litellm | 3.6G | 2G | 5G |
| rook-ceph mgr | 4.0G | 2G | 4G |
| grafana | 1.5G | 1G | 2G |
| p2pool | 1.7G | 1G | 2G |

**Limits only — no request changes.** Raising a limit doesn't consume scheduling capacity (only requests do), so this is safe on nodes already at 88–92% requested. It stops the pointless kill/restart thrash on pods whose real footprint already exceeds their ceiling.

Not included: vmsingle (also limit<peak, but its VMSingle CR resource block wasn't safely locatable in this pass) and request-rightsizing (blocked — see notes; the cluster is at capacity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)