### PR TITLE
fix(media): wire nfs-media component per-app instead of namespace-aggregate

### DIFF
--- a/kubernetes/apps/media/bazarr/ks.yaml
+++ b/kubernetes/apps/media/bazarr/ks.yaml
@@ -10,6 +10,7 @@ spec:
   components:
     - ../../../../components/volsync
     - ../../../../components/nfs-scaler
+    - ../../../../components/nfs-media
   dependsOn:
     - name: cloudnative-pg-cluster
       namespace: database

--- a/kubernetes/apps/media/fileflows/ks.yaml
+++ b/kubernetes/apps/media/fileflows/ks.yaml
@@ -10,6 +10,7 @@ spec:
   components:
     - ../../../../components/volsync
     - ../../../../components/nfs-scaler
+    - ../../../../components/nfs-media
   wait: true
   path: ./kubernetes/apps/media/fileflows/app
   prune: true

--- a/kubernetes/apps/media/kustomization.yaml
+++ b/kubernetes/apps/media/kustomization.yaml
@@ -7,7 +7,6 @@ namespace: media
 components:
   - ../../components/common
   - ../../components/affinity-control-1
-  - ../../components/nfs-media
 
 resources:
   - ./bazarr/ks.yaml

--- a/kubernetes/apps/media/qbittorrent/ks.yaml
+++ b/kubernetes/apps/media/qbittorrent/ks.yaml
@@ -11,6 +11,7 @@ spec:
   components:
     - ../../../../components/volsync
     - ../../../../components/nfs-scaler
+    - ../../../../components/nfs-media
   wait: false
   prune: true
   sourceRef:

--- a/kubernetes/apps/media/qui/ks.yaml
+++ b/kubernetes/apps/media/qui/ks.yaml
@@ -11,6 +11,7 @@ spec:
   components:
     - ../../../../components/volsync
     - ../../../../components/nfs-scaler
+    - ../../../../components/nfs-media
   dependsOn:
     - name: qbittorrent
   wait: false

--- a/kubernetes/apps/media/radarr/ks.yaml
+++ b/kubernetes/apps/media/radarr/ks.yaml
@@ -11,6 +11,7 @@ spec:
   components:
     - ../../../../components/volsync
     - ../../../../components/nfs-scaler
+    - ../../../../components/nfs-media
   wait: true
   prune: true
   sourceRef:

--- a/kubernetes/apps/media/sonarr/ks.yaml
+++ b/kubernetes/apps/media/sonarr/ks.yaml
@@ -11,6 +11,7 @@ spec:
   components:
     - ../../../../components/volsync
     - ../../../../components/nfs-scaler
+    - ../../../../components/nfs-media
   wait: true
   prune: true
   sourceRef:

--- a/kubernetes/apps/media/unpackerr/ks.yaml
+++ b/kubernetes/apps/media/unpackerr/ks.yaml
@@ -9,6 +9,7 @@ spec:
   targetNamespace: *namespace
   components:
     - ../../../../components/nfs-scaler
+    - ../../../../components/nfs-media
   wait: true
   path: ./kubernetes/apps/media/unpackerr/app
   prune: true


### PR DESCRIPTION
## Summary
- The `nfs-media` Component (added in c791dda75) was only included via the `media` namespace's aggregate `kustomization.yaml` — one Kustomization-reconcile scope removed from the 7 apps whose HelmReleases reference its ConfigMap via `valuesFrom`
- That cross-scope reference doesn't resolve at HelmRelease-reconcile time, so `persistence.media.type` gets set with no `server` value → `helm template` fails with `server not set` on all 7 apps (`bazarr`, `fileflows`, `qbittorrent`, `qui`, `radarr`, `sonarr`, `unpackerr`) — this is what's currently red on `main` and on #3800
- Fix: include the component in each affected app's own `ks.yaml`, matching the existing per-app pattern already used for `volsync`/`nfs-scaler`. Removed it from the namespace-aggregate level to avoid two Kustomizations both trying to own the same ConfigMap.
- Confirmed `nfs-scaler` (KEDA scale-to-zero on NFS-down) and `nfs-media` (the `/media` mount values) are intentionally separate components, not a merge candidate — `nfs-scaler` is used by 13 apps including `nextcloud`/`immich`/`kopia` that have nothing to do with the media export, and `jellyfin` mounts media at a different path (`/ext_media`) than `nfs-media` hardcodes.

## Test plan
- [x] `flate test hr -n media` — 17/17 passed (was 7 failing)
- [x] `flate test all` — 272/272 passed, full cluster tree, no regressions