### PR TITLE
fix(kopiur-system): allow kopiur-system to reference kopia-nas

### DIFF
--- a/kubernetes/apps/kopiur-system/kopiur/repository/clusterrepository.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/repository/clusterrepository.yaml
@@ -9,6 +9,7 @@ spec:
     list:
       - ai
       - default
+      - kopiur-system
       - media
   backend:
     filesystem:


### PR DESCRIPTION
## Summary
- The Maintenance CR (PR #3826) lives in `kopiur-system` alongside the `ClusterRepository`, its secret, and the controller — it's a repository-level operational concern, not tied to any one app namespace.
- `allowedNamespaces.list` only had the 3 app namespaces from Phase 2 (`ai`, `default`, `media`). The admission webhook correctly rejected the Maintenance CR: `namespace "kopiur-system" is not in the allowedNamespaces of ClusterRepository "kopia-nas"`.
- Adds `kopiur-system` to the list.

## Test plan
- [x] `flate test all` passes (277/277, same 2 pre-existing unrelated warnings)
- [ ] Confirm on merge: `Maintenance/kopia-nas` admits successfully and reports the fork's lease conflict via status