### PR TITLE
fix(sglang): bump sglang-rdna4 image to v0.5.15

### DIFF
--- a/.github/workflows/build-sglang-rdna4.yaml
+++ b/.github/workflows/build-sglang-rdna4.yaml
@@ -26,7 +26,7 @@ permissions:
 
 env:
   IMAGE: ghcr.io/tanguille/sglang-rdna4
-  TAG: v0.5.14-gfx1201 # stable tag, rebuilt in place; Renovate digest-pins it on the HelmRelease
+  TAG: v0.5.15-gfx1201 # stable tag, rebuilt in place; Renovate digest-pins it on the HelmRelease
 
 jobs:
   build:

--- a/docker/sglang-rdna4/Dockerfile
+++ b/docker/sglang-rdna4/Dockerfile
@@ -57,12 +57,38 @@ ARG FORK_REF=a0445f59e9624622ca72895a34dfc1421a345881
 RUN git clone "${FORK_REPO}" "${REPO_DIR}" \
     && git -C "${REPO_DIR}" checkout "${FORK_REF}"
 
+# LOCAL OVERRIDE for the v0.5.15 bump (fork not yet rebased past v0.5.14 as of FORK_REF above):
+# setup.sh's patch loop (git apply -> fallback `patch --fuzz=3`) fails 2 of the fork's 46
+# patches against the v0.5.15 tree. 064 (ministral3 kwarg fix) is dropped outright — it only
+# touches models/ministral3.py, a file we never import (we serve qwen36-27b). 073 (mamba
+# extra_buffer ROCm guard) is NOT obsolete: the same unguarded auto-select-extra_buffer-on-HIP
+# bug it fixed in v0.5.14's server_args.py still exists in v0.5.15, just relocated by a
+# resolution-pipeline refactor into arg_groups/overrides.py::_mamba_radix_cache_resolution — so
+# it's replaced with a hand-rebased patch targeting the new location (same guard, verified via
+# `git apply --check` against the real v0.5.15 blob before being wired in here). This is now
+# OUR patch to maintain until mattbucci ships v0.5.15 support upstream — re-verify both on the
+# next SGLANG_TAG bump.
+COPY patches/073-rdna4-mamba-extra-buffer-hip-fallback-v0515.patch /tmp/073-rebase.patch
+RUN rm -f "${REPO_DIR}/patches/064-ministral3-v0513-keyword-super-init.patch" \
+    && cp /tmp/073-rebase.patch "${REPO_DIR}/patches/073-rdna4-mamba-extra-buffer-hip-fallback.patch"
+
+# 003 (sgl_kernel/__init__.py fallbacks) is applied separately by setup_sgl_kernel.sh, not the
+# main patch loop above, and also fails to apply against v0.5.15 — the file grew a NEW
+# unconditional `from sgl_kernel.infllm_v2 import (...)` (upstream v0.5.15's new sm80/90/120a
+# CUDA-only flash kernels; confirmed via sgl-kernel/CMakeLists.txt they're never built by our
+# ROCm setup_rocm.py path). Rebased to keep 003's original try/except-around-common_ops idiom
+# and extend the same guard to the new infllm_v2 import — those two names are never referenced
+# again in the file, so None on ImportError is inert. Also ours to maintain until v0.5.15.
+COPY patches/003-rdna4-sgl-kernel-fallbacks-v0515.patch /tmp/003-rebase.patch
+RUN cp /tmp/003-rebase.patch "${REPO_DIR}/patches/003-rdna4-sgl-kernel-fallbacks.patch"
+
 # setup.sh: clone stock SGLang @ SGLANG_TAG -> RDNA4 patch series -> conda env $ENV_NAME ->
 # torch 2.11.0+rocm7.2 stable (setup.sh's default; the old 2.12 nightly became unfetchable and
 # faulted with expandable_segments) -> triton 3.6 -> the native gfx1201 HIP kernels.
-# SGLANG_TAG override is REQUIRED: setup.sh defaults to v0.5.13.post1, and the v0.5.14 patch
-# series (001/028/073) only applies cleanly to the v0.5.14 upstream tree.
-ARG SGLANG_TAG=v0.5.14
+# SGLANG_TAG override is REQUIRED: setup.sh defaults to v0.5.13.post1, and the patch series only
+# applies cleanly to the upstream tree it was built against (see the local-override note above
+# for the two v0.5.15 exceptions).
+ARG SGLANG_TAG=v0.5.15
 WORKDIR ${REPO_DIR}
 # GPU-free build: the HIP kernels cross-compile via PYTORCH_ROCM_ARCH=gfx1201 (explicit target,
 # no device probe). setup.sh runs under `set -eo pipefail` and its ONE fatal GPU touch is a

--- a/docker/sglang-rdna4/README.md
+++ b/docker/sglang-rdna4/README.md
@@ -15,13 +15,13 @@ conda-only, no upstream Dockerfile), then applies the three TP=1 fixes `setup.sh
 > exactly (same `FORK_REF`, `SGLANG_TAG`, and the three patches). Keep them in sync — that
 > script remains the emergency PVC-rebuild fallback if the registry is ever unreachable.
 
-## Pins (verified against `env-rebuild.sh`, 2026-06-27)
+## Pins (verified against `env-rebuild.sh`, 2026-07-11)
 
 | Component | Pin |
 |---|---|
 | Base image | `rocm/dev-ubuntu-24.04:7.2.4-complete` @ `sha256:92f309c5…` |
-| Fork ref | `60ffa9501c2c6e5db628e58c7f75b727a6127ebb` |
-| SGLang | `v0.5.14` (stock + the fork's RDNA4 patch series + 3 TP=1 fixes) |
+| Fork ref | `a0445f59e9624622ca72895a34dfc1421a345881` |
+| SGLang | `v0.5.15` (stock + the fork's RDNA4 patch series + 3 TP=1 fixes + 3 local v0.5.15 overrides, see below) |
 | PyTorch | `2.11.0+rocm7.2` (setup.sh default; 2.12 nightly is unfetchable + faults `expandable_segments`) |
 | Triton | `3.6.0` |
 | conda env | `sglang-triton36-v0514` (must match the fork's `common.sh` default `launch.sh` activates) |
@@ -34,6 +34,31 @@ crashes on the first request or OOM-restarts hours in on the first grammar/tool-
 1. `jit_kernel/kvcache.py` `can_use_store_cache() -> False` — JIT store_cache aborts at TP=1 (`kvcache.cuh:204`).
 2. `srt/layers/sampler.py` — gate the cross-TP token-id all-reduce on `world > 1` (NCCL lazy-init OOM).
 3. `pip uninstall kernels` — transformers-5.x's hub-kernels loader crashes `import sglang`.
+
+### Local v0.5.15 patch overrides (ours to maintain until the fork rebases)
+
+The fork's `main` branch hadn't rebased past v0.5.14 as of `FORK_REF` above when upstream shipped
+v0.5.15. Two of the fork's 46 RDNA4 patches don't apply to the v0.5.15 tree; a third gap only
+shows up mid-build. All three are handled in the Dockerfile right after the fork clone, before
+`setup.sh` runs:
+
+- **`064-ministral3-v0513-keyword-super-init.patch`**: dropped. Only touches `models/ministral3.py`,
+  a file we never import (we serve `qwen36-27b`). Still broken on v0.5.15 if you serve Ministral3/Devstral.
+- **`073-rdna4-mamba-extra-buffer-hip-fallback.patch`**: hand-rebased
+  (`patches/073-rdna4-mamba-extra-buffer-hip-fallback-v0515.patch`). Not obsolete, just relocated —
+  v0.5.15's resolution-pipeline refactor moved the mamba-cache-strategy auto-select logic from
+  `server_args.py` into `arg_groups/overrides.py::_mamba_radix_cache_resolution`; same ROCm guard,
+  new location.
+- **`003-rdna4-sgl-kernel-fallbacks.patch`**: hand-rebased
+  (`patches/003-rdna4-sgl-kernel-fallbacks-v0515.patch`). `sgl_kernel/__init__.py` grew a new
+  unconditional `infllm_v2` import (v0.5.15's new CUDA-only kernels, never built by `setup_rocm.py`
+  on ROCm) not covered by the original patch; guarded the same way the file already guards
+  `common_ops`.
+
+Both rebased patches were verified with `git apply --check` against the actual `v0.5.15` tag
+blobs before use. Re-verify all three on the next `SGLANG_TAG` bump — drop any that the fork has
+since fixed upstream. Filed as
+[mattbucci/2x-R9700-RDNA4-GFX1201-sglang-inference#3](https://github.com/mattbucci/2x-R9700-RDNA4-GFX1201-sglang-inference/issues/3).
 
 ## Building — GPU-free, no build host requirement
 
@@ -62,7 +87,7 @@ by a **cold boot with the Triton cache cleared** (`/cache/sglang/triton`) before
 pinned into the HelmRelease, to prove runtime compilation still works on the slim base.
 
 CI (`.github/workflows/build-sglang-rdna4.yaml`) builds on **`ubuntu-latest`** — zero contact
-with control-1 / live serving, no maintenance window — and pushes the `v0.5.14-gfx1201` tag.
+with control-1 / live serving, no maintenance window — and pushes the `v0.5.15-gfx1201` tag.
 It fires on a merged change to the build inputs (a Renovate `FORK_REF` / base-digest bump;
 docs excluded so a README edit can't repush the image) or on manual dispatch
 (`gh workflow run build-sglang-rdna4.yaml`). Build locally with plain
@@ -76,7 +101,7 @@ the deployment — but the HelmRelease uses the repo-wide `tag: <tag>@sha256:<di
 bare `@digest`: Renovate's flux manager needs the tag present to issue digest-bump PRs.
 
 ```bash
-skopeo inspect docker://ghcr.io/tanguille/sglang-rdna4:v0.5.14-gfx1201 --format '{{.Digest}}'
+skopeo inspect docker://ghcr.io/tanguille/sglang-rdna4:v0.5.15-gfx1201 --format '{{.Digest}}'
 ```
 
 ## What's baked vs. supplied at runtime

--- a/docker/sglang-rdna4/patches/003-rdna4-sgl-kernel-fallbacks-v0515.patch
+++ b/docker/sglang-rdna4/patches/003-rdna4-sgl-kernel-fallbacks-v0515.patch
@@ -1,0 +1,40 @@
+diff --git a/sgl-kernel/python/sgl_kernel/__init__.py b/sgl-kernel/python/sgl_kernel/__init__.py
+index 0000000..0000000 100644
+--- a/sgl-kernel/python/sgl_kernel/__init__.py
++++ b/sgl-kernel/python/sgl_kernel/__init__.py
+@@ -15,8 +15,12 @@ else:
+         _preload_cuda_library,
+     )
+
+-    # Initialize the ops library based on current GPU
+-    common_ops = _load_architecture_specific_ops()
++    # Initialize the ops library based on current GPU.
++    # On unsupported platforms (e.g. RDNA4/gfx12xx) gracefully degrade to torch fallbacks.
++    try:
++        common_ops = _load_architecture_specific_ops()
++    except ImportError:
++        common_ops = None
+
+     # Preload the CUDA library to avoid the issue of libcudart.so.12 not found
+     if torch.version.cuda is not None:
+@@ -72,7 +76,14 @@ else:
+     )
+     from sgl_kernel.grammar import apply_token_bitmask_inplace_cuda
+-    from sgl_kernel.infllm_v2 import (
+-        infllmv2_attn_stage1,
+-        max_pooling_1d_varlen,
+-    )
++    # RDNA4/ROCm: infllm_v2 (sm80/90/120a CUDA-only flash kernels, added
++    # upstream v0.5.15) is never built by setup_rocm.py; guard the import
++    # instead of crashing sglang startup for a backend we never select.
++    try:
++        from sgl_kernel.infllm_v2 import (
++            infllmv2_attn_stage1,
++            max_pooling_1d_varlen,
++        )
++    except ImportError:
++        infllmv2_attn_stage1 = None
++        max_pooling_1d_varlen = None
+     from sgl_kernel.kvcacheio import (
+         transfer_kv_all_layer,
+         transfer_kv_all_layer_mla,

--- a/docker/sglang-rdna4/patches/073-rdna4-mamba-extra-buffer-hip-fallback-v0515.patch
+++ b/docker/sglang-rdna4/patches/073-rdna4-mamba-extra-buffer-hip-fallback-v0515.patch
@@ -1,0 +1,27 @@
+diff --git a/python/sglang/srt/arg_groups/overrides.py b/python/sglang/srt/arg_groups/overrides.py
+index 0000000..0000000 100644
+--- a/python/sglang/srt/arg_groups/overrides.py
++++ b/python/sglang/srt/arg_groups/overrides.py
+@@ -1037,12 +1037,19 @@ def _mamba_radix_cache_resolution(view: Any) -> dict:
+     declared: Dict[str, Any] = {"uses_mamba_radix_cache": True}
+     if view.mamba_radix_cache_strategy == "auto":
+         wants_overlap = not view.disable_overlap_schedule
+         wants_paging = view.page_size is not None and view.page_size > 1
+-        if (wants_overlap or wants_paging) and supports_mamba_cache_extra_buffer(
+-            view, model_arch
+-        ):
++        if (
++            (wants_overlap or wants_paging)
++            and supports_mamba_cache_extra_buffer(view, model_arch)
++            # RDNA4/ROCm: extra_buffer needs the FLA kernel (CUDA/MUSA/NPU
++            # only); 'auto' must fall back to no_buffer on HIP instead of
++            # asserting at startup in _validate_mamba_extra_buffer. Mirrors
++            # upstream fork patch 073 (server_args.py), relocated after the
++            # v0.5.15 resolution-pipeline refactor moved this logic here.
++            and (is_cuda() or is_musa() or is_npu())
++        ):
+             declared["mamba_radix_cache_strategy"] = "extra_buffer"
+         else:
+             declared["mamba_radix_cache_strategy"] = "no_buffer"
+             declared["disable_overlap_schedule"] = True
+     return declared

--- a/kubernetes/apps/ai/sglang/README.md
+++ b/kubernetes/apps/ai/sglang/README.md
@@ -1,7 +1,7 @@
 # sglang — Qwen3.6-27B on RDNA4
 
 Primary inference backend for `qwen-3.6`. Serves dense **Qwen3.6-27B-AWQ** on the single
-AMD R9700 (gfx1201/RDNA4, 32 GB) via the **mattbucci SGLang RDNA4 fork** (v0.5.14, torch
+AMD R9700 (gfx1201/RDNA4, 32 GB) via the **mattbucci SGLang RDNA4 fork** (v0.5.15, torch
 2.11+rocm7.2, Triton 3.6), TP=1, prefix-cache on.
 
 Full benchmarks, the optimization ledger and the engine-selection rationale live in
@@ -9,7 +9,8 @@ Full benchmarks, the optimization ledger and the engine-selection rationale live
 
 ## Config at a glance
 
-- **Engine:** SGLang v0.5.14 (mattbucci fork @ `60ffa9501`), `qwen36-27b` preset, TP=1, KV
+- **Engine:** SGLang v0.5.15 (mattbucci fork @ `a0445f59e9`, 3 local v0.5.15 patch overrides —
+  see [`docker/sglang-rdna4/README.md`](../../../../docker/sglang-rdna4/README.md)), `qwen36-27b` preset, TP=1, KV
   dtype fp8_e4m3, mem-fraction 0.875, 48Gi pod limit (~15 GB pinned HiCache host pools + the
   AWQ shard-load transient, ~6 GB at 2 loader threads).
   mem-fraction was cut 0.90→0.875 to free ~0.8 GB VRAM for the co-resident VAAPI transcoders

--- a/kubernetes/apps/ai/sglang/app/scripts/sglang-env-rebuild.sh
+++ b/kubernetes/apps/ai/sglang/app/scripts/sglang-env-rebuild.sh
@@ -10,7 +10,7 @@
 #      WITHOUT IT: periodic HIP-OOM restarts on tool-calling / PR-review traffic.
 #   3. `pip uninstall kernels` — transformers 5.x hub-kernels crashes `import sglang`.
 # It also pins ENV_NAME / SGLANG_DIR / SGLANG_TAG (common.sh defaults point at the author's
-# ephemeral /data/* paths; setup.sh defaults SGLANG_TAG to v0.5.13.post1 — wrong for a v0.5.14 build).
+# ephemeral /data/* paths; setup.sh defaults SGLANG_TAG to v0.5.13.post1 — wrong for our build).
 #
 # HOW TO RUN: bring serving down (the build needs the GPU), then run in a pod on the GPU node with
 # the `sglang` PVC at /cache, same ROCm base image as the Deployment, as root:
@@ -23,9 +23,10 @@
 # COSMETIC, the env is already built by then; this script applies the post-build fixes regardless.
 set -uo pipefail
 
-# v0.5.14 + 46 patches (incl 073 mamba HIP fallback; 065 dropped/upstreamed). Validated 2026-06-27.
+# v0.5.15 + 46 patches (incl 073 mamba HIP fallback; 065 dropped/upstreamed; 064/073/003
+# locally overridden below for v0.5.15, see docker/sglang-rdna4/README.md). Validated 2026-07-11.
 # Bump to rebase onto a newer fork HEAD (also bump SGLANG_TAG below to match the upstream version).
-FORK_REF="${FORK_REF:-60ffa9501c2c6e5db628e58c7f75b727a6127ebb}"
+FORK_REF="${FORK_REF:-a0445f59e9624622ca72895a34dfc1421a345881}"
 
 export ROCM_PATH=/opt/rocm
 export PYTORCH_ROCM_ARCH=gfx1201
@@ -33,7 +34,7 @@ export CONDA_BASE=/cache/sglang/conda
 export ENV_NAME=sglang-triton36-v0514                    # must match the fork common.sh default launch.sh activates
 export REPO_DIR=/cache/sglang/repo-v0514
 export SGLANG_DIR=/cache/sglang/repo-v0514/components/sglang    # PVC path (common.sh default is the ephemeral /data/sgl-v0514)
-export SGLANG_TAG=v0.5.14                                 # CRITICAL: setup.sh defaults to v0.5.13.post1; the v0514 patches (001/028/073) only apply to the v0.5.14 upstream tree
+export SGLANG_TAG=v0.5.15                                 # CRITICAL: setup.sh defaults to v0.5.13.post1; the patch series only applies to the upstream tree it was built against
 export TRITON_CACHE_DIR=/cache/sglang/triton
 export HF_HOME=/cache/hf
 export RUSTUP_HOME=/opt/rust/rustup CARGO_HOME=/opt/rust/cargo
@@ -59,6 +60,81 @@ echo "=== clone fork @ $FORK_REF -> $REPO_DIR ==="
 [ -d "$REPO_DIR/.git" ] || git clone https://github.com/mattbucci/2x-R9700-RDNA4-GFX1201-sglang-inference.git "$REPO_DIR"
 git -C "$REPO_DIR" fetch origin --depth 200
 git -C "$REPO_DIR" checkout "$FORK_REF"
+
+echo "=== v0.5.15 local patch overrides (mirrors docker/sglang-rdna4/Dockerfile) ==="
+# Fork not yet rebased past v0.5.14 as of FORK_REF above. 064 (ministral3) dropped, unused model.
+# 073/003 hand-rebased for v0.5.15 -- see docker/sglang-rdna4/README.md for the why.
+rm -f "$REPO_DIR/patches/064-ministral3-v0513-keyword-super-init.patch"
+
+cat > "$REPO_DIR/patches/073-rdna4-mamba-extra-buffer-hip-fallback.patch" <<'EOF073'
+diff --git a/python/sglang/srt/arg_groups/overrides.py b/python/sglang/srt/arg_groups/overrides.py
+index 0000000..0000000 100644
+--- a/python/sglang/srt/arg_groups/overrides.py
++++ b/python/sglang/srt/arg_groups/overrides.py
+@@ -1037,12 +1037,19 @@ def _mamba_radix_cache_resolution(view: Any) -> dict:
+     declared: Dict[str, Any] = {"uses_mamba_radix_cache": True}
+     if view.mamba_radix_cache_strategy == "auto":
+         wants_overlap = not view.disable_overlap_schedule
+         wants_paging = view.page_size is not None and view.page_size > 1
+-        if (wants_overlap or wants_paging) and supports_mamba_cache_extra_buffer(
+-            view, model_arch
+-        ):
++        if (
++            (wants_overlap or wants_paging)
++            and supports_mamba_cache_extra_buffer(view, model_arch)
++            and (is_cuda() or is_musa() or is_npu())  # RDNA4/ROCm: extra_buffer
++            # needs the FLA kernel (CUDA/MUSA/NPU only); fall back to
++            # no_buffer on HIP instead of asserting at startup.
++        ):
+             declared["mamba_radix_cache_strategy"] = "extra_buffer"
+         else:
+             declared["mamba_radix_cache_strategy"] = "no_buffer"
+             declared["disable_overlap_schedule"] = True
+     return declared
+EOF073
+
+cat > "$REPO_DIR/patches/003-rdna4-sgl-kernel-fallbacks.patch" <<'EOF003'
+diff --git a/sgl-kernel/python/sgl_kernel/__init__.py b/sgl-kernel/python/sgl_kernel/__init__.py
+index 0000000..0000000 100644
+--- a/sgl-kernel/python/sgl_kernel/__init__.py
++++ b/sgl-kernel/python/sgl_kernel/__init__.py
+@@ -15,8 +15,12 @@ else:
+         _preload_cuda_library,
+     )
+
+-    # Initialize the ops library based on current GPU
+-    common_ops = _load_architecture_specific_ops()
++    # Initialize the ops library based on current GPU.
++    # On unsupported platforms (e.g. RDNA4/gfx12xx) gracefully degrade to torch fallbacks.
++    try:
++        common_ops = _load_architecture_specific_ops()
++    except ImportError:
++        common_ops = None
+
+     # Preload the CUDA library to avoid the issue of libcudart.so.12 not found
+     if torch.version.cuda is not None:
+@@ -72,7 +76,14 @@ else:
+     )
+     from sgl_kernel.grammar import apply_token_bitmask_inplace_cuda
+-    from sgl_kernel.infllm_v2 import (
+-        infllmv2_attn_stage1,
+-        max_pooling_1d_varlen,
+-    )
++    # RDNA4/ROCm: infllm_v2 (sm80/90/120a CUDA-only flash kernels, added
++    # upstream v0.5.15) is never built by setup_rocm.py; guard the import
++    # instead of crashing sglang startup for a backend we never select.
++    try:
++        from sgl_kernel.infllm_v2 import (
++            infllmv2_attn_stage1,
++            max_pooling_1d_varlen,
++        )
++    except ImportError:
++        infllmv2_attn_stage1 = None
++        max_pooling_1d_varlen = None
+     from sgl_kernel.kvcacheio import (
+         transfer_kv_all_layer,
+         transfer_kv_all_layer_mla,
+EOF003
 
 echo "=== setup.sh (conda env + torch 2.11 stable + triton 3.6 + native gfx1201 kernels) ==="
 cd "$REPO_DIR"


### PR DESCRIPTION
## Summary
- Fork not yet rebased past v0.5.14; hand-rebase the 2 of 46 RDNA4 patches relevant to our `qwen36-27b` preset (073 mamba/ROCm cache guard relocated by v0.5.15's resolution-pipeline refactor; 003 sgl_kernel init, new unconditional infllm_v2 import gap), drop 064 (ministral3, unused model)
- Mirrors the fix into the PVC rebuild fallback script per the documented sync requirement
- Deployed image digest already pinned on main via #3798; this closes the remaining gap between that and the Dockerfile/CI that actually builds it

## Test plan
- [x] GPU-free build (`docker build --build-arg SGLANG_TAG=v0.5.15 docker/sglang-rdna4`) succeeds
- [x] Cold boot on control-1 R9700, GDN/DeltaNet kernel path active correctly
- [x] Several hours of real production traffic, zero crashes/restarts
- [x] Performance ballpark check vs documented v0.5.14 baseline, no regression signal
- [x] Both rebased patches verified with `git apply --check` against the real v0.5.15 tag blobs