### PR TITLE
fix(kopiur-system): run kopia-nas movers with GID 568 for repo write access

### DIFF
--- a/kubernetes/apps/kopiur-system/kopiur/repository/clusterrepository.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/repository/clusterrepository.yaml
@@ -25,5 +25,8 @@ spec:
   bootstrap:
     failurePolicy:
       activeDeadlineSeconds: 2700
+  moverDefaults:
+    securityContext:
+      runAsGroup: 568
   scheduleDefaults:
     timezone: ${TIMEZONE}


### PR DESCRIPTION
## Summary
- The adopted NFS kopia repository (`/mnt/TanguilleServer/VolsyncKopia`) is entirely owned by `568:568` — the volsync fork's UID, itself a TrueCharts-derived convention used cluster/NAS-wide.
- `kopiur-mover` runs as `65532:65532` (distroless nonroot). Live-verified via a throwaway pod: `runAsGroup: 65532` → `mkdir: permission denied`; `runAsGroup: 568` → write succeeds.
- Bootstrap (mostly read-only) already succeeds without this, but real snapshot/maintenance writes need it — this closes that gap ahead of Phase 3.

## Context
Also root-caused and fixed directly on the NAS (data, not git-tracked): 1,943/3,409 directories and 7,089/8,139 files in the repo had drifted to `0700` (owner-only), causing kopiur's bootstrap to hang in an infinite silent retry loop rather than fail fast. Normalized to `0775` to match the already-working majority. That data-level fix is what actually got Phase 2 bootstrap to `Ready` (493 snapshots discovered); this PR is the follow-up so future write operations don't hit the same UID/GID gap.

## Test plan
- [x] Live-verified `runAsGroup: 568` grants write via a throwaway UID 65532/GID 568 pod (`mkdir` succeeded)
- [x] `flate test all` passes (277/277, same 2 pre-existing unrelated warnings)
- [ ] Confirm on merge: Flux reconciles the ClusterRepository without drift from the already-live `kubectl patch`