### PR TITLE
fix(kopiur-system): raise bootstrap job deadline for the adopted repository

### DIFF
--- a/kubernetes/apps/kopiur-system/kopiur/repository/clusterrepository.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/repository/clusterrepository.yaml
@@ -22,5 +22,8 @@ spec:
       name: kopia-nas-password
       namespace: kopiur-system
       key: KOPIA_PASSWORD
+  bootstrap:
+    failurePolicy:
+      activeDeadlineSeconds: 600
   scheduleDefaults:
     timezone: ${TIMEZONE}


### PR DESCRIPTION
## Summary
- The `kopia-nas` `ClusterRepository`'s bootstrap Job hit `DeadlineExceeded` (default `activeDeadlineSeconds: 120`) connecting to the adopted production repository — the first connect + catalog scan against real history (22 snapshot identities) over NFS needs more time than the default budget.
- Raised `spec.bootstrap.failurePolicy.activeDeadlineSeconds` to `600`, per the CRD's own documented guidance for slow backends.

## Test plan
- [x] `flate test all --path ./kubernetes/flux/cluster` — 277/277 passed
- [ ] Post-merge: bootstrap Job completes, `ClusterRepository/kopia-nas` reaches `Ready`