### PR TITLE
feat(kopiur-system): add kopia-nas Maintenance CR (PromptCondition)

### DIFF
--- a/kubernetes/apps/kopiur-system/kopiur/repository/kustomization.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/repository/kustomization.yaml
@@ -4,4 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - clusterrepository.yaml
+  - maintenance.yaml
   - secret.sops.yaml

--- a/kubernetes/apps/kopiur-system/kopiur/repository/maintenance.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/repository/maintenance.yaml
@@ -1,0 +1,21 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kopiur.home-operations.com/maintenance_v1alpha1.json
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: Maintenance
+metadata:
+  name: kopia-nas
+spec:
+  repository:
+    kind: ClusterRepository
+    name: kopia-nas
+  schedule:
+    quick:
+      cron: "H */6 * * *"
+      jitter: 30m
+    full:
+      cron: "H 3 * * 0"
+      jitter: 1h
+    timezone: ${TIMEZONE}
+  ownership:
+    owner: kopiur/kopia-nas
+    takeoverPolicy: PromptCondition


### PR DESCRIPTION
## Summary
- Phase 3 step 1: standalone `Maintenance` CR for `ClusterRepository/kopia-nas`, `ownership.takeoverPolicy: PromptCondition`.
- The ClusterRepository already defaults to `spec.maintenance.enabled: false` (confirmed live in its status), so there's no auto-managed Maintenance to conflict with this explicit one.
- `PromptCondition` is non-destructive: it surfaces the fork's existing lease as a condition without seizing it. Force takeover is a deliberate follow-up once the fork's `KopiaMaintenance` (`volsync-system`) is stood down.
- Field shapes and the `ownership.owner` free-form-string pattern verified against kopiur's own `deploy/examples/scenarios/05-adopt-existing-repo.yaml`, which matches our exact scenario (adopting an existing repo's maintenance lease).

## Test plan
- [x] `flate test all` passes (277/277, same 2 pre-existing unrelated warnings)
- [ ] Confirm on merge: `Maintenance/kopia-nas` reports the lease conflict via status/conditions (fork still holds it)