### PR TITLE
chore(rook-ceph): drop resource/spec values that only restate chart defaults

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/app/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/app/helmrelease.yaml
@@ -17,5 +17,4 @@ spec:
     resources:
       requests:
         cpu: 100m # unchangable
-        memory: 128Mi # unchangable
       limits: {}

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -52,13 +52,10 @@ spec:
           ms_osd_compression_algorithm: snappy
       cleanupPolicy:
         wipeDevicesFromOtherClusters: true
-      crashCollector:
-        disable: false
       csi:
         readAffinity:
           enabled: true
       dashboard:
-        enabled: true
         urlPrefix: /
         ssl: false
         prometheusEndpoint: http://vmsingle-victoria-metrics.observability.svc.cluster.local:8428
@@ -95,7 +92,6 @@ spec:
         mgr:
           requests:
             cpu: "200m"
-            memory: "512Mi"
           limits:
             memory: "4Gi"
       storage:

--- a/kubernetes/apps/rook-ceph/rook-ceph/csi/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/csi/helmrelease.yaml
@@ -22,7 +22,6 @@ spec:
           replicas: 2
         nodePlugin:
           priorityClassName: system-node-critical
-          kubeletDirPath: /var/lib/kubelet
     drivers:
       rbd:
         enabled: true
@@ -67,7 +66,6 @@ spec:
       cephfs:
         enabled: true
         name: rook-ceph.cephfs.csi.ceph.com
-        snapshotPolicy: volumeSnapshot
         controllerPlugin:
           replicas: 2
           resources: *csiControllerResources


### PR DESCRIPTION
## Summary
- Removed `crashCollector.disable`, `dashboard.enabled`, cluster `mgr.requests.memory`, operator `requests.memory`, CSI `kubeletDirPath`, and `cephfs.snapshotPolicy` from the rook-ceph HelmReleases — each value exactly restated its chart's own shipped default with zero behavioral effect.
- Verified via `helm template` diff on the affected chart (`rook-ceph` v1.20.2) that the rendered manifest is byte-identical with and without the removed operator `memory: 128Mi` line.
- Values inside list-type fields (`cephBlockPools`, `cephFileSystems`, etc.) were deliberately left untouched — Helm replaces lists wholesale rather than deep-merging them, so those fields are load-bearing even where they happen to match the chart's shown default.

## Test plan
- [ ] `flux diff kustomization rook-ceph-cluster` / `flux diff kustomization rook-ceph-csi` (or dry-run apply) shows no unintended changes to the rendered CephCluster/CSI resources
- [ ] Confirm rook-ceph-operator, cluster, and CSI HelmReleases reconcile cleanly after merge