### PR TITLE
fix(sglang): remove misleading L3 dashboard panels

### DIFF
--- a/kubernetes/apps/ai/sglang/app/dashboard/sglang.json
+++ b/kubernetes/apps/ai/sglang/app/dashboard/sglang.json
@@ -2072,159 +2072,13 @@
       "interval": "1m"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "Local-disk usage on control-1's /var/openebs (device vda, backs all openebs-hostpath PVs on the node, of which the L3 cache is the dominant grower under its 80G soft cap). sglang's HiCacheFile backend doesn't export its own size metrics in this version (get_stats() unimplemented), and openebs-hostpath's CSI driver doesn't report per-PVC usage (kubelet_volume_stats_used_bytes returns the whole-filesystem figure for every PVC on it) -- so this is node filesystem usage, not an L3-exclusive number.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "yellow",
-                "value": 0.85
-              },
-              {
-                "color": "red",
-                "value": 0.95
-              }
-            ]
-          },
-          "unit": "percentunit",
-          "decimals": 0
-        },
-        "overrides": []
-      },
-      "id": 93,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "center",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": ["lastNotNull"],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "value",
-        "wideLayout": true
-      },
-      "pluginVersion": "11.0.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "expr": "1 - (node_filesystem_avail_bytes{nodename=\"control-1\", mountpoint=\"/var\"} / node_filesystem_size_bytes{nodename=\"control-1\", mountpoint=\"/var\"})",
-          "instant": true,
-          "legendFormat": "/var usage",
-          "refId": "A"
-        }
-      ],
-      "title": "L3 Disk Cache Usage",
-      "type": "stat",
-      "gridPos": {
-        "x": 0,
-        "y": 74,
-        "w": 12,
-        "h": 8
-      }
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "Read/write throughput on control-1's host disk (/dev/vda4, backs the L3 PVC via openebs-hostpath). Shared with the rest of that device's local PVs, so treat as an activity trend, not an L3-exclusive figure.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "drawStyle": "line",
-            "fillOpacity": 10,
-            "gradientMode": "none",
-            "lineWidth": 2,
-            "showPoints": "never",
-            "spanNulls": true
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          },
-          "unit": "Bps",
-          "min": 0
-        },
-        "overrides": []
-      },
-      "id": 94,
-      "options": {
-        "legend": {
-          "calcs": ["mean", "max"],
-          "displayMode": "table",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        }
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "expr": "rate(node_disk_read_bytes_total{nodename=\"control-1\", device=\"vda\"}[$__rate_interval])",
-          "legendFormat": "disk read",
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "expr": "rate(node_disk_written_bytes_total{nodename=\"control-1\", device=\"vda\"}[$__rate_interval])",
-          "legendFormat": "disk write",
-          "refId": "B"
-        }
-      ],
-      "title": "L3 Host Disk I/O (shared device)",
-      "type": "timeseries",
-      "gridPos": {
-        "x": 12,
-        "y": 74,
-        "w": 12,
-        "h": 8
-      }
-    },
-    {
       "id": 60,
       "type": "row",
       "title": "GPU Hardware (R9700 / gfx1201)",
       "collapsed": false,
       "gridPos": {
         "x": 0,
-        "y": 82,
+        "y": 74,
         "w": 24,
         "h": 1
       },
@@ -2266,7 +2120,7 @@
       },
       "gridPos": {
         "x": 0,
-        "y": 83,
+        "y": 75,
         "w": 12,
         "h": 8
       },
@@ -2350,7 +2204,7 @@
       },
       "gridPos": {
         "x": 12,
-        "y": 83,
+        "y": 75,
         "w": 12,
         "h": 8
       },


### PR DESCRIPTION
## Summary
- Remove "L3 Disk Cache Usage" and "L3 Host Disk I/O" panels from the sglang Grafana dashboard
- L3 hicache was trialled and removed 2026-07-08 (0% hit rate over 6h+, documented in `docs/llm-hosting/sglang-blockers.md`)
- Neither panel ever measured an L3-exclusive metric — both are generic control-1 node `/var` filesystem usage and `vda` disk I/O, shared with every other workload on the node (the panel description already disclosed this, but the titles didn't, causing confusion during an incident review today)
- No functional change to sglang itself, dashboard-only

## Test plan
- [x] JSON validated after edit
- [x] Remaining panels' gridPos y-values shifted up to close the gap left by the removed panels