### PR TITLE
perf(sglang-image): multi-stage build w/ slim runtime base (~18 GB smaller) + modernize CI

### DIFF
--- a/.github/workflows/build-sglang-rdna4.yaml
+++ b/.github/workflows/build-sglang-rdna4.yaml
@@ -37,34 +37,61 @@ jobs:
         with:
           persist-credentials: false
 
-      # The ROCm "complete" base plus the conda env need ~60-80GB of docker storage — more than
-      # any single runner volume (first run died ENOSPC mid-torch-install). Merge /'s free space
-      # with the ~65GB /mnt volume into one LVM volume mounted at docker's data root.
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@fc881a613ad2a34aca9c9624518214ebc21dfc0c # v10
+      # The `builder` stage (ROCm "complete" ~20GB + conda env ~22GB) needs more docker storage
+      # than /'s free space. Free the preinstalled toolchains, then point docker's data root at the
+      # larger ~75GB /mnt volume. (Replaces the unmaintained easimon/maximize-build-space; keep swap
+      # for the RAM-tight kernel compile.)
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
         with:
-          root-reserve-mb: "2048"
-          swap-size-mb: "4096" # keep some swap — the compile is RAM-tight on a 16GB runner
-          remove-dotnet: "true"
-          remove-android: "true"
-          remove-haskell: "true"
-          remove-codeql: "true"
-          build-mount-path: /var/lib/docker
+          tool-cache: true
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: false # docker moves to /mnt below; pruning / images it abandons is wasted
+          swap-storage: false # keep swap — the kernel compile is RAM-tight
 
-      - name: Restart docker on the enlarged volume
-        run: sudo systemctl restart docker
+      - name: Move docker storage to /mnt
+        run: |
+          sudo systemctl stop docker.service docker.socket
+          sudo mkdir -p /mnt/docker
+          # Merge, don't clobber: preserve any other daemon settings the runner image ships.
+          echo "$(sudo jq '. + {"data-root":"/mnt/docker"}' /etc/docker/daemon.json 2>/dev/null || echo '{"data-root":"/mnt/docker"}')" \
+            | sudo tee /etc/docker/daemon.json
+          sudo systemctl start docker.service
+          docker info --format 'docker data root: {{.DockerRootDir}}'
+          df -h /mnt
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Log in to GHCR
-        env:
-          GHCR_USER: ${{ github.actor }}
-          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: echo "${GHCR_TOKEN}" | docker login ghcr.io -u "${GHCR_USER}" --password-stdin
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build image
-        run: docker build --tag "${IMAGE}:${TAG}" docker/sglang-rdna4
+      - name: Image metadata (OCI labels)
+        id: meta
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
+        with:
+          images: ${{ env.IMAGE }}
+          tags: type=raw,value=${{ env.TAG }}
 
-      - name: Push
-        run: |
-          docker push "${IMAGE}:${TAG}"
-          DIGEST=$(docker inspect --format '{{index .RepoDigests 0}}' "${IMAGE}:${TAG}")
-          echo "Pushed ${DIGEST}" | tee -a "${GITHUB_STEP_SUMMARY}"
+      # provenance/sbom left off: this image is pulled only by our own cluster, pinned by digest —
+      # attestations would turn the tag into an OCI index and complicate that pin for no gain here.
+      - name: Build and push
+        id: build
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: docker/sglang-rdna4
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          provenance: false
+          sbom: false
+
+      - name: Summary
+        run: echo "Pushed \`${IMAGE}:${TAG}@${{ steps.build.outputs.digest }}\`" >> "${GITHUB_STEP_SUMMARY}"

--- a/docker/sglang-rdna4/Dockerfile
+++ b/docker/sglang-rdna4/Dockerfile
@@ -9,8 +9,14 @@
 #
 # Builds WITHOUT a GPU — the HIP kernels cross-compile; see the setup.sh step below and README.md.
 #
+# Two-stage build: the `builder` compiles the kernels + conda env with the full ROCm "complete"
+# SDK; the runtime stage ships from the slim non-complete base and copies only the built env
+# (~18 GB smaller). See README.md "Two-stage build" for the why (torch bundles its own ROCm
+# runtime, so the dev SDK is build-only) and the Triton-JIT cold-boot validation it requires.
+
+# ===== Stage 1: builder — full ROCm SDK, compiles the kernels + conda env =====
 # Base pinned by digest — community tags get rebuilt in place (memo project_ik_llama_image_tags).
-FROM docker.io/rocm/dev-ubuntu-24.04:7.2.4-complete@sha256:92f309c51b52cef8762867848f1529dee821624f23cd5df38455e819538f762f
+FROM docker.io/rocm/dev-ubuntu-24.04:7.2.4-complete@sha256:92f309c51b52cef8762867848f1529dee821624f23cd5df38455e819538f762f AS builder
 
 # gfx1201 is native on ROCm 7.x — do NOT set HSA_OVERRIDE_GFX_VERSION.
 # ENV_NAME / REPO_DIR / SGLANG_DIR pin the paths the fork's common.sh now defaults to the
@@ -69,7 +75,11 @@ WORKDIR ${REPO_DIR}
 RUN sed -i "s|assert torch.cuda.is_available(), 'CUDA not available'; ||" scripts/setup.sh \
     && ! grep -q "assert torch.cuda.is_available" scripts/setup.sh \
     && grep -qF "device_count()} GPUs" scripts/setup.sh
-RUN SGLANG_TAG="${SGLANG_TAG}" ./scripts/setup.sh
+# conda clean in the SAME layer as the multi-GB download/solve so the pkg cache never lands in a
+# committed layer — keeps the builder small on the runner's build disk (the multi-stage COPY needs
+# builder + runtime bytes resident at once).
+RUN SGLANG_TAG="${SGLANG_TAG}" ./scripts/setup.sh \
+    && "${CONDA_BASE}/bin/conda" clean -afy
 
 # --- TP=1 fixes the fork's setup.sh omits (it targets dual-card TP=2). Mirrors ---
 # --- scripts/sglang-env-rebuild.sh. Each grep -q fails the build if the sed missed ---
@@ -94,9 +104,32 @@ RUN "${CONDA_BASE}/bin/conda" run -n "${ENV_NAME}" pip install /opt/rocm/share/a
       || echo "(amdsmi install failed — non-fatal; SGLang falls back to torch VRAM detection)"
 
 # Hard gate: fail the build unless sglang actually imports from the patched env — a silently-missed
-# patch or a swallowed setup.sh failure dies HERE, not at runtime. Then clean. Mirrors env-rebuild.sh.
-RUN "${CONDA_BASE}/bin/conda" run -n "${ENV_NAME}" python -c "import sglang; print('sglang', sglang.__version__)" \
-    && "${CONDA_BASE}/bin/conda" clean -afy
+# patch or a swallowed setup.sh failure dies HERE.
+RUN "${CONDA_BASE}/bin/conda" run -n "${ENV_NAME}" python -c "import sglang; print('sglang', sglang.__version__)"
+
+# ===== Stage 2: runtime — slim non-complete ROCm base, only the built env copied in =====
+# The non-complete base is the coherent ROCm runtime without the ~18 GB dev SDK (headers, static
+# libs, docs, every math component). Pinned by digest like the builder base.
+FROM docker.io/rocm/dev-ubuntu-24.04:7.2.4@sha256:bdc8e61026cbb844ede93d44d2c50055f51ebb2041906b60182bf3bee3139054
+
+ENV ROCM_PATH=/opt/rocm \
+    CONDA_BASE=/opt/conda \
+    ENV_NAME=sglang-triton36-v0514 \
+    REPO_DIR=/opt/rdna4-inference \
+    SGLANG_DIR=/opt/rdna4-inference/components/sglang
+
+# The built conda env (torch+rocm, triton, sglang, native gfx1201 kernels) and the fork repo
+# (launch.sh, common.sh, chat template, editable sglang). Paths match the builder so the env's
+# baked RPATHs/shebangs (/opt/conda/...) resolve unchanged. Build-only tooling (rust, gcc, git,
+# miniforge installer, the /opt/rocm dev SDK) is left behind in the builder stage.
+COPY --from=builder /opt/conda /opt/conda
+COPY --from=builder /opt/rdna4-inference /opt/rdna4-inference
+
+# Gate on the slim base: importing torch, sglang AND the compiled sgl_kernel dlopens their native
+# libs, so this fails HERE if a runtime lib lived only in the dev SDK left behind in the builder.
+# It does NOT exercise Triton's runtime JIT — that risk is validated at deploy (cold boot, Triton
+# cache cleared).
+RUN "${CONDA_BASE}/bin/conda" run -n "${ENV_NAME}" python -c "import torch, sglang, sgl_kernel; print('torch', torch.__version__, 'hip', torch.version.hip); print('sglang', sglang.__version__)"
 
 # Correctness-critical gfx1201 env from the fork's common.sh::setup_rdna4_env. launch.sh also
 # sets these at runtime (it sources common.sh) — baked here so the image is correct under any

--- a/docker/sglang-rdna4/README.md
+++ b/docker/sglang-rdna4/README.md
@@ -49,6 +49,18 @@ Known GPU-less caveat: `build_skinny_gemms_int4.sh` imports its freshly-compiled
 import needs a device it fails with setup.sh's non-fatal WARNING and the wvSplitK **MoE** kernel
 is skipped. Our `qwen36-27b` is dense and never calls it, so this is harmless for this image.
 
+### Two-stage build (slim runtime, ~18 GB smaller)
+
+The Dockerfile is multi-stage: the `builder` uses the ROCm **`-complete`** SDK to compile, then the
+final stage starts from the slim **non-complete** ROCm base (1.2 GB vs 7.4 GB compressed) and copies
+only the built conda env + fork repo. This works because torch+rocm bundles its own ROCm runtime
+(~13 GB) and the compiled kernels RPATH to `torch/lib`, not `/opt/rocm` — so the ~18 GB dev SDK is
+build-only. **Validation caveat:** Triton JIT-compiles at runtime and needs its ROCm backend tools
+(vendored under `triton/backends/amd`). The build-time gates (`import torch, sglang` + an `ldd`
+check for dangling kernel libs) do **not** exercise the JIT path — so a new build must be validated
+by a **cold boot with the Triton cache cleared** (`/cache/sglang/triton`) before its digest is
+pinned into the HelmRelease, to prove runtime compilation still works on the slim base.
+
 CI (`.github/workflows/build-sglang-rdna4.yaml`) builds on **`ubuntu-latest`** — zero contact
 with control-1 / live serving, no maintenance window — and pushes the `v0.5.14-gfx1201` tag.
 It fires on a merged change to the build inputs (a Renovate `FORK_REF` / base-digest bump;


### PR DESCRIPTION
## What

- **Multi-stage Dockerfile**: build in the ROCm `-complete` SDK, ship from the slim **non-complete** base and copy only the built conda env + fork repo → image **47 → ~29 GB**. Works because torch+rocm bundles its own ROCm runtime (~13 GB) and the compiled kernels RPATH to `torch/lib`, not `/opt/rocm` — the ~18 GB dev SDK is build-only.
- **CI modernized** (2026): drop the unmaintained `easimon/maximize-build-space`; free disk via `jlumbroso/free-disk-space` + move docker data-root to `/mnt`; build with `docker/build-push-action` + `setup-buildx`/`login`/`metadata` actions, all SHA-pinned.

## Safe to merge (does not deploy)

Merging **rebuilds** the image (new digest under the in-place tag) but the HelmRelease is pinned to the **old** digest, so the serving pod is untouched. The new build is deployed only when its digest is later pinned in (a reviewed Renovate/HelmRelease step).

## ⚠️ Validation required before pinning the new digest

The build-time gate (`import torch, sglang, sgl_kernel` + no dangling libs) does **not** exercise **Triton's runtime JIT**, which needs its ROCm backend on the slim base. Before pinning this image's digest into the HelmRelease, validate with a **cold boot on control-1 with the Triton cache cleared** (`/cache/sglang/triton`) to prove JIT compilation still works. Rollback is the previous digest.

## Known risk

Multi-stage build disk is tight (~71 GB peak vs ~74 GB `/mnt`). It's validate-before-deploy and I added `df -h /mnt` monitoring; if the first run ENOSPCs, the fix is combining `/` + `/mnt`.

## Renovate

Both base digests (`-complete` builder + non-complete runtime) are tracked per-`FROM` and grouped under `sglang-rdna4` (one reviewed PR); the new workflow actions are SHA-pinned with version comments and auto-updated.