### PR TITLE
fix(vmcp): add resource limits to ha VirtualMCPServer to prevent OOMKill

### DIFF
--- a/kubernetes/apps/ai/toolhive/config/virtualmcpservers.yaml
+++ b/kubernetes/apps/ai/toolhive/config/virtualmcpservers.yaml
@@ -51,6 +51,17 @@ metadata:
   name: ha
 spec:
   replicas: 2
+  podTemplateSpec:
+    spec:
+      containers:
+        - name: vmcp
+          resources:
+            requests:
+              cpu: 100m
+              memory: 512Mi
+            limits:
+              cpu: 500m
+              memory: 1Gi
   sessionStorage:
     provider: redis
     address: dragonfly.database.svc.cluster.local:6379


### PR DESCRIPTION
Add podTemplateSpec with resource limits to the ha VirtualMCPServer matching the unified vmcp pattern:

- requests cpu: 100m, memory: 512Mi
- limits cpu: 500m, memory: 1Gi

This prevents OOMKill by providing explicit resource limits for the Home Assistant VirtualMCPServer.