### PR TITLE
fix(sglang): raise Deployment progressDeadlineSeconds to 1800s

### DIFF
--- a/kubernetes/apps/ai/sglang/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/sglang/app/helmrelease.yaml
@@ -17,6 +17,25 @@ spec:
     timeout: 30m
     remediation:
       retries: -1 # no rollback: a cold Triton recompile can exceed the upgrade timeout
+  # app-template 5.0.1 doesn't expose the Deployment's progressDeadlineSeconds, and the k8s default
+  # (600s) is shorter than a cold model load here — ~5-8 min normally, ~13-15 min if it OOM-retries
+  # once during the load peak. When that happens Flux/kstatus marks the Deployment "Failed"
+  # (ProgressDeadlineExceeded) mid-boot, so the helm upgrade fails "early" even though the pod then
+  # comes up Ready — wedging the HelmRelease in a failed state (and its rollback can't remediate:
+  # "missing target release"). Raise it to 1800s (= the upgrade timeout) so a slow-but-recovering
+  # boot stays "InProgress" and Flux waits it out instead of failing. progressDeadlineSeconds is a
+  # Deployment.spec field (not the pod template), so patching it never triggers a rollout. The chart
+  # doesn't template it, so a postRenderer is the only way to set it.
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              kind: Deployment
+              name: sglang
+            patch: |-
+              - op: add
+                path: /spec/progressDeadlineSeconds
+                value: 1800
   valuesFrom:
     - kind: ConfigMap
       name: affinity-control-1


### PR DESCRIPTION
**Fixes the HelmRelease wedging permanently.**

**Root cause:** app-template 5.0.1 doesn't template `progressDeadlineSeconds`, so the Deployment used the k8s default **600s**. A cold model load takes ~5-8 min normally, or ~13-15 min when it OOM-retries once during the load peak — past 600s. Flux/kstatus then marks the Deployment `Failed` (ProgressDeadlineExceeded) mid-boot, so the helm upgrade fails "early" even though the pod comes up Ready seconds later — leaving the HelmRelease stuck `failed` with a rollback that can't remediate (`missing target release`). This is what showed up as "sglang failing" today.

**Fix:** a Flux `postRenderer` (same pattern the repo already uses in llmkube) patching `progressDeadlineSeconds: 1800` (= the upgrade timeout) onto the Deployment, so a slow-but-recovering boot stays `InProgress` and Flux waits it out.

**Safe to apply:** `progressDeadlineSeconds` is a `Deployment.spec` field, not the pod template — patching it does **not** trigger a rollout/cold-load. Combined with the drop-cache flag (lower memory peak) and the 31-min startup probe (no leak), this makes the whole cold-load path robust.