### PR TITLE
fix(kopiur-system): raise bootstrap deadline to 45min, second bottleneck found

### DIFF
--- a/kubernetes/apps/kopiur-system/kopiur/repository/clusterrepository.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/repository/clusterrepository.yaml
@@ -24,6 +24,6 @@ spec:
       key: KOPIA_PASSWORD
   bootstrap:
     failurePolicy:
-      activeDeadlineSeconds: 600
+      activeDeadlineSeconds: 2700
   scheduleDefaults:
     timezone: ${TIMEZONE}


### PR DESCRIPTION
## Summary
- Follow-up to #3817. Even after removing 311,591 empty shard directories (kopia#2600) from the adopted repository, the bootstrap Job still hit the 600s deadline.
- Investigated: no lock contention from the still-active volsync fork (its last maintenance run completed 4h prior, no concurrent syncs at the time). Low CPU throughout both failures is consistent with I/O-bound work, not a hang/crash.
- Working theory: kopia's connect + catalog-scan step also reads snapshot manifest blob *content* (not just directory listings) to build the discovered-Snapshot catalog — a different cost layer than the directory-count problem already fixed.
- Raised `activeDeadlineSeconds` to 2700 (45min) as a one-time bootstrap cost, to establish whether this genuinely just needs more time.

## Test plan
- [x] `flate test all --path ./kubernetes/flux/cluster` — 277/277 passed
- [ ] Post-merge: bootstrap Job completes, `ClusterRepository/kopia-nas` reaches `Ready`