### PR TITLE
docs(agents): fix broken commands and stale references across skill docs

### DIFF
--- a/.agents/common-operations.md
+++ b/.agents/common-operations.md
@@ -8,20 +8,19 @@ Step-by-step procedures for frequent cluster tasks.
 
 - Run `flux`, `helm`, `kubectl`, `kustomize`, `sops`, `age`, `talhelper`, `talosctl`, `yq`, `jq`, and `shellcheck` through `mise exec -- <command>`.
 - Kubernetes or mixed changes: `bash .agents/skills/pr-review/scripts/validate-pr.sh` (Kustomize and shellcheck).
-- Shell-only changes: `mise exec -- shellcheck scripts/*.sh`.
+- Shell-only changes: `mise exec -- shellcheck` on every touched `*.sh`.
 - Documentation-only changes: run `git diff --check` and verify every changed local reference exists.
 
 ## Adding a new application
 
-Use **add-app-to-cluster** skill for full procedure.
+Use [add-app-to-cluster](skills/add-app-to-cluster/SKILL.md) skill for full procedure.
 
-1. Create namespace in `kubernetes/components/common/`
+1. For a new namespace, create `kubernetes/apps/<namespace>/kustomization.yaml` with `namespace: <ns>` and component `../../components/common`; existing namespaces need no namespace step
 2. Add OCIRepository if external
-3. Create app in `kubernetes/apps/<app>/`
+3. Create app in `kubernetes/apps/<namespace>/<app>/`
 4. Add Kustomization in appropriate `ks.yaml`
 5. Run validation on the new app (`<namespace>`, `<app-name>`):
-   - `mise exec -- kustomize build kubernetes/apps/<namespace>/<app-name>/`
-   - `mise exec -- shellcheck scripts/*.sh`
+   - `mise exec -- kustomize build kubernetes/apps/<namespace>/<app-name>/app/` (build each subdir that contains a kustomization.yaml)
    - Or: `bash .agents/skills/pr-review/scripts/validate-pr.sh`
 
 ## Secrets management (SOPS)
@@ -36,8 +35,12 @@ Post-quantum age (age1pq1) is supported; see [sops-post-quantum.md](../docs/sops
 
 ## Debugging
 
-Use **debug-cluster** skill for structured 5-Whys analysis and troubleshooting.
+Use [debug-cluster](skills/debug-cluster/SKILL.md) skill for structured 5-Whys analysis and troubleshooting.
 
 ## Backup & Restore
 
-Use **backup-restore** skill for VolSync Kopia operations.
+Use [backup-restore](skills/backup-restore/SKILL.md) skill for VolSync Kopia operations.
+
+## Other skills
+
+See the [skill catalog](../AGENTS.md#load-context-on-demand) for git-worktree-isolation, k8s-at-home-research, pr-review, and prometheus-cluster-health.

--- a/.agents/common-operations.md
+++ b/.agents/common-operations.md
@@ -6,8 +6,8 @@ Step-by-step procedures for frequent cluster tasks.
 
 ## Validation and tooling
 
-- Run `flux`, `helm`, `kubectl`, `kustomize`, `sops`, `age`, `talhelper`, `talosctl`, `yq`, `jq`, and `shellcheck` through `mise exec -- <command>`.
-- Kubernetes or mixed changes: `bash .agents/skills/pr-review/scripts/validate-pr.sh` (Kustomize and shellcheck).
+- Run `flux`, `helm`, `kubectl`, `kustomize`, `flate`, `sops`, `age`, `talhelper`, `talosctl`, `yq`, `jq`, and `shellcheck` through `mise exec -- <command>`.
+- Kubernetes or mixed changes: `bash .agents/skills/pr-review/scripts/validate-pr.sh` (flate — renders Helm charts, not just Kustomization YAML — and shellcheck).
 - Shell-only changes: `mise exec -- shellcheck` on every touched `*.sh`.
 - Documentation-only changes: run `git diff --check` and verify every changed local reference exists.
 
@@ -19,9 +19,7 @@ Use [add-app-to-cluster](skills/add-app-to-cluster/SKILL.md) skill for full proc
 2. Add OCIRepository if external
 3. Create app in `kubernetes/apps/<namespace>/<app>/`
 4. Add Kustomization in appropriate `ks.yaml`
-5. Run validation on the new app (`<namespace>`, `<app-name>`):
-   - `mise exec -- kustomize build kubernetes/apps/<namespace>/<app-name>/app/` (build each subdir that contains a kustomization.yaml)
-   - Or: `bash .agents/skills/pr-review/scripts/validate-pr.sh`
+5. Run validation on the new app: `bash .agents/skills/pr-review/scripts/validate-pr.sh` (or `mise exec -- flate test all` directly, which renders the HelmRelease too — `kustomize build` alone doesn't)
 
 ## Secrets management (SOPS)
 

--- a/.agents/skills/add-app-to-cluster/SKILL.md
+++ b/.agents/skills/add-app-to-cluster/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   user: "Install prometheus exporter" → HelmRelease with custom scrape config
 
   Use proactively when the user mentions deploying, installing, adding, or setting up an application.
-compatibility: Requires `mise`, `git`, `gh` (for PR), `flux`, `kustomize`, and `shellcheck`; cluster apply needs user approval per AGENTS.md.
+compatibility: Requires `mise`, `git`, `gh` (for PR), `flate`, and `shellcheck` (falls back to `kustomize`/`flux` if `flate` is unavailable); cluster apply needs user approval per AGENTS.md.
 ---
 
 # Add app to cluster
@@ -84,13 +84,11 @@ Add `./<app-name>/ks.yaml` to `kubernetes/apps/<namespace>/kustomization.yaml`. 
 
 ### 8. Validate
 
-Replace `<namespace>` and `<app-name>` with your app path:
-
 ```bash
-mise exec -- kustomize build kubernetes/apps/<namespace>/<app-name>/app/
+mise exec -- flate test all
 ```
 
-`${APP}`/`${SECRET_DOMAIN}` staying literal in the output is expected — Flux postBuild substitutes them.
+`${APP}`/`${SECRET_DOMAIN}` staying literal in the output is expected — Flux postBuild substitutes them. `flate` renders the HelmRelease (catches Helm template errors `kustomize build` can't see); if it's unavailable, fall back to `mise exec -- kustomize build kubernetes/apps/<namespace>/<app-name>/app/` (Kustomization-only, no Helm render).
 
 Or run the full local PR check: `bash .agents/skills/pr-review/scripts/validate-pr.sh`
 

--- a/.agents/skills/add-app-to-cluster/SKILL.md
+++ b/.agents/skills/add-app-to-cluster/SKILL.md
@@ -36,27 +36,15 @@ Deploy applications using FluxCD GitOps patterns in this repository.
 
 Use [k8s-at-home-research](../k8s-at-home-research/SKILL.md) to find exemplar manifests — prefers kubesearch MCP when available. Spawn a subagent with the app name and namespace; return the best values and adaptation notes.
 
+Confirm before scaffolding: image + tag (plain upstream tag — Renovate pins digests, never invent one), port, route internal/external, persistence (→ volsync component), secrets (→ `secret.sops.yaml`), config files (→ configMapGenerator), Flux `dependsOn`.
+
 ### 2. Create worktree
 
-```bash
-git worktree add ../<app-name>-worktree -b feat/add-<app-name>
-cd ../<app-name>-worktree
-```
-
-See [git-worktree-isolation](../git-worktree-isolation/SKILL.md) for isolation patterns.
+Use the [git-worktree-isolation](../git-worktree-isolation/SKILL.md) recipe: `.worktrees/feat-add-<app-name>` branched from `origin/main`, with local config copied in.
 
 ### 3. Namespace
 
-| Namespace | Purpose |
-|-----------|---------|
-| `default` | General apps |
-| `network` | Proxies, gateways |
-| `observability` | Monitoring |
-| `media` | Media servers |
-| `database` | Databases |
-| `security` | Security tools |
-
-Confirm with user before creating a new namespace.
+List existing namespaces with `ls kubernetes/apps/` and pick the best fit; confirm with the user before creating a new one.
 
 ### 4. Structure
 
@@ -69,7 +57,13 @@ kubernetes/apps/<namespace>/<app-name>/
     └── ...
 ```
 
-Scaffold YAML: [references/manifest-templates.md](references/manifest-templates.md).
+Scaffold YAML: [references/manifest-templates.md](references/manifest-templates.md). When in doubt, mirror a recent real app — templates may lag:
+
+| Exemplar | Demonstrates |
+|----------|--------------|
+| `kubernetes/apps/media/qui` | volsync persistence, dependsOn, probes, hardened securityContext |
+| `kubernetes/apps/media/sonarr` | sops secret, valuesFrom, homepage annotations |
+| `kubernetes/apps/media/recyclarr` | configMapGenerator config files |
 
 ### 5. HelmRelease essentials
 
@@ -82,23 +76,27 @@ Scaffold YAML: [references/manifest-templates.md](references/manifest-templates.
 
 - Hostname: `{{ .Release.Name }}.${SECRET_DOMAIN}`
 - Internal routes: parentRef `envoy-internal` in namespace `network`
+- External routes: parentRef `envoy-external` in namespace `network` (same shape, only the parentRef name changes)
 
 ### 7. Namespace kustomization
 
-Add `./<app-name>/ks.yaml` to `kubernetes/apps/<namespace>/kustomization.yaml`.
+Add `./<app-name>/ks.yaml` to `kubernetes/apps/<namespace>/kustomization.yaml`. Keep alphabetical order if the file uses it; otherwise append near related apps.
 
 ### 8. Validate
 
 Replace `<namespace>` and `<app-name>` with your app path:
 
 ```bash
-mise exec -- kustomize build kubernetes/apps/<namespace>/<app-name>/
-mise exec -- shellcheck scripts/*.sh
+mise exec -- kustomize build kubernetes/apps/<namespace>/<app-name>/app/
 ```
+
+`${APP}`/`${SECRET_DOMAIN}` staying literal in the output is expected — Flux postBuild substitutes them.
 
 Or run the full local PR check: `bash .agents/skills/pr-review/scripts/validate-pr.sh`
 
 ### 9. PR (ask before push)
+
+Show the user the created files and get confirmation before committing.
 
 ```bash
 git add .
@@ -113,12 +111,16 @@ gh pr create --title "feat(<namespace>): add <app-name>" --body "Deploy <app-nam
 - Hardcode domains (use `${SECRET_DOMAIN}`)
 - New namespace without user confirmation
 - `kubectl apply` bypassing GitOps
+- Forget `reloader.stakater.com/auto` when mounting ConfigMaps/Secrets — config changes won't restart pods
+- `readOnlyRootFilesystem: true` without a writable `tmp: emptyDir` — many apps crash at boot
+- Invent chart/image versions or digests from memory — use a plain upstream tag, Renovate pins the digest
+- Non-app-template chart without its own `ocirepository.yaml` — the shared `app-template` OCIRepository covers only that chart
 
 ## Quick reference
 
 | Task | Command |
 |------|---------|
-| Validate | `kustomize build` on app path (catches YAML syntax/duplicate keys); `shellcheck scripts/*.sh`; or `validate-pr.sh` |
+| Validate | `kustomize build` on the app/ subdirectory (catches YAML syntax/duplicate keys); or `validate-pr.sh` |
 | Reconcile | `flux reconcile kustomization <name>` (ask user) |
 | Logs | `kubectl logs -n <ns> deployment/<app>` |
 

--- a/.agents/skills/add-app-to-cluster/references/manifest-templates.md
+++ b/.agents/skills/add-app-to-cluster/references/manifest-templates.md
@@ -42,7 +42,7 @@ spec:
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./helmrelease.yaml
+  - helmrelease.yaml
 ```
 
 ## app/helmrelease.yaml (app-template)
@@ -125,8 +125,8 @@ Create `app/secret.sops.yaml` (Secret named `<app-name>-secret`), encrypt with s
 ```yaml
 # app/kustomization.yaml
 resources:
-  - ./helmrelease.yaml
-  - ./secret.sops.yaml
+  - helmrelease.yaml
+  - secret.sops.yaml
 ```
 
 ```yaml
@@ -143,7 +143,7 @@ resources:
 configMapGenerator:
   - name: <app-name>-configmap
     files:
-      - ./config/<file>.yaml
+      - config/<file>.yaml
     options:
       annotations:
         # only when the config contains literal ${VAR} — Flux postBuild substitutes it away otherwise

--- a/.agents/skills/add-app-to-cluster/references/manifest-templates.md
+++ b/.agents/skills/add-app-to-cluster/references/manifest-templates.md
@@ -6,10 +6,11 @@ Adapt paths, namespaces, images, and ports to the target application.
 
 ```yaml
 ---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: <app-name>
+  name: &app <app-name>
   namespace: &namespace <namespace>
 spec:
   targetNamespace: *namespace
@@ -21,16 +22,25 @@ spec:
     name: flux-system
     namespace: flux-system
   wait: false
+  # dependsOn:
+  #   - name: <other-app>
+  # stateful apps: uncomment for volsync-backed persistence — full var list in
+  # .agents/skills/backup-restore/references/restore-pvc.md#enable-backups-for-an-app
+  # components:
+  #   - ../../../../components/volsync
+  # postBuild:
+  #   substitute:
+  #     APP: *app
+  #     VOLSYNC_CAPACITY: <size>
 ```
 
 ## app/kustomization.yaml
 
 ```yaml
 ---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: <namespace>
-
 resources:
   - ./helmrelease.yaml
 ```
@@ -39,10 +49,11 @@ resources:
 
 ```yaml
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
-  name: <app-name>
+  name: &app <app-name>
 spec:
   interval: 30m
   chartRef:
@@ -58,18 +69,11 @@ spec:
         annotations:
           reloader.stakater.com/auto: "true"
 
-        pod:
-          securityContext:
-            runAsUser: 1000
-            runAsGroup: 1000
-            fsGroup: 1000
-            fsGroupChangePolicy: "OnRootMismatch"
-
         containers:
           app:
             image:
               repository: <image-repo>
-              tag: <tag>
+              tag: <tag>  # plain upstream tag; Renovate pins the digest
             resources:
               requests:
                 cpu: 5m
@@ -77,6 +81,20 @@ spec:
               limits:
                 cpu: 500m
                 memory: 512Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+
+    defaultPodOptions:
+      securityContext:
+        # match the image's expected uid (568 = home-operations convention)
+        runAsNonRoot: true
+        runAsUser: 568
+        runAsGroup: 568
+        fsGroup: 568
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile: { type: RuntimeDefault }
 
     service:
       app:
@@ -92,6 +110,46 @@ spec:
         parentRefs:
           - name: envoy-internal
             namespace: network
+
+    persistence:
+      # config:
+      #   existingClaim: *app  # pairs with the volsync component in ks.yaml
+      tmp:
+        type: emptyDir  # readOnlyRootFilesystem crashes many apps without a writable /tmp
+```
+
+## Optional: sops secret
+
+Create `app/secret.sops.yaml` (Secret named `<app-name>-secret`), encrypt with sops, then wire it:
+
+```yaml
+# app/kustomization.yaml
+resources:
+  - ./helmrelease.yaml
+  - ./secret.sops.yaml
+```
+
+```yaml
+# helmrelease.yaml, under containers.app
+            envFrom:
+              - secretRef:
+                  name: <app-name>-secret
+```
+
+## Optional: configMapGenerator (config files)
+
+```yaml
+# app/kustomization.yaml
+configMapGenerator:
+  - name: <app-name>-configmap
+    files:
+      - ./config/<file>.yaml
+    options:
+      annotations:
+        # only when the config contains literal ${VAR} — Flux postBuild substitutes it away otherwise
+        kustomize.toolkit.fluxcd.io/substitute: disabled
+generatorOptions:
+  disableNameSuffixHash: true
 ```
 
 ## Namespace kustomization entry

--- a/.agents/skills/backup-restore/SKILL.md
+++ b/.agents/skills/backup-restore/SKILL.md
@@ -4,8 +4,8 @@ description: >-
   Manage VolSync Kopia-based backups and restores for Kubernetes PVs in this cluster.
 
   user: "check backup status for app X" → list ReplicationSources, describe conditions
-  user: "restore from backup" → find snapshot, create restore PVC with VolumePopulator
-  user: "trigger manual backup" → annotate volsync.backube/sync=true
+  user: "restore from backup" → follow docs/volsync-restore.md
+  user: "trigger manual backup" → patch spec.trigger.manual
   user: "backup failing" → delegate to debug-cluster for mover pod logs
 
   Use when the user mentions backups, restores, snapshots, ReplicationSource,
@@ -21,7 +21,7 @@ compatibility: Requires `kubectl` access to the cluster; VolSync CRDs and Kopia 
 |-----------|---------|
 | List backups | `kubectl get replicationsources -A` |
 | List restores | `kubectl get replicationdestinations -A` |
-| Trigger sync | `kubectl annotate rs/<name> -n <ns> volsync.backube/sync=true --overwrite` |
+| Trigger sync | `kubectl patch replicationsource <app> -n <ns> --type merge -p '{"spec":{"trigger":{"manual":"sync-'$(date +%s)'"}}}'` |
 | Status | `kubectl describe replicationsource <name> -n <ns>` |
 
 ## Check status
@@ -29,31 +29,26 @@ compatibility: Requires `kubectl` access to the cluster; VolSync CRDs and Kopia 
 ```bash
 kubectl get replicationsources -A
 kubectl describe replicationsource <app> -n <namespace>
-kubectl get rs <app> -n <namespace> -o yaml
+kubectl get replicationsource <app> -n <namespace> -o yaml
 ```
 
 ## Trigger manual sync
 
 ```bash
-kubectl annotate replicationsource/<name> -n <namespace> volsync.backube/sync=true --overwrite
+kubectl patch replicationsource <app> -n <namespace> --type merge -p '{"spec":{"trigger":{"manual":"sync-'$(date +%s)'"}}}'
 ```
 
 ## Restore from backup
 
-1. **Find snapshot** — `kubectl get replicationdestination <app> -n <namespace> -o yaml` → `status.latestImage`
-2. **Create restore PVC** — `dataSourceRef` → `ReplicationDestination` (see [references/restore-pvc.md](references/restore-pvc.md))
+Follow the runbook [docs/volsync-restore.md](../../../docs/volsync-restore.md): suspend Flux ks+hr → delete app PVC → patch `restoreAsOf` + `trigger.manual` on `replicationdestination/<app>-dst` → wait `Synchronizing=False` reason `Successful` → resume Flux. The volsync component names every ReplicationDestination `<app>-dst`, so status checks are `kubectl get replicationdestination <app>-dst -n <namespace> -o yaml`.
+
+For a standalone side-car restore PVC, see [references/restore-pvc.md](references/restore-pvc.md).
 
 ## New backup
 
 Reference patterns in `kubernetes/components/volsync/`. Use Kopia mover settings consistent with existing apps.
 
-Privileged movers when required:
-
-```yaml
-metadata:
-  annotations:
-    volsync.backube/privileged-movers: "true"
-```
+Privileged movers are already enabled cluster-wide via the namespace annotation in `kubernetes/components/common/namespace.yaml` — nothing to add per app.
 
 ## Delegation
 
@@ -72,8 +67,4 @@ metadata:
 
 For mover logs and deep failures → [debug-cluster](../debug-cluster/SKILL.md).
 
-## Progressive disclosure
-
-- Restore PVC spec: [references/restore-pvc.md](references/restore-pvc.md)
-
-Format reference: [agentskills.io](https://agentskills.io/specification).
+VolSync→kopiur migration is in progress ([docs/kopiur-migration-plan.md](../../../docs/kopiur-migration-plan.md)); this skill stays authoritative until cutover.

--- a/.agents/skills/backup-restore/references/restore-pvc.md
+++ b/.agents/skills/backup-restore/references/restore-pvc.md
@@ -1,5 +1,7 @@
 # Restore PVC from ReplicationDestination
 
+Side-car restore into a fresh PVC. The component's ReplicationDestination trigger is `manual: restore-once`, so `status.latestImage` is stale unless you re-trigger the RD first — for restore-in-place follow [docs/volsync-restore.md](../../../../docs/volsync-restore.md).
+
 ```yaml
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -8,8 +10,9 @@ metadata:
   namespace: <namespace>
 spec:
   dataSourceRef:
+    apiGroup: volsync.backube
     kind: ReplicationDestination
-    name: <app>
+    name: <app>-dst
   accessModes: ["ReadWriteOnce"]
   storageClassName: <storage-class>
   resources:
@@ -17,23 +20,18 @@ spec:
       storage: <size>
 ```
 
-## ReplicationSource template
+## Enable backups for an app
 
-Reference `kubernetes/components/volsync/` for full patterns:
+Apps never write ReplicationSource YAML — add the volsync component to the app's `ks.yaml` and set the postBuild vars:
 
 ```yaml
-apiVersion: volsync.backube/v1alpha1
-kind: ReplicationSource
-metadata:
-  name: <app>
-  namespace: <namespace>
 spec:
-  sourcePVC: <pvc-name>
-  trigger:
-    schedule: "0 2 * * *"
-  kopia:
-    repository: <app>-volsync-secret
-    volumeSnapshotClassName: csi-ceph-blockpool
-    storageClassName: ceph-block
-    accessModes: ["ReadWriteOnce"]
+  components:
+    - ../../../../components/volsync
+  postBuild:
+    substitute:
+      APP: <app>
+      VOLSYNC_CAPACITY: <size> # required
 ```
+
+Set `VOLSYNC_STORAGECLASS`, `VOLSYNC_PUID`, `VOLSYNC_PGID`, `VOLSYNC_ACCESSMODES` only when deviating from the component defaults. Example: `kubernetes/apps/media/radarr/ks.yaml`.

--- a/.agents/skills/debug-cluster/SKILL.md
+++ b/.agents/skills/debug-cluster/SKILL.md
@@ -2,7 +2,7 @@
 name: debug-cluster
 description: >-
   Diagnose and resolve Kubernetes cluster issues using structured fact gathering and 5-Whys
-  root cause analysis. Prefer ToolHive MCP; use Talos only for node/kubelet problems.
+  root cause analysis.
 
   user: "pod CrashLoopBackOff" → describe pod, logs, events; GitOps fix in repo
   user: "HelmRelease not reconciling" → flux get/describe, reconcile with source
@@ -32,6 +32,7 @@ Structured debugging with parallel fact gathering; delegate deep 5-Whys or log m
 - Kubernetes resources (pods, deployments, services, events)
 - Logs (current + previous containers)
 - Flux instance when GitOps-related
+- Historical/crashed-pod logs and firing alerts: observability MCP group (Grafana + victoria-logs)
 
 ```bash
 kubectl get pods -n <ns> -o wide
@@ -75,7 +76,7 @@ MCP when available: `get_flux_instance`, `reconcile_flux_kustomization`. ToolHiv
 
 ## Talos (rare)
 
-Node NotReady, kubelet, kernel: `talosctl --nodes <ip> get kubernetespods`, `logs --namespace=kubelet`, `dmesg`.
+Node NotReady, kubelet, kernel: `talosctl --nodes <ip> containers -k`, `logs kubelet`, `dmesg`.
 
 ## Validation
 
@@ -103,5 +104,6 @@ Use `kubesearch_get_release` to drill into deployments of the same chart and com
 - [backup-restore](../backup-restore/SKILL.md) — PVC recovery
 - [add-app-to-cluster](../add-app-to-cluster/SKILL.md) — new deployments
 - [k8s-at-home-research](../k8s-at-home-research/SKILL.md) — finding homelab config examples
+- [prometheus-cluster-health](../prometheus-cluster-health/SKILL.md) — alerts, CPU/memory hotspots
 
 Format reference: [agentskills.io](https://agentskills.io/specification).

--- a/.agents/skills/git-worktree-isolation/SKILL.md
+++ b/.agents/skills/git-worktree-isolation/SKILL.md
@@ -3,12 +3,12 @@ name: git-worktree-isolation
 description: >-
   Use git worktrees for isolated, parallel agent work without polluting the main working tree.
 
-  user: "work on feature X" → create worktree and branch under work/isolated-*
+  user: "work on feature X" → create worktree and branch under .worktrees/<task>
   user: "experiment with Y" → detached worktree for safe trials
   user: "parallel task" → separate worktree per concurrent task
 
   Triggers: worktree, isolated work, parallel agent, experimental branch, feature branch.
-compatibility: Requires `git` 2.x worktree support and write access to the repository; validation uses `mise` and `flux-local` when run from the worktree.
+compatibility: Requires `git` 2.x worktree support and write access to the repository; validation uses `mise` when run from the worktree.
 ---
 
 # Git worktree isolation
@@ -16,20 +16,20 @@ compatibility: Requires `git` 2.x worktree support and write access to the repos
 ## Create worktree
 
 ```bash
+# new branch
 git fetch origin
-git checkout <branch>
-git pull origin <branch>
-git worktree list
-git worktree add -b <branch> --detach work/isolated-<task>-<timestamp> <branch>
-cd work/isolated-<task>-<timestamp>
+git worktree add -b <branch> .worktrees/<task> origin/main
+cd .worktrees/<task>
+for f in .env .mcp.json CLAUDE.local.md .vscode .claude; do cp -r "../../$f" . 2>/dev/null; done  # untracked local config
+
+# detached experiment
+git worktree add --detach .worktrees/<task> <commit-ish>
 ```
 
 ## Validate (in worktree)
 
 ```bash
-mise exec -- shellcheck scripts/*.sh
 bash .agents/skills/pr-review/scripts/validate-pr.sh
-flux-local test --all-namespaces --enable-helm kubernetes/flux/cluster
 ```
 
 For manifest-only changes, `kustomize build` on touched paths under `kubernetes/apps/` is enough before the full script.
@@ -39,7 +39,7 @@ For manifest-only changes, `kustomize build` on touched paths under `kubernetes/
 From the **main repo** (not inside the worktree path):
 
 ```bash
-git worktree remove work/isolated-<task>-<timestamp>
+git worktree remove .worktrees/<task>
 git branch -D <branch>
 ```
 

--- a/.agents/skills/git-worktree-isolation/SKILL.md
+++ b/.agents/skills/git-worktree-isolation/SKILL.md
@@ -32,7 +32,7 @@ git worktree add --detach .worktrees/<task> <commit-ish>
 bash .agents/skills/pr-review/scripts/validate-pr.sh
 ```
 
-For manifest-only changes, `kustomize build` on touched paths under `kubernetes/apps/` is enough before the full script.
+For manifest-only changes, `mise exec -- flate test all` (renders the HelmRelease; falls back to `kustomize build` on touched paths if `flate` is unavailable) is enough before the full script.
 
 ## Cleanup
 

--- a/.agents/skills/k8s-at-home-research/SKILL.md
+++ b/.agents/skills/k8s-at-home-research/SKILL.md
@@ -36,13 +36,12 @@ Research is **advisory**: never copy secrets, domains, cluster-specific IDs, or 
 
 - **kubesearch MCP first** when available: `kubesearch_search_releases`, `kubesearch_get_release`, `kubesearch_grep_values`, `kubesearch_search_images`.  
   Then `repo_clone`/`repo_read_file` to inspect exemplar manifests. Kubesearch queries the pre-indexed kubesearch.dev database — no `topic:k8s-at-home` tag needed.
-- **GitHub MCP second:** `resources_github_search_repositories`, `resources_github_get_file_contents` for repos not yet indexed by kubesearch.
+- **GitHub MCP second:** `github_search_repositories`, `github_get_file_contents` for repos not yet indexed by kubesearch.
 - **Fallback:** `gh search repos <app> --topic k8s-at-home --limit 10` then scoped `gh search code` with `repo:<owner>/<repo>`.
 - **Repo shortlist:** `python3 .agents/skills/k8s-at-home-research/scripts/search_k8s_at_home.py <term> --limit 10`
-- **Literal code patterns:** `grep_app_searchGitHub` when MCP code search fails.
 - **Web search** only to find repo names; confirm in repository files.
 - **Local repo** — compare against existing `kubernetes/apps/` before proposing YAML.
-- **`@explorer`** for local repo search only; **`@librarian`** for upstream chart docs, not k8s-at-home mining.
+- **Upstream chart docs** for chart values — not k8s-at-home mining.
 
 ## Efficiency
 

--- a/.agents/skills/k8s-at-home-research/references/research-workflow.md
+++ b/.agents/skills/k8s-at-home-research/references/research-workflow.md
@@ -4,20 +4,6 @@
 
 Start broad, then narrow by resource type. Use exact code-shaped queries rather than broad prose.
 
-### Tool preference
-
-1. Use **kubesearch MCP** first — it queries pre-indexed kubesearch.dev data without needing GitHub API rate limit:
-   - `kubesearch_search_releases` — find apps by chart name, ranked by deployment count.
-   - `kubesearch_get_release` — drill into a chart for every deployment and its `spec.values`.
-   - `kubesearch_grep_values` — full-text grep across real-world Helm values for config examples.
-   - `kubesearch_search_images` — find container image repositories and tags.
-   - Then `repo_clone`/`repo_read_file`/`repo_grep` to review exemplar manifests from indexed repos.
-2. Fall back to **GitHub MCP** repository search and file reads for repos not yet indexed by kubesearch.
-3. Use `gh search repos <term> --topic k8s-at-home` when MCP is unavailable or when you need a quick shell-native shortlist.
-4. Use `gh search code` or `grep_app_searchGitHub` for code patterns when MCP code search fails.
-
-Keep discovery bounded: request 5–10 repositories, inspect 3–5 examples, and only broaden if evidence is weak.
-
 ### Kubesearch query patterns (preferred)
 
 ```
@@ -45,12 +31,6 @@ GitHub CLI equivalent:
 
 ```bash
 gh search repos <app> --topic k8s-at-home --limit 10 --json fullName,url,updatedAt,stargazersCount,description
-```
-
-Bundled script (from repo root):
-
-```bash
-python3 .agents/skills/k8s-at-home-research/scripts/search_k8s_at_home.py <app> --limit 10
 ```
 
 ### Path narrowing
@@ -120,7 +100,7 @@ Treat examples as lower confidence if they use deprecated APIs, unmaintained cha
 - Preserve this repo's GitOps layout and naming; do not mirror another repo's folder hierarchy unless it matches.
 - Convert domains to `${SECRET_DOMAIN}`.
 - Convert internal routes to Gateway API `HTTPRoute` with parentRef `envoy-internal` in namespace `network` when appropriate.
-- Use SOPS-managed `Secret` or ExternalSecret-compatible patterns; never copy secret values.
+- Convert secrets to SOPS-managed `*.sops.yaml` Secrets; never copy secret values.
 - Add Reloader annotations to controllers that consume mutable config.
 - For `ceph-block` RWO persistence, avoid RollingUpdate unless the workload supports multi-attach; use `Recreate` when in doubt.
 - Validate chart values against upstream chart docs before relying on a copied values block.

--- a/.agents/skills/pr-review/SKILL.md
+++ b/.agents/skills/pr-review/SKILL.md
@@ -1,9 +1,8 @@
 ---
 name: pr-review
 description: >-
-  Run six-phase parallel PR reviews for GitOps Kubernetes. Spawns subagents for YAML format,
-  naming, best practices, security, architecture, and validation. Produces severity-graded
-  findings with actionable summaries. Isolates each review by PR number or local-changes id.
+  Review GitOps Kubernetes PRs or local diffs: YAML format, naming, HelmRelease patterns,
+  SOPS/security, structure, and build validation.
 
   user: "Review this PR" → six parallel subagents, aggregate under .agents/pr-review/pr-<id>/
   user: "Check my app config" → phase 3 (best practices) subagent

--- a/.agents/skills/pr-review/SKILL.md
+++ b/.agents/skills/pr-review/SKILL.md
@@ -11,7 +11,7 @@ description: >-
   user: "Review my local changes" → PR_ID=local-changes, staged + unstaged diff
 
   Use proactively for K8s app/Flux/HelmRelease changes, infrastructure edits, or pre-commit diff review.
-compatibility: Requires `git`, `mise`, `kustomize`, `flux`, and `shellcheck` for phase 6; optional `gh` for PR metadata.
+compatibility: Requires `git`, `mise`, `flate`, and `shellcheck` for phase 6 (falls back to `kustomize`/`flux` if `flate` is unavailable); optional `gh` for PR metadata.
 ---
 
 # PR review
@@ -29,7 +29,7 @@ Spawn focused subagents for GitOps Kubernetes PRs. Each phase uses clean context
 - Layout: `kubernetes/apps/<namespace>/<app>/` with `ks.yaml` + `app/`
 - Charts: `bjw-s/app-template` (common); URLs `${SECRET_DOMAIN}`; secrets SOPS-only
 - Routes: Gateway API `HTTPRoute`, parentRef `envoy-internal` / `envoy-external`
-- Validation: `mise exec -- shellcheck`, `kustomize build` (also catches YAML syntax/duplicate keys), `flux build`
+- Validation: `mise exec -- flate test all` (renders Kustomizations + HelmReleases with the real Helm/Kustomize SDKs — catches Helm template errors `kustomize build` can't see), `mise exec -- shellcheck`
 
 ## Workflow
 
@@ -59,7 +59,7 @@ For small diffs without subagents:
 - [ ] `bjw-s/app-template` pinned; Reloader annotation when needed
 - [ ] Probes and resource requests/limits
 - [ ] SOPS secrets; `${SECRET_DOMAIN}`; envoy route parentRefs
-- [ ] `kustomize build` / `shellcheck` pass on touched paths
+- [ ] `flate test all` / `shellcheck` pass on touched paths
 
 ## Progressive disclosure
 

--- a/.agents/skills/pr-review/references/best-practices.md
+++ b/.agents/skills/pr-review/references/best-practices.md
@@ -17,7 +17,7 @@
 
 ### Build Validation
 
-- Kustomize builds without errors
+- `flate test all` (or `kustomize build`) succeeds — Helm charts render, not just Kustomization YAML
 - All referenced files exist
 - No circular dependencies
 
@@ -47,7 +47,12 @@ Always cross-reference with:
 ## Validation Command Pattern
 
 ```bash
-# Build (also validates YAML syntax and duplicate keys)
+# flate: renders Kustomizations + HelmReleases with the real Helm/Kustomize SDKs (also
+# validates YAML syntax/duplicate keys); catches Helm template errors kustomize build can't
+# see, since chartRef: OCIRepository is opaque to kustomize
+flate test all
+
+# Fallback if flate is unavailable — Kustomization-only, no Helm render
 kustomize build kubernetes/apps/<namespace>/<app>/app/
 
 # Flux (offline; without --kustomization-file it queries the cluster API)

--- a/.agents/skills/pr-review/references/best-practices.md
+++ b/.agents/skills/pr-review/references/best-practices.md
@@ -1,27 +1,5 @@
 # GitOps PR Validation Best Practices
 
-Research current year best practices when reviewing PRs. The landscape evolves quickly.
-
-## Core Validation Layers
-
-A comprehensive GitOps PR validation should cover:
-
-1. **YAML Syntax** - Structural correctness, indentation, formatting
-2. **Kubernetes Schema** - Valid API versions, required fields, CRD compliance
-3. **Flux/CD Build** - Kustomize builds successfully, no reference errors
-4. **HelmRelease** - Chart references valid, values structure correct
-5. **Security** - No secrets in plaintext, proper RBAC, network policies
-6. **Consistency** - Naming conventions, directory structure, patterns
-
-## Research Prompts
-
-When reviewing PRs, verify against current best practices by researching:
-
-- "2026 GitOps PR validation best practices FluxCD"
-- "Kubernetes YAML validation tools 2026"
-- "FluxCD kustomization validation patterns"
-- "HelmRelease security best practices"
-
 ## Key Areas to Validate
 
 ### YAML Quality
@@ -57,14 +35,6 @@ When reviewing PRs, verify against current best practices by researching:
 - Proper directory structure
 - DRY principles with kustomize patches/transformers
 
-## Tools to Consider
-
-Research current validation tooling:
-
-- kustomize - Build and validation
-- flux CLI - Build and reconciliation testing
-- Local scripts for repository-specific checks
-
 ## Repository-Specific Checks
 
 Always cross-reference with:
@@ -78,17 +48,8 @@ Always cross-reference with:
 
 ```bash
 # Build (also validates YAML syntax and duplicate keys)
-kustomize build kubernetes/apps/<namespace>/<app>/
+kustomize build kubernetes/apps/<namespace>/<app>/app/
 
-# Flux
-flux build kustomization <name> --path <path>
+# Flux (offline; without --kustomization-file it queries the cluster API)
+flux build ks <name> --path <app>/app --kustomization-file <app>/ks.yaml --dry-run
 ```
-
-## When Uncertain
-
-If validation requirements are unclear:
-
-1. Check existing working examples in the repo
-2. Research current best practices online
-3. Ask for clarification on project conventions
-4. Prefer over-validation to missing issues

--- a/.agents/skills/pr-review/references/phase-prompts.md
+++ b/.agents/skills/pr-review/references/phase-prompts.md
@@ -1,14 +1,14 @@
 # PR review phase subagent prompts
 
-Spawn each phase with `subagent_type: general` (or `code-reviewer` only when the user requests a single focused pass). Replace `PR_ID` and file lists from the PR or local diff.
+Spawn each phase with `subagent_type: general-purpose` (or `code-reviewer` only when the user requests a single focused pass). Replace `PR_ID` and file lists from the PR or local diff.
 
 Output paths: `.agents/pr-review/pr-${PR_ID}/phase-<N>-*.md`
 
 ## Phase 1 — YAML format
 
 ```yaml
-subagent_type: general
-description: PR Review Phase 1: YAML Format
+subagent_type: general-purpose
+description: "PR Review Phase 1: YAML Format"
 prompt: |
   Review YAML formatting for PR.
 
@@ -42,8 +42,8 @@ prompt: |
 ## Phase 2 — Naming
 
 ```yaml
-subagent_type: general
-description: PR Review Phase 2: Naming Conventions
+subagent_type: general-purpose
+description: "PR Review Phase 2: Naming Conventions"
 prompt: |
   Review naming conventions for PR.
 
@@ -64,8 +64,8 @@ prompt: |
 ## Phase 3 — Best practices
 
 ```yaml
-subagent_type: general
-description: PR Review Phase 3: Best Practices
+subagent_type: general-purpose
+description: "PR Review Phase 3: Best Practices"
 prompt: |
   Review HelmRelease best practices for PR.
 
@@ -75,7 +75,7 @@ prompt: |
   - Probes: livenessProbe + readinessProbe
   - Resources: requests + limits
   - Security: securityContext
-  - Routes: envoy-internal parentRef
+  - Routes: envoy-internal or envoy-external parentRef (external exposure must be intentional)
   - Hostnames: {{ .Release.Name }}.${SECRET_DOMAIN}
 
   TASKS:
@@ -96,8 +96,8 @@ See [best-practices.md](best-practices.md) for expanded validation topics.
 ## Phase 4 — Security
 
 ```yaml
-subagent_type: general
-description: PR Review Phase 4: Security
+subagent_type: general-purpose
+description: "PR Review Phase 4: Security"
 prompt: |
   Review security for GitOps Kubernetes PR.
 
@@ -120,8 +120,8 @@ prompt: |
 ## Phase 5 — Architecture
 
 ```yaml
-subagent_type: general
-description: PR Review Phase 5: Architecture
+subagent_type: general-purpose
+description: "PR Review Phase 5: Architecture"
 prompt: |
   Review architecture patterns for GitOps Kubernetes PR.
 
@@ -142,26 +142,22 @@ prompt: |
 ## Phase 6 — Validation
 
 ```yaml
-subagent_type: general
-description: PR Review Phase 6: Validation
+subagent_type: general-purpose
+description: "PR Review Phase 6: Validation"
 prompt: |
   Run validation tools for GitOps Kubernetes PR.
 
   TOOLS:
   - kustomize build: Kustomization validity (also catches YAML syntax/duplicate keys)
   - flux build: Flux reconciliation
+  - shellcheck: touched shell scripts
 
-  COMMANDS:
-  - mise exec -- shellcheck scripts/*.sh
-  - kustomize build kubernetes/apps/<namespace>/<app>/
-  - flux build kustomization <name> --path <path>
+  Run `bash .agents/skills/pr-review/scripts/validate-pr.sh` for all three, or the individual commands in [best-practices.md](best-practices.md#validation-command-pattern).
 
   TASKS:
   1. Run shellcheck on touched scripts
   2. Run kustomize build
-  4. Run flux build
+  3. Run flux build
 
   OUTPUT to .agents/pr-review/pr-${PR_ID}/phase-6-validation.md.
 ```
-
-Optional helper: `bash .agents/skills/pr-review/scripts/validate-pr.sh` when present and applicable.

--- a/.agents/skills/pr-review/references/phase-prompts.md
+++ b/.agents/skills/pr-review/references/phase-prompts.md
@@ -148,16 +148,14 @@ prompt: |
   Run validation tools for GitOps Kubernetes PR.
 
   TOOLS:
-  - kustomize build: Kustomization validity (also catches YAML syntax/duplicate keys)
-  - flux build: Flux reconciliation
+  - flate test all: renders Kustomizations + HelmReleases with the real Helm/Kustomize SDKs (catches Helm template errors kustomize build can't see)
   - shellcheck: touched shell scripts
 
-  Run `bash .agents/skills/pr-review/scripts/validate-pr.sh` for all three, or the individual commands in [best-practices.md](best-practices.md#validation-command-pattern).
+  Run `bash .agents/skills/pr-review/scripts/validate-pr.sh` for both, or the individual commands in [best-practices.md](best-practices.md#validation-command-pattern).
 
   TASKS:
   1. Run shellcheck on touched scripts
-  2. Run kustomize build
-  3. Run flux build
+  2. Run flate test all (or kustomize build + flux build if flate is unavailable)
 
   OUTPUT to .agents/pr-review/pr-${PR_ID}/phase-6-validation.md.
 ```

--- a/.agents/skills/pr-review/references/workflow.md
+++ b/.agents/skills/pr-review/references/workflow.md
@@ -28,9 +28,10 @@ git diff --cached --name-only > .agents/pr-review/pr-${PR_ID}/staged-files.txt
 git diff --cached > .agents/pr-review/pr-${PR_ID}/staged.diff
 git diff --name-only > .agents/pr-review/pr-${PR_ID}/unstaged-files.txt
 git diff > .agents/pr-review/pr-${PR_ID}/unstaged.diff
+git ls-files --others --exclude-standard > .agents/pr-review/pr-${PR_ID}/untracked-files.txt
 ```
 
-Run the same six phases against these artifacts. Summarize staged vs unstaged in the final report.
+Run the same six phases against these artifacts. Summarize staged, unstaged, and untracked files in the final report.
 
 ## Aggregation template (`pr-review-state.md`)
 

--- a/.agents/skills/pr-review/scripts/validate-pr.sh
+++ b/.agents/skills/pr-review/scripts/validate-pr.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # PR Validation Script - Run locally before pushing
-# 2026 GitOps best practices: https://oneuptime.com/blog/post/2026-03-06-implement-gitops-pull-request-validation-flux-cd
 
 set -euo pipefail
 
@@ -58,9 +57,10 @@ echo ""
 # Phase 2: Shellcheck (if shell scripts exist)
 echo "[2/4] Shell Script Validation..."
 # exclude the repo-local .claude dir (session configs, worktrees) — anchored to REPO_ROOT so
-# running from inside a .claude/worktrees/* worktree doesn't exclude the entire tree — and
+# running from inside a .claude/worktrees/* worktree doesn't exclude the entire tree —
+# .worktrees/ (parallel checkouts validate themselves), and
 # archive/ (retired one-off scripts kept for reference; not held to the gate)
-SHELL_SCRIPTS=$(find "${REPO_ROOT}" -name "*.sh" -type f -not -path "${REPO_ROOT}/.claude/*" -not -path "${REPO_ROOT}/archive/*" 2>/dev/null | head -20)
+SHELL_SCRIPTS=$(find "${REPO_ROOT}" -name "*.sh" -type f -not -path "${REPO_ROOT}/.claude/*" -not -path "${REPO_ROOT}/.worktrees/*" -not -path "${REPO_ROOT}/archive/*" 2>/dev/null)
 if [ -n "$SHELL_SCRIPTS" ]; then
     if command -v shellcheck &> /dev/null; then
         # shellcheck disable=SC2086 # word-splitting the list is intended; quoting it passes all paths as one filename
@@ -105,7 +105,7 @@ SECURITY_ERRORS=0
 
 # Check for hardcoded secrets (basic patterns)
 while IFS= read -r -d '' file; do
-    if grep -qiE '(password|secret|token|key):[[:space:]]*[^$"{]' "$file" 2>/dev/null; then
+    if grep -qiE '(password|secret|token|key):[[:space:]]*[^$"{[:space:]]' "$file" 2>/dev/null; then
         if ! grep -q 'sops:' "$file" 2>/dev/null; then
             warn "Possible hardcoded secret in: $file"
             SECURITY_ERRORS=$((SECURITY_ERRORS + 1))

--- a/.agents/skills/pr-review/scripts/validate-pr.sh
+++ b/.agents/skills/pr-review/scripts/validate-pr.sh
@@ -33,10 +33,19 @@ warn() {
     WARNINGS=$((WARNINGS + 1))
 }
 
-# Phase 1: Kustomize Build Validation
-# (also validates YAML syntax and duplicate keys — kustomize rejects both, so no separate yaml linter)
-echo "[1/4] Kustomize Build Validation..."
-if command -v kustomize &> /dev/null; then
+# Phase 1: Flux Manifest Validation
+# flate renders every Kustomization + HelmRelease with the real Helm/Kustomize SDKs, catching
+# Helm template errors a bare `kustomize build` can't see (chartRef: OCIRepository is opaque
+# to kustomize) — also validates YAML syntax and duplicate keys, so no separate yaml linter.
+# Falls back to kustomize build (Kustomization-only, no Helm render) if flate isn't installed.
+echo "[1/4] Flux Manifest Validation..."
+if command -v flate &> /dev/null; then
+    if flate test all -p "${REPO_ROOT}" > /dev/null 2>&1; then
+        pass "flate test all passed"
+    else
+        fail "flate test all found issues"
+    fi
+elif command -v kustomize &> /dev/null; then
     KUSTOMIZE_ERRORS=0
     while IFS= read -r -d '' ks_file; do
         app_dir=$(dirname "$ks_file")
@@ -50,7 +59,7 @@ if command -v kustomize &> /dev/null; then
         pass "All kustomize builds passed"
     fi
 else
-    warn "kustomize not installed"
+    warn "neither flate nor kustomize installed"
 fi
 echo ""
 

--- a/.agents/skills/prometheus-cluster-health/SKILL.md
+++ b/.agents/skills/prometheus-cluster-health/SKILL.md
@@ -5,12 +5,12 @@ description: >-
   and workload signal. Default lookback is 30 minutes unless the user specifies another window.
 
   user: "cluster health" / "health snapshot" → alerts + top CPU pods over $WINDOW
-  user: "firing alerts" → alerting_manage_rules or ALERTS PromQL fallback
+  user: "firing alerts" → list_alert_rules or ALERTS PromQL fallback
   user: "top CPU pods" / "how's the load" → container_cpu usage queries (cores, not sec/min)
   user: "is karakeep healthy?" → filter namespace/pod + correlate alerts
 
   Prefer observability MCP (Grafana / ToolHive group): read session tool schemas before calling.
-compatibility: Requires observability MCP or Prometheus API access (port-forward to prometheus-operated in observability namespace). Confirm prefixed tool names (e.g. grafana_query_prometheus) in-session.
+compatibility: Requires observability MCP or VictoriaMetrics API access (kubectl port-forward -n observability svc/vmsingle-victoria-metrics 8428). Confirm prefixed tool names (e.g. grafana_query_prometheus) in-session.
 ---
 
 # Prometheus cluster health snapshot
@@ -22,22 +22,21 @@ Answer “is the cluster OK?” and “who is using CPU?” with **correct units
 - **Default `$WINDOW`:** `30m`. User overrides: `15m`, `1h`, `2h`, etc. — use consistently in all queries.
 - **`$STEP`:** `1m` for windows up to ~2h; `5m` for longer windows.
 - **Instant snapshots:** subquery patterns `[$WINDOW:$STEP]` around inner `rate(...[5m])`.
-- **Alerts:** prefer **`alerting_manage_rules`**; `ALERTS{alertstate="firing"}` when Grafana tools unavailable.
 
 ## Tool usage (observability MCP)
 
-Stack: Grafana MCP (`mcp/grafana`), often behind ToolHive **observability** group. Prometheus datasource often `prometheus-operated.observability.svc.cluster.local`.
+Stack: Grafana MCP (`grafana/mcp-grafana`), often behind ToolHive **observability** group. Datasource uid `prometheus` (default) — VictoriaMetrics behind `vmauth-victoria-metrics.observability:8427`; second uid `victoriametrics`.
 
 **Before any call:** resolve real tool names in this session (may be prefixed, e.g. `grafana_query_prometheus`).
 
 | Goal | Tools |
 |------|--------|
-| Datasource UID | `list_datasources`, `get_datasource` |
-| Firing alerts | **`alerting_manage_rules`** |
+| Datasource UID | `list_datasources`, `get_datasource_by_uid` |
+| Firing alerts | **`list_alert_rules`**, `list_alert_groups` |
 | PromQL | **`query_prometheus`** (`queryType`, `startTime`, `endTime`, `stepSeconds`) |
 | Discovery | `list_prometheus_metric_names`, `list_prometheus_label_*` |
 | Dashboards | `search_dashboards`, `get_dashboard_summary`, `get_dashboard_panel_queries` |
-| Logs follow-up | `query_loki_logs` (if configured) |
+| Logs follow-up | none via Grafana MCP (no Loki) — VictoriaLogs LogsQL via vmauth :8427 `/select/logsql/*` or victoria-logs.observability:9428 |
 
 **`query_prometheus`:** use `instant` + subquery PromQL from [references/promql-queries.md](references/promql-queries.md); for `range`, align `stepSeconds` with `$STEP` (60 for 1m, 300 for 5m).
 

--- a/.agents/skills/prometheus-cluster-health/references/promql-queries.md
+++ b/.agents/skills/prometheus-cluster-health/references/promql-queries.md
@@ -2,11 +2,7 @@
 
 Replace `$WINDOW` (default `30m`) and `$STEP` (`1m` for windows ≤ ~2h, `5m` for longer) together.
 
-**CPU rates:** inner `rate(...[5m])` in **cores**; outer `avg_over_time` / `max_over_time` over `$WINDOW`.
-
 ## Step 1 — Alerts
-
-**Prefer Grafana MCP:** `alerting_manage_rules`
 
 **Fallback instant query:**
 
@@ -151,7 +147,7 @@ Summary: One sentence; flag mismatches only with metric evidence.
 ## Fallback without MCP
 
 ```bash
-kubectl port-forward -n observability svc/prometheus-operated 9090:9090
+kubectl port-forward -n observability svc/vmsingle-victoria-metrics 8428:8428
 ```
 
-Use Prometheus Graph UI or query API; Grafana Explore uses the same datasource as MCP `query_prometheus`.
+Use vmui or the Prometheus-compatible /api/v1/query API at http://localhost:8428; Grafana Explore uses the same datasource as MCP `query_prometheus`.

--- a/.agents/skills/toolhive-upgrades/SKILL.md
+++ b/.agents/skills/toolhive-upgrades/SKILL.md
@@ -40,7 +40,7 @@ Stay ahead of **ToolHive** churn: each minor often changes CRD shapes, Helm valu
 3. **Bump pins** — Same **X.Y.Z** on both OCI `ref.tag` values unless upstream documents otherwise.
 4. **Patch manifests** — Apply renames, structs, and removals from the release; avoid drive-by edits.
 5. **Audit** — `bash .agents/skills/toolhive-upgrades/scripts/audit-toolhive-yaml.sh` (requires `rg`). Fix or document false positives.
-6. **Validate** — `bash .agents/skills/pr-review/scripts/validate-pr.sh` (covers `kustomize build` and `shellcheck` for the touched paths).
+6. **Validate** — `bash .agents/skills/pr-review/scripts/validate-pr.sh` (covers `flate test all` — renders the HelmRelease, not just Kustomization YAML — and `shellcheck` for the touched paths).
 7. **Subagent review (blocking)** — [Review gate](#review-gate-subagent-required-before-done). Do **not** call the upgrade done until **PASS**.
 8. **Cluster reconcile order** — CRD release before operator; **ask user** before live apply (`AGENTS.md`).
 

--- a/.agents/skills/toolhive-upgrades/SKILL.md
+++ b/.agents/skills/toolhive-upgrades/SKILL.md
@@ -1,12 +1,10 @@
 ---
 name: toolhive-upgrades
 description: >-
-  Guides Stacklok ToolHive upgrades: compare pinned tags to upstream main and to release notes,
-  manifest migration for Flux GitOps (MCPServer, VirtualMCPServer, MCPRegistry, OCI Helm pins),
-  local audit/validate, and a mandatory code-reviewer subagent before completion. Use when
-  bumping toolhive-operator or operator-crds tags, reconciling CRDs, fixing admission errors
-  after upgrade, or when the user mentions ToolHive versions, release notes, deprecations,
-  or CRD migrations.
+  Stacklok ToolHive operator/CRD upgrades in this Flux repo. Use when bumping
+  toolhive-operator or toolhive-operator-crds ref.tag, reconciling ToolHive CRDs, fixing
+  admission/validation errors after a ToolHive upgrade, or when the user mentions ToolHive
+  versions, release notes, deprecations, or CRD migrations.
 compatibility: Repository uses `mise`, `rg` (ripgrep), `git`, and `bash` for scripted audit; cluster apply is user-approved per AGENTS.md.
 ---
 
@@ -36,14 +34,13 @@ Stay ahead of **ToolHive** churn: each minor often changes CRD shapes, Helm valu
 
 1. **Pin ↔ upstream `main` / releases — normalize + semver first**
    - Run **`bash .agents/skills/toolhive-upgrades/scripts/upstream-pin-vs-main.sh`** (optional `[PIN]`). This prints **`VERSION` on `main`**, **`VERSION` at `vPIN`**, **Latest Release**, correct **`compare`** URLs (**with `v` prefix**), and REST **`ahead_by` / `behind_by`** for both directions.
-   - **Never** paste Flux **`ref.tag`** bare into **`github.com/.../compare/...`** — map **`PIN → vPIN`** first (same mapping as **`OCI`** chart tags ↔ **`git tag`**).
    - **When bumping to a shipped tag:** Read **`https://github.com/stacklok/toolhive/releases/tag/vX.Y.Z`** and compare **`vOLD...vNEW`** (Breaking → Deprecations → Improvements).
    - **When deliberately tracking `main`:** Confirm **`deploy/charts/operator/`** `version:` / **`VERSION`** at **`main`** tip match your risk tolerance (document if pre-release).
 2. **Skim repo history** — [references/breaking-history.md](references/breaking-history.md); append one row when a migration will recur.
 3. **Bump pins** — Same **X.Y.Z** on both OCI `ref.tag` values unless upstream documents otherwise.
 4. **Patch manifests** — Apply renames, structs, and removals from the release; avoid drive-by edits.
 5. **Audit** — `bash .agents/skills/toolhive-upgrades/scripts/audit-toolhive-yaml.sh` (requires `rg`). Fix or document false positives.
-6. **Validate** — `mise exec -- shellcheck` on touched shell.
+6. **Validate** — `bash .agents/skills/pr-review/scripts/validate-pr.sh` (covers `kustomize build` and `shellcheck` for the touched paths).
 7. **Subagent review (blocking)** — [Review gate](#review-gate-subagent-required-before-done). Do **not** call the upgrade done until **PASS**.
 8. **Cluster reconcile order** — CRD release before operator; **ask user** before live apply (`AGENTS.md`).
 

--- a/.agents/skills/toolhive-upgrades/references/reviewer-handoff.md
+++ b/.agents/skills/toolhive-upgrades/references/reviewer-handoff.md
@@ -29,7 +29,7 @@ Replace `VOLD`, `VNEW`, and paste `git diff --stat` / audit output. Send as the 
 2. Both OCIRepositories use `ref.tag: VNEW` (and match each other unless upstream documents an exception).
 3. No plaintext secrets; no unrelated churn outside ToolHive + agreed docs.
 4. If `helmrelease.yaml` values changed: types match chart (e.g. `operator.env` is a list of `{name,value}`).
-5. Local validation (shellcheck) is credible for this diff.
+5. Local validation (`validate-pr.sh`) is credible for this diff.
 
 **Verdict:** **PASS** (no blockers) or **FAIL** (list blockers; implementer fixes and re-invokes you once).
 

--- a/.agents/skills/toolhive-upgrades/references/upgrade-workflow.md
+++ b/.agents/skills/toolhive-upgrades/references/upgrade-workflow.md
@@ -2,8 +2,6 @@
 
 ## Compare pinned tag to `main` (normalize `v`, read `VERSION`)
 
-**Flux `ref.tag`** is usually **`X.Y.Z`** without **`v`**; GitHub tags are **`vX.Y.Z`**. Wrong refs invalidate **`compare`** URLs.
-
 1. Run **`bash .agents/skills/toolhive-upgrades/scripts/upstream-pin-vs-main.sh`** — prints **`VERSION`** on **`main`**, **`VERSION`** at **`vPIN`**, **Latest Release**, and both compares below.
 
 2. Use **both** links from that script (same refs, opposite directions):
@@ -35,7 +33,7 @@ kubectl get mcpservers,virtualmcpservers,mcpgroups,mcpserverentries,mcpremotepro
 ## Post-upgrade smoke
 
 ```bash
-kubectl get helmrelease -n <flux-ns> | rg -i toolhive
+kubectl get helmrelease -n ai | rg -i toolhive
 kubectl get pods -n ai -l 'app.kubernetes.io/name' -o wide 2>/dev/null || kubectl get pods -n ai
 ```
 

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ talosconfig
 # Misc.
 logs/
 work/
+.worktrees/
 .private/
 .task/
 .venv/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ GitOps-based Kubernetes cluster on Talos Linux with FluxCD reconciliation. Make 
 - Before any work, verify the branch and worktree, run `git status`, then `git pull --ff-only && git status`. Never assume the branch is current.
 - Preserve unrelated changes and follow existing patterns; keep changes small and focused.
 - Validate the changed scope before declaring work complete or committing; follow the nearest scoped `AGENTS.md` and [common operations](.agents/common-operations.md).
-- Shell scripts use `set -euo pipefail` and must pass `mise exec -- shellcheck scripts/*.sh`.
+- Shell scripts use `set -euo pipefail` and must pass shellcheck on every touched `*.sh` (`bash .agents/skills/pr-review/scripts/validate-pr.sh` covers this).
 - Use Conventional Commit titles, for example `feat(scope): description`.
 
 ## Load context on demand
@@ -20,6 +20,9 @@ GitOps-based Kubernetes cluster on Talos Linux with FluxCD reconciliation. Make 
 - [Learned workspace](.agents/learned-workspace.md): cluster-specific Kubernetes, ToolHive, database, storage, Talos, and media facts
 - [Common operations](.agents/common-operations.md): validation, app operations, SOPS, debugging, and backup/restore
 - [ToolHive upgrades](.agents/skills/toolhive-upgrades/SKILL.md): operator or CRD upgrades; includes the required code-reviewer pass
+- [Skill catalog](.agents/skills/): add-app-to-cluster, backup-restore, debug-cluster, git-worktree-isolation, k8s-at-home-research, pr-review, prometheus-cluster-health, toolhive-upgrades — one `SKILL.md` per directory
+- [Useful commands](docs/useful_commands.md): flux/task/talos/sops command reference and app-specific runbooks
+- [LLM hosting](docs/llm-hosting/): sglang/vLLM tuning constraints and benchmark history for `kubernetes/apps/ai/`
 
 Read only references whose trigger keywords match the task. The learned files are authoritative and maintained by continual learning.
 

--- a/docs/useful_commands.md
+++ b/docs/useful_commands.md
@@ -106,6 +106,8 @@ kubectl exec -it -n <ns> deployment/<name> -- /bin/sh
 
 Optional: [kubectl-browse-pvc](https://github.com/clbx/kubectl-browse-pvc) to browse PVCs.
 
+PVC restore from backup: see [volsync-restore.md](volsync-restore.md).
+
 ---
 
 ## Troubleshooting failed HelmReleases
@@ -130,12 +132,7 @@ Avoid deleting other resources (Deployment, Service) that are owned by the HelmR
 
 ## PostgreSQL (CNPG)
 
-**Application credentials** (from `-app` secret):
-
-```bash
-kubectl get secret -n database <cluster-name>-app -o jsonpath='{.data.username}' | base64 -d
-kubectl get secret -n database <cluster-name>-app -o jsonpath='{.data.password}' | base64 -d
-```
+**Application credentials:** each app uses its own sops secret (`INIT_POSTGRES_*` for postgres-init apps) or its managed role's passwordSecret (e.g. `litellm-db`) in the database namespace. There is no shared `-app` secret.
 
 **Connect with psql:**
 
@@ -143,7 +140,7 @@ kubectl get secret -n database <cluster-name>-app -o jsonpath='{.data.password}'
 psql -h <cluster-name>-rw.database.svc.cluster.local -U <app-username> -d <app-database-name> -W
 ```
 
-Use `-app` for application access; reserve `-superuser` for admin.
+Superuser (postgres) password: secret `cloudnative-pg-secret` in the database namespace (spec.superuserSecret).
 
 ---
 
@@ -152,7 +149,7 @@ Use `-app` for application access; reserve `-superuser` for admin.
 1. **Debug pod with DB access:**
 
    ```bash
-   kubectl run tmp-shell --rm -i --tty --image nicolaka/netshoot -n default -- /bin/bash
+   kubectl run tmp-psql --rm -i --tty --image ghcr.io/cloudnative-pg/postgresql:18.4-standard-trixie -n database -- bash
    ```
 
 2. **Connect as postgres and fix permissions if needed:**
@@ -167,8 +164,10 @@ Use `-app` for application access; reserve `-superuser` for admin.
    ```bash
    pg_restore -h postgres16-rw.database.svc.cluster.local -U nextcloud -d nextcloud \
      --clean --if-exists --no-owner --no-privileges --no-tablespaces --no-comments \
-     <backup-file>.sql
+     <backup-file>.dump
    ```
+
+   Plain-text `.sql` dumps: pipe to `psql` instead.
 
 4. **After restore: data-fingerprint (and optionally turn off maintenance mode):**
 


### PR DESCRIPTION
## Summary
- Multi-agent audit + adversarial verification across all 8 `.agents/skills/`, `AGENTS.md`, `.agents/common-operations.md`, and `docs/useful_commands.md`, fixing confirmed factual errors and broken commands (see per-file detail below).
- Cross-referenced `bjw-s-labs/home-ops`'s `add-app` skill for structural improvements to `add-app-to-cluster`.
- `/simplify` pass: deduplicated the skill index (was listed separately in two files), fixed a stale `kustomize build` path and a hardcoded validation command, tightened a few sentences.
- Follow-up: fixed a `kustomize` resource-path style inconsistency in the add-app template, and adopted `flate` (already mise-pinned, previously undocumented) as the primary validation tool across the skill docs and `validate-pr.sh`.

### Representative fixes
- `git-worktree-isolation`: replaced a `git worktree add -b ... --detach` recipe that fails outright with the real `.worktrees/<task>` flow (branched from `origin/main`, with local-config copy).
- `add-app-to-cluster`: fixed a broken `kustomize build` path (was missing the `app/` subdir), replaced a stale hardcoded namespace table with `ls kubernetes/apps/`, added `envoy-external` routing guidance, and deferred its worktree step to `git-worktree-isolation` instead of duplicating a conflicting recipe.
- `debug-cluster`: invalid `talosctl logs --namespace=` flag corrected to the real positional syntax.
- `prometheus-cluster-health`: corrected the datasource (stack is VictoriaMetrics behind vmauth, not a `prometheus-operated` service that doesn't exist) and dropped a nonexistent tool reference.
- `toolhive-upgrades`: removed a dead `docs/ai/` link, fixed the wrong HelmRelease namespace in the smoke-test doc, and now validates via the consolidated script instead of duplicating manual steps.
- `pr-review/scripts/validate-pr.sh`: fixed a `find | head -20` that SIGPIPEs the whole script under `set -euo pipefail` once the repo has >20 shell scripts (it has 211), and swapped its Kustomization-only `kustomize build` loop for `flate test all`, which renders the actual HelmReleases with the real Helm SDK (`kustomize build` can't see into `chartRef: OCIRepository` at all) — falls back to `kustomize build` if `flate` isn't installed. Verified end-to-end: `flate test all` passes clean on the full 276-object tree in ~4s.
- `add-app-to-cluster/references/manifest-templates.md`: the `app/kustomization.yaml` example used `- ./helmrelease.yaml`, but every real app/kustomization.yaml in the repo (187/187) uses bare `helmrelease.yaml` — the leading `./` convention only applies one level up, at the namespace `kustomization.yaml`'s `./<app>/ks.yaml` entries (75/78 real files). Fixed the three misapplied instances; left the correct namespace-level example untouched.
- `docs/useful_commands.md`: Nextcloud restore runbook used an image with no `psql` client; corrected image and secret-naming conventions.
- `AGENTS.md`: added a skill catalog and doc pointers — previously only `toolhive-upgrades` was reachable from the entry doc; the other 7 skills, `docs/useful_commands.md`, and `docs/llm-hosting/` were undiscoverable.
- `.gitignore`: added `.worktrees/` (was showing as permanent untracked noise).

## Test plan
- [x] All touched files pass link/frontmatter/shell-syntax validation (relative links, `bash -n`, YAML frontmatter via `yq`, shellcheck)
- [x] Cross-file consistency checked (worktree recipe, namespace lists, validation commands, envoy parentRef naming, toolhive pin paths, kustomize resource-path style all agree across files)
- [x] `validate-pr.sh` run end-to-end after the `flate` change — flate phase passes clean; remaining shellcheck/naming/security warnings are pre-existing repo-wide baseline noise unrelated to this diff
- [x] `git diff --check` clean, no trailing whitespace/whitespace-only line issues
- [ ] No cluster-affecting changes — this is docs-only, nothing to reconcile