### PR TITLE
perf(sglang): tune scheduler admission and cache write policy

### DIFF
--- a/docs/llm-hosting/sglang-blockers.md
+++ b/docs/llm-hosting/sglang-blockers.md
@@ -192,6 +192,16 @@ extension probe (`/v1/completions`, request B = A's prompt + A's output + more),
 release newer than v0.5.14 exists; main is ~545 commits ahead with unreleased hicache/mamba fixes —
 the pinned fork tree carries stock v0.5.14 hicache code (no fork patch touches it).
 
+**L3 disk tier trialled and removed (2026-07-08):** a disk-backed third tier below the RAM L2
+(`--hicache-storage-backend file` on control-1's local virtio disk, capped 80 GB via
+`SGLANG_HICACHE_FILE_BACKEND_MAX_SIZE`) was measured over 6h+ real traffic plus repeated synthetic
+load with intentionally-reused prefixes. It logged a 0% hit rate throughout and cost measurable
+throughput in a clean A/B (L3 off completed more requests with fewer aborts). At this working-set
+size the RAM L2 already holds every reused prefix, so the disk tier only added write traffic —
+removed from the helmrelease. `write_back` write policy was kept: it is an L1→L2 (GPU→host)
+optimization independent of any storage backend. Don't re-propose L3 without a working set that
+overflows L2.
+
 **When to revisit:** (1) HiCache: on the next FORK_REF/tag bump, re-check #29034/#30314/#24121 — a
 release with the unified-tree fixes could restore `--hicache-size` sizing and remove the stall risk.
 (2) If a future fork rebase relaxes the `no_buffer`→overlap-off constraint, re-test overlap+cache.

--- a/kubernetes/apps/ai/sglang/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/sglang/app/helmrelease.yaml
@@ -139,7 +139,19 @@ spec:
               # guard passes at boot). Issue-by-issue rationale + the #30314 stall risk live in
               # docs/llm-hosting/sglang-blockers.md ("HiCache re-check"). HiCache never pages an
               # ACTIVE request's KV, so the ctx ≤ KV-pool clean-rejection invariant above still holds.
-              EXTRA_ARGS: '--max-mamba-cache-size 48 --served-model-name qwen-3.6 --mamba-ssm-dtype bfloat16 --max-queued-requests 32 --weight-loader-drop-cache-after-load --enable-hierarchical-cache --hicache-io-backend direct --hicache-ratio 1.5 --model-loader-extra-config {"num_threads":2}'
+              # schedule-conservativeness 0.1 (2026-07-08): default (1.0) reserves a large per-request
+              # token margin before admitting into a running batch, which under concurrent long-context
+              # load left requests queueing (p99 ~250s) until the CLIENT gave up — sglang itself never
+              # rejected them (0 server aborts throughout testing). Swept 1.0/0.5/0.3/0.2/0.15/0.1 with
+              # synthetic concurrent load; 0.1 gave the best observed abort rate (0%) with no retraction
+              # cost (0 retracted at every value tested) — HiCache's cheap host-tier reload is what makes
+              # a smaller admission margin safe now (a wrong guess costs ms, not a 155-303s re-prefill).
+              # hicache-write-policy write_back (2026-07-08): default (write_through) copies every cached
+              # node to the host tier on first hit, whether or not it's ever reused. write_back skips those
+              # per-hit copies and only backs a node up at eviction (then demotes it to host instead of
+              # dropping it), cutting GPU→host write amplification on the hot path. (A disk-backed L3 tier
+              # was trialled and dropped — see docs/llm-hosting/sglang-blockers.md "HiCache re-check".)
+              EXTRA_ARGS: '--max-mamba-cache-size 48 --served-model-name qwen-3.6 --mamba-ssm-dtype bfloat16 --max-queued-requests 32 --weight-loader-drop-cache-after-load --enable-hierarchical-cache --hicache-io-backend direct --hicache-ratio 1.5 --model-loader-extra-config {"num_threads":2} --schedule-conservativeness 0.1 --hicache-write-policy write_back'
             probes:
               startup: &probeBase
                 enabled: true


### PR DESCRIPTION
Two live-validated SGLang serving tunables, plus a documented rejected alternative.

## Changes

- **`--schedule-conservativeness 1.0 → 0.1`** — the default reserves a large per-request admission margin that, under concurrent long-context load, left requests queueing (p99 ~250s) until clients gave up (sglang itself never aborted them). Swept `1.0/0.5/0.3/0.2/0.15/0.1` under synthetic load; `0.1` gave the best abort rate (0%) with zero retraction cost at every tested value.
- **`--hicache-write-policy write_back`** — defers the GPU→host KV backup from per-hit to eviction time, cutting write amplification on the hot path. Traced against the fork source to confirm it is an L1→L2 optimization, independent of any storage backend.

## Removed / documented as rejected

- A disk-backed **HiCache L3 tier** was trialled (2026-07-07/08) and removed from this PR: 0% hit rate over 6h+ real traffic plus repeated synthetic load, and measurable throughput cost in a clean A/B — the RAM-backed L2 already holds the reused prefixes at this working-set size. The finding is recorded in `docs/llm-hosting/sglang-blockers.md` ("HiCache re-check") so it is not re-proposed.

## Validation

Both settings were validated by live-patching the running deployment under synthetic concurrent load before landing here.
