### PR TITLE
feat(kopiur-system): adopt existing kopia repository in place (phase 2/7)

### DIFF
--- a/docs/kopiur-migration-plan.md
+++ b/docs/kopiur-migration-plan.md
@@ -321,39 +321,66 @@ webhook TLS self-provisioned); `kopiur-dashboard` ConfigMap present;
 
 In `kopiur-system`:
 
-- Add `BACKUP_NFS_PATH` to cluster-settings with the same value as
-  `VOLSYNC_NFS_PATH` (both live until Phase 6).
-- Run the migration CLI in GitOps/offline mode against this repo, resolving
-  the existing sops-encrypted per-app secrets from the *live* cluster
-  (already decrypted by Flux — this avoids ever writing the plaintext
-  password to a local file):
+- `BACKUP_NFS_PATH` was already added to cluster-settings in Phase 1 (both
+  live until Phase 6).
+- **Deviation from the original plan**: `-f kubernetes/apps` (offline/GitOps
+  mode) doesn't work in this repo — `ReplicationSource`/`ReplicationDestination`
+  are raw manifests in the `volsync` Kustomize Component, substituted by
+  Flux's `postBuild.substitute` (`${APP}`, `${TRUENAS_IP}`, etc.) only at
+  apply time. Scanning the git tree directly picks up the literal
+  placeholders, not resolved values. Ran against the **live cluster**
+  instead (read-only; no `--apply`), per namespace (`-A` isn't accepted by
+  `migrate volsync`):
   ```bash
-  kubectl kopiur migrate volsync \
-    -f kubernetes/apps \
-    --resolve-secrets --from-cluster-secrets \
-    --out-dir .worktrees/kopiur-migration/generated
+  kubectl kopiur migrate volsync -n ai --resolve-secrets -v
+  kubectl kopiur migrate volsync -n default --resolve-secrets -v
+  kubectl kopiur migrate volsync -n media --resolve-secrets -v
   ```
-- Review stderr's mapped/UNMAPPABLE/ignored accounting for every field the
-  tool touched — nothing should be silently dropped. Our component has no
-  `actions.beforeSnapshot/afterSnapshot` hooks and no `policyConfig` raw
-  policy files, so we don't expect any UNMAPPABLE entries; investigate if
-  any appear.
-- The tool emits `_shared.yaml` (derived `ClusterRepository` + secret) and
-  one file per app with pinned `spec.identity`. Diff `_shared.yaml` against
-  hand-drafted expectations before applying:
-  - `create.enabled` must be **absent or false** (adopt, never initialize —
-    if the tool emitted `create: {enabled: true}`, stop and investigate,
-    that means it didn't detect the fork correctly).
-  - `encryption.passwordSecretRef.namespace` must be **explicit**
-    (kopiur#232 — the controller rejects reconcile without it even though
-    the schema doc string implies it's optional).
-  - `maintenance.enabled` should be **false/absent** here — Phase 3 takes
-    explicit ownership-transfer control instead of leaving this implicit.
-  - Add `scheduleDefaults.timezone: ${TIMEZONE}` (not something the tool
-    infers from VolSync, since VolSync's component never set one).
-- Apply the `_shared.yaml`-derived `ClusterRepository` (commit it as
-  `kubernetes/apps/kopiur-system/kopiur/repository/clusterrepository.yaml`
-  + its `ExternalSecret`/sops secret).
+- stderr accounting: 18 UNMAPPABLE `spec.kopia.moverVolumes` (expected —
+  our repo is inline-NFS via `moverVolumes`, not a PVC, so the tool can't
+  infer a `backend.filesystem.volume.pvc.name`; fixed manually below) and
+  18 UNMAPPABLE `storageClassName`/`accessModes` staging overrides (expected
+  per the tool's own docs — kopiur derives these from the source PVC, no
+  per-policy override exists). No unexpected UNMAPPABLE entries.
+- **The tool emits one namespaced `Repository` object per app** (not a
+  single shared `_shared.yaml`), since each app has its own
+  `${APP}-volsync-secret`. Confirmed via SHA-256 comparison of
+  `KOPIA_PASSWORD` across 6 apps spanning all 3 namespaces (`ai`, `default`,
+  `media`) that every app shares the **same password and the same repo
+  path** (`filesystem:///mnt/repository`) — genuinely one repository, not
+  N separate ones. Consolidated by hand into a single `ClusterRepository`
+  instead of applying 18 redundant `Repository` objects (matching Phase 1's
+  `installScope: cluster` + `credentialProjection` design intent).
+- Fixed the backend: the `Repository`/`ClusterRepository` CRD's
+  `backend.filesystem.volume` supports `oneOf: [pvc, nfs]` — used the
+  inline `nfs: {server: ${TRUENAS_IP}, path: ${BACKUP_NFS_PATH}}` form
+  (same NFS export as Phase 1's operator-level `/repo` mount and the
+  fork's own `moverVolumes`), not a PVC.
+- `allowedNamespaces.list: [ai, default, media]` — explicit, matching the
+  3 namespaces with live volsync apps today (least-privilege for a
+  password-bearing cluster-scoped resource; extend when a new namespace
+  onboards).
+- `create` and `maintenance` left absent (adopt in place; Phase 3 takes
+  explicit ownership-transfer control).
+- `encryption.passwordSecretRef` has an explicit `namespace: kopiur-system`
+  (kopiur#232) and points at a **new** `kopia-nas-password` secret in
+  `kopiur-system` (sops-encrypted, password copied from the live
+  `ai/hermes-volsync-secret` and verified byte-identical via SHA-256 —
+  the plaintext was never printed to any log or chat output) — not one of
+  the 18 existing per-app secrets, since those get deleted in Phase 6.
+- Applied the (renamed to match this repo's convention)
+  `kubernetes/apps/kopiur-system/kopiur/repository/{clusterrepository.yaml,secret.sops.yaml}`,
+  reconciled by a second Flux `Kustomization` document
+  (`kopiur-repository`, `dependsOn: [kopiur]`) appended to
+  `kopiur/ks.yaml`, mirroring the `volsync`/`volsync-maintenance`
+  multi-document pattern exactly (including redeclaring `&namespace` in
+  the second document — kustomize's YAML parser does **not** share
+  anchors across `---`-separated documents, despite `volsync-maintenance`
+  appearing to alias across documents at first glance).
+- Per-app `SnapshotPolicy`/`SnapshotSchedule` objects (identities verified
+  to match `<app>@<namespace>:/data` for all 18 live apps via the dry-run)
+  are **not** applied in this phase — that's Phase 4's reusable Component +
+  canary, not 18 hand-copied one-off files.
 
 Verify (the load-bearing step of the whole plan):
 1. `ClusterRepository` reaches Ready with `create` untouched (wrong password
@@ -375,7 +402,13 @@ Verify (the load-bearing step of the whole plan):
 
 **Rollback**: delete the ClusterRepository — catalog rows vanish, repo data
 untouched (discovered snapshots are Retain-forced).
-**Status**: ☐ not started
+**Status**: ☑ manifests drafted + validated 2026-07-11
+(`kubernetes/apps/kopiur-system/kopiur/{ks.yaml,repository/*}`, committed
+locally on `docs/kopiur-phase1-verified` — `kustomize build` and
+`flate test all` both clean, 277/277). Not yet pushed/applied — the "Verify"
+steps above (ClusterRepository Ready, discovered Snapshot identities,
+snapshot-count cross-check against the 22-identity baseline) are pending
+push authorization and a live reconcile.
 
 ## Phase 3 — Maintenance ownership takeover
 

--- a/docs/kopiur-migration-plan.md
+++ b/docs/kopiur-migration-plan.md
@@ -306,13 +306,16 @@ kopiur.home-operations.com` → 8, kopiur alerts visible in the ruler and the
 dashboard in Grafana. Nothing touches volsync; deleting the Kustomization
 reverts everything.
 
-**Status**: ☑ manifests written + validated 2026-07-11 (`kubernetes/apps/kopiur-system/{kustomization.yaml,kopiur/ks.yaml,kopiur/app/*}`,
-`BACKUP_NFS_PATH` added to cluster-settings); `kustomize build` and a real
-`helm template` dry-run against the pinned chart both confirmed clean
-(NFS volume mounted at `/repo`, podSecurityContext 568, RBAC/Deployments/
-ServiceMonitor/PrometheusRule/dashboard all render). Not yet committed or
-pushed — cluster-side verification (operator Ready, CRD count, alerts live)
-pending push authorization.
+**Status**: ☑ done — merged via PR #3800 (2026-07-11) and verified live in-cluster:
+Kustomization `kopiur` `Ready=True`; `kopiur-controller` + `kopiur-webhook`
+pods `1/1 Running`; `kubectl get crd | grep kopiur.home-operations.com` → 8;
+validating + mutating webhooks registered; `/repo` NFS volume mounted on the
+controller (confirmed via pod spec + clean startup logs, leader elected,
+webhook TLS self-provisioned); `kopiur-dashboard` ConfigMap present;
+`PrometheusRule/kopiur-controller` live with 6 alerts
+(`KopiurBackupConsecutiveFailures`, `KopiurBackupStale`,
+`KopiurRepositoryNotReady`, `KopiurSnapshotFailed`, `KopiurRestoreFailed`,
+`KopiurReconcileErrorsHigh`). No volsync apps touched.
 
 ## Phase 2 — Adopt the repository via `kubectl kopiur migrate volsync`
 

--- a/docs/kopiur-migration-plan.md
+++ b/docs/kopiur-migration-plan.md
@@ -306,16 +306,10 @@ kopiur.home-operations.com` → 8, kopiur alerts visible in the ruler and the
 dashboard in Grafana. Nothing touches volsync; deleting the Kustomization
 reverts everything.
 
-**Status**: ☑ done — merged via PR #3800 (2026-07-11) and verified live in-cluster:
-Kustomization `kopiur` `Ready=True`; `kopiur-controller` + `kopiur-webhook`
-pods `1/1 Running`; `kubectl get crd | grep kopiur.home-operations.com` → 8;
-validating + mutating webhooks registered; `/repo` NFS volume mounted on the
-controller (confirmed via pod spec + clean startup logs, leader elected,
-webhook TLS self-provisioned); `kopiur-dashboard` ConfigMap present;
-`PrometheusRule/kopiur-controller` live with 6 alerts
-(`KopiurBackupConsecutiveFailures`, `KopiurBackupStale`,
-`KopiurRepositoryNotReady`, `KopiurSnapshotFailed`, `KopiurRestoreFailed`,
-`KopiurReconcileErrorsHigh`). No volsync apps touched.
+**Status**: ☑ done — merged via PR #3800 (2026-07-11); all Verify criteria
+above confirmed live in-cluster the same day (Kustomization `Ready=True`,
+CRD count 8, 6 `PrometheusRule/kopiur-controller` alerts, dashboard present).
+No volsync apps touched.
 
 ## Phase 2 — Adopt the repository via `kubectl kopiur migrate volsync`
 

--- a/kubernetes/apps/kopiur-system/kopiur/ks.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/ks.yaml
@@ -20,3 +20,22 @@ spec:
     namespace: flux-system
   targetNamespace: *namespace
   wait: true
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: kopiur-repository
+  namespace: &namespace kopiur-system
+spec:
+  dependsOn:
+    - name: kopiur
+  interval: 1h
+  path: ./kubernetes/apps/kopiur-system/kopiur/repository
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  wait: true

--- a/kubernetes/apps/kopiur-system/kopiur/repository/clusterrepository.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/repository/clusterrepository.yaml
@@ -1,0 +1,26 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kopiur.home-operations.com/clusterrepository_v1alpha1.json
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: ClusterRepository
+metadata:
+  name: kopia-nas
+spec:
+  allowedNamespaces:
+    list:
+      - ai
+      - default
+      - media
+  backend:
+    filesystem:
+      path: /repo
+      volume:
+        nfs:
+          server: "${TRUENAS_IP}"
+          path: ${BACKUP_NFS_PATH}
+  encryption:
+    passwordSecretRef:
+      name: kopia-nas-password
+      namespace: kopiur-system
+      key: KOPIA_PASSWORD
+  scheduleDefaults:
+    timezone: ${TIMEZONE}

--- a/kubernetes/apps/kopiur-system/kopiur/repository/kustomization.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/repository/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - clusterrepository.yaml
+  - secret.sops.yaml

--- a/kubernetes/apps/kopiur-system/kopiur/repository/secret.sops.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/repository/secret.sops.yaml
@@ -1,0 +1,63 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kopia-nas-password
+type: Opaque
+stringData:
+  KOPIA_PASSWORD: ENC[AES256_GCM,data:FLJXc5Fe08s=,iv:bwcE3aH4/gM8NVbIzWgQmduBpKucVd5pE9NfcVLnzSc=,tag:jdD2sWnVCW3m8QbBbkjQpQ==,type:str]
+sops:
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAvSEZjS0xZNkNRRFluZlRl
+        Q2JEQTZsbDBPdmVMVzdCUVVVWmppM1dRSnlnCks0Z2RWcTRqRDU3OW9mTExiTFR4
+        SWZualFMaHY3Y3hvaklwM3V0cTE3dEEKLS0tIFdEbmN2ay9pV09yOHU2ZEkwWFY4
+        MXJDbU5nRGxhRmQwdXUrS0YwK0Z1OEUKU3hDRZKMUeFiZni04yh8oLoXiIsivkq2
+        9JV1LQBzs2UTGVu4jDjFDhU0ZBCYCWKvFTnCqhzRGcAVV9pwB4+65Q==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age12gul5m0dg9nn2gk69uvzwdxyluh5xt02m8wvyg9hn7c93nz7xehswmdenq
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IG1sa2VtNzY4eDI1NTE5IFVyMXN6REkz
+        WDU0ZE43QWh0ZG9Zek1lb3J3T3pYTk0xNlJJbmRscHBjRWh1c2RETjBHTm1zd2ZU
+        K3ZPNnBtQnVaZnZMZmgwb3FtYnRUdTJ5RllWNWgvUTQzZ3ZuMGZpUFI5VEJoRURy
+        cmpTVjlxc0FGTmg5VzViUERlUHAwSCs5TmlCaVVLQjV2QUtyUmlEWnN3Y2Q1NEJs
+        Q3lqandCSFlmQmwxenhOZkh6RHV2cUFlK3p6cWtBZWlsMjc4d2ZlYkpWcGNNZEZq
+        blZkc05IakxUb1VRNTVId2wxNE9JWGxoMGlqbXNaa0RGNWFFRUtkYTRoMndVVVdU
+        SzRDWG9jUjFWRFZZTjlQeDA2YWdpM2w1Z3RhZzBkSHdjbVRheHFPQVkzanlUTmJG
+        Y28rU0ZrVWE1aU1ORHhjM1ZzM1FPVnhPUnR3NUtjSUZiQ0RDZXVLOE9IVTgvaVZQ
+        NHdxNHBoeFVPNFFnOWpYNTJFTXgvYlN1dWJXSzJtOS8wY0JFMTE1KzZBYzJEZndO
+        Z2lRV0llOTdDdmZpSGJZU3JTYnNKRDRoTXNIT0VRWER6YlVTeCtTR1F2UXBnaktr
+        ejJMYTFVamlyM3Y2OFlIbk04RGNOZ2djL0o5QUxiV3M3YlZLbUVqNldjandoNE9L
+        cnczbmc0aXBUUmhPU0FORzRJSS9hN1ZLS3laQUZTYUlvRkZPK2ZQTWYyRkNtcUE1
+        cGdRZGJ5cXA2L0hDeVQ2ZG9CSnNod1QwWnZLWDhnME9uaDU3Mm02NUc2UkhoWVYw
+        bUtoMUxZK3lnVDB2aS9uUExhSjB4UkIzejlrc0JSVHBiMWY5elN3TlYxTEd2R3lj
+        Wm1iSFNmaXRIRXl1TWxmOHFiQzE5R2tpMDRhbjdlbTdLT2pPUk51QXF2dFhhcVVI
+        bVZMOWZWeHJ1c3h5U0JTVkdIa0RYdXRzRHZyT1REc1lxUGxwUVo1Y1h0Rk5Nem1u
+        Q3NZWmUySDVYeFBFWitaQWl0UXFTSnJ5czIrK1BWOXNnRUxqVlpJVjNqT2RBQUxR
+        bTArREhTckxyVU1QUnBKMHd2cEQ2ZzNUZGNCSzVpWStuMWZOVGFQY2NyWWFpeEJM
+        NENYU2s4NmdMcFNSUlNJYVNBeWdBMzVBK3A1NVMzUitZSWI2VmhjNWZrUmgxdkZU
+        eVhPZVo4S0pkaGFoRS9YK3luQ0Q5UjJuYkc0M0tMVm1lU3ZHOFYvcXVteVlQVnVi
+        b2lweWt6bTNjNXNyQWlQQzIzbUhTU0JaZm1pUVV3dzFSYy9kQXFJTkJmUXRGYXhY
+        SkNzNENoZ2VTTU1LZVNYWmJxS21PZVhzcm5sL0srWFBaS3BTYkdJNFlZQi9FTXFV
+        UHAwY01oZFBQL1NXdzB5clhBY1cwaVBCdlk1Tlo0R3hxMW12WGxDT3V4VE5ML1hZ
+        Y2FJbmhFN3FuNXMydEhIQnEyYlBPN1VMR0FRRit6R2RYR01EMW5rQ0lpVVJPbG9p
+        UmhrT3pxWEd3QjliRG9aRmhkSzlQaTZCZUVIbitDTTJSWVN1TUVid080bHZtKzV2
+        QUs0MzY5WER4ejhmSjVkT0Y0TjNNNnh0MDhmQTF1dDQvdU9MZFh5NmdaMVprcnJr
+        MTExSU9FV0pLTVdmSi9EOWVHVjVxakNCdDVDaHQ2YVpUZXZHZGJTM0dYZW4rT0Qw
+        dWVIdjczcW83MDhkQ2RaSXJSV2plUGJXWE5iQ0tOaFJrTGlwVGRkbEkrMUcvelJ3
+        a2JjTU5zQU44aU1tUmZ0emo0c1lIWDBxNWxPL1N5RG5hR2ZJb2xiRTJ6S05uSlVT
+        VitUSXJKOWYxOWVkelVnWGNleEt6RnNGWnNRZkVrQWFaTGtNanBBVmVLdmZwS01i
+        cE9ydndTNS8zRVVsUEJ2cS9ERFhhZzVhK25TU3VrdmlyTG4wSHk3RGZWWEdUZmx5
+        NDhROExQMmgzS0xFdDZLcEFPV1hCR0J5bGFkQlg4ZmhsREloeXpzUlpuVzFLUQpm
+        TWhvV1NFcEZsZmp4UzR3cTNYbGR0YVc4MWJxRjZlQjVpay80dFF0TVNFCi0tLSA5
+        YW1Ld2crNlNqTGxjMWk3aG56Qk0wVTc1TC8yUU1ZeXNPMW8wd0M0VkNjCpi8a1y4
+        19SugLI+83eoOF7mFRrwvDCrneJPo8zuVXls60Sq68RaSlhXL/5ZIgyeevHXuIBS
+        owakTfvXpHVWBq4=
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1pq1f696t70thmae32r7s6eqscyncz4tveaqsd53k2pw82kems2v02mcmeuj4j85swr6zdp3z3ay6kuq26z9d37928w58se3a7cvghzzlthmhfmdcn66sc8kcwp56672yjn5szvqet5q5v46a3kphepytfstdah95v95awn25jvc8ce2nmes0cqykax6n2tkf94pxqcjkn55wjjrgmk2dgh2xggl5gskxy4t20x88pqqtgnfe8pyymfuwmy3e9muvja9x3gf8can07seky8hv6ve9v0auzdyhpa2xwczme5ejxtdx6xtqp47cwe8q026gzh5wz0x82dezz5jkgznskq960ltwtfxsdj27seql0rtu3jqqkkm4xgqcfzjnxrzyevea8vgz5hr8053yt56qd9r6umydx93usfuzznen9wlew6500ydcqpjk2jm4x0ewy34ngjpj4uwu4p5dzynca4grrfghsnllum865u9f8py3nq69r0kjarppxfgvfgptuqpxkar2wvq7r8ys4vuuc2pj0433ceax49znp8sfqj5dl29ulcczqqw20pcjygxkc26tzv35ln8c7jjfre957v88wq9n8xxf4qgw3wpv2hh74gwuacnr2f4krkxzjs45a46v62jdkgmq0qnk3vhe9s2kgfjw3dzn6d4fnwyrt4ke6fverqc4x4mxpj6ffahw3mqv8g6vjgg2p46u53zrhgsnyr4x5dmxsmmpzdhjdu436ey89qmxgca8sjdwuzjhcvtewm9yppzjs9ef2p8q2mdjfcjh3uu3fq5py04sv8pskjvqd9y0ta8axmh239u4zlrgpdmwfe7r0wpgt788xgjwjx0vxdjr5gzk4quukyv2rvefjacg38mpwqyjaxv9q294v4f03g5x3ve79c27fgt3u34vmrcty09sje3yw2rraa5x9y5t3u4rtcpu5ay8jrx44u8dfehw5ulgfgqjza0lce4tz6s34uq00ayrg6vk6hgjuql55z6taltx04mjehmkk487ddd5zuzguqu8nvz2d5fhgl6sx3x775zdw29xnr8jgmltyfze2ymsz92u2dk4v70jzfsvc34m3ajkg9965rcqe9nn3aehwcr047p6xfnc55cv6tjewdrg6mff4glrwd9p8q5sa9repr0w3hzw42d9dys6u8hr50v83v8y5lzncql6ty9gfkcc4pcst683ddz2vky7u9g8gkrjy440r8yrsdw5cq6cpj23fjqxrj0t2gj5cpyv6407luycyd8p6pmjym3g46w2aj7f79nce73g30zwr4hx7mz2emrwkkgst53q85zyveg7fen5vtfjc3y6m0f5mkwj3yq5643c3jstgcz9fgsgu5hdx4u27wud5a3kgv8ysdh9z295mxh6j2pp96qwk34jevrqhn8zutwvvzwla53mrqh6czjpq6ud0c0psd7zznkgjczqsppq36ujygqnz4nc5sg40ngkfh3k5qyfdvx4slv9xcaceu83mzzr0unc3y4fznt0dal42z2kye8vxjz4yur33azljufrzg3d0lmxw2n53efhjr8wxtfstz4jjhn9pynzf425jryfpgf23pc6ykm4049qgu2xsz2nyrhty5yjla9xueyxwka77ztx7n6ndak0lg5n2fpveff8j2g49dyp3wqsvqmnm638nxwrd3g4hxqese8mmwt3cmr0jdykdnvqsmd9zumt0e6jkaktpppspsw4szfu7ft79r8gqwspdw7256lqmpr6r6hm2xxv0uwzqw6q3ffcy4y9n7tzxzhr22gf3qwxu8rhq9ceuj8jd4qsc7yexsa27d3dkwelklhk77c8zlf5aeg8y3usluk4y749ltlt7eh5xyf8al09nwljekxe74s7uj0hd07sm0zxgqal48prwgvl9svx0ucvze2yy3yygsqjwpc
+  encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-07-11T14:42:24Z"
+  mac: ENC[AES256_GCM,data:F64eyDsQy3ZwgotBZLd75Ol4KiUqiJWjYlrag8AKZBEJlcHeoeU2sCF5tmQ8XH0+EuDLh6fSVVvFs4573WJAaqx0JHGqzG4hvUYBdNpCheKNJvVxWPS5+Q8pOg6brzk4iWG4ut1aCGUzjuBcatA+y/agiyx/nKvNPLAohgFKB8s=,iv:3vSL7wweMdecDQyytwcI7Rdkd3JMkjZOdJHGVAWY25g=,tag:BLzJbqtQasrJsnX2nKUUFQ==,type:str]
+  mac_only_encrypted: true
+  version: 3.13.2


### PR DESCRIPTION
## Summary
- Marks Phase 1 (operator install, PR #3800) as verified live in-cluster.
- Phase 2: adopts the existing per-app kopia repository (currently backed by the VolSync fork) in place via a single `ClusterRepository`, no `create` block.

## Details
- Confirmed via SHA-256 hash comparison across 6 apps spanning all 3 namespaces (`ai`, `default`, `media`) that every app's `KOPIA_PASSWORD` and repo path are identical — genuinely one shared repository, not 18 separate ones. Consolidated accordingly instead of applying the CLI's raw per-app `Repository` output.
- Backend uses inline NFS (`backend.filesystem.volume.nfs`), matching this repo's existing mover volumes — the CLI assumed a PVC-backed repo and left that field `UNMAPPABLE`.
- New `kopia-nas-password` secret in `kopiur-system` (sops-encrypted), not reused from the 18 existing per-app volsync secrets since those get deleted in Phase 6.
- `allowedNamespaces.list: [ai, default, media]` — explicit, least-privilege for a password-bearing cluster-scoped resource.
- `kopiur-repository` Flux Kustomization added as a second document in `kopiur/ks.yaml` (`dependsOn: [kopiur]`), mirroring the existing `volsync`/`volsync-maintenance` pattern.
- Per-app `SnapshotPolicy`/`SnapshotSchedule` are intentionally **not** included here — that's Phase 4 (reusable component + canary app).

## Test plan
- [x] `kustomize build kubernetes/apps/kopiur-system` — clean
- [x] `flate test all --path ./kubernetes/flux/cluster` — 277/277 passed
- [ ] Post-merge: `ClusterRepository/kopia-nas` reaches `Ready=True`
- [ ] Post-merge: discovered `Snapshot` CRs match `<app>@<namespace>:/data` identities for all 18 live apps
- [ ] Post-merge: snapshot counts match the 22-identity baseline (18 live + 5 orphaned decommissioned-app identities)