### PR TITLE
toolhive: fix unified VMCP resources, simplify, add probes

### DIFF
--- a/kubernetes/apps/ai/toolhive/config/virtualmcpservers.yaml
+++ b/kubernetes/apps/ai/toolhive/config/virtualmcpservers.yaml
@@ -162,11 +162,35 @@ spec:
               value: ${LITELLM_API_KEY}
           resources:
             requests:
-              cpu: 100m
-              memory: 256Mi
+              cpu: 200m
+              memory: 1Gi
             limits:
               cpu: 500m
-              memory: 1Gi
+              memory: 2Gi
+          startupProbe:
+            httpGet:
+              path: /health
+              port: http
+              scheme: HTTP
+            failureThreshold: 30
+            periodSeconds: 5
+            initialDelaySeconds: 0
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+              scheme: HTTP
+            failureThreshold: 3
+            periodSeconds: 10
+            initialDelaySeconds: 120
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: http
+              scheme: HTTP
+            failureThreshold: 3
+            periodSeconds: 10
+            initialDelaySeconds: 30
   sessionStorage:
     provider: redis
     address: dragonfly.database.svc.cluster.local:6379
@@ -195,9 +219,8 @@ spec:
       conflictResolutionConfig:
         prefixFormat: "{workload}_"
     optimizer:
-      # embeddingServerRef intentionally omitted: it provisions a managed TEI server,
-      # which the operator rejects when embeddingProvider is "openai" (admission-time
-      # incompatibility). We route to litellm -> the existing iGPU embedder instead.
+      # embeddingServerRef omitted: operator rejects when embeddingProvider is "openai".
+      # Routes to litellm -> existing iGPU embedder instead.
       embeddingProvider: openai
       embeddingService: http://litellm.ai.svc.cluster.local/v1
       embeddingModel: vmcp-embedding


### PR DESCRIPTION
## What

- Bump unified VMCP memory: 256Mi→1Gi request, 1Gi→2Gi limit
- Add explicit startup/liveness/readiness probes (was relying on operator defaults)
- Simplify verbose config comments

## Why

The unified VMCP aggregates ~194 tools. Cold embedding takes 27-35s on iGPU and 256Mi was causing OOMKilled restarts. /health always returned 200 even when MCP protocol handler was wedged — now Kubernetes probes detect actual failures.