### PR TITLE
fix(kopiur-system): bump kopiur 0.7.1 -> 0.7.2

### DIFF
--- a/docs/kopiur-migration-plan.md
+++ b/docs/kopiur-migration-plan.md
@@ -317,6 +317,14 @@ above confirmed live in-cluster the same day (Kustomization `Ready=True`,
 CRD count 8, 6 `PrometheusRule/kopiur-controller` alerts, dashboard present).
 No volsync apps touched.
 
+**Follow-up (2026-07-11): bumped `0.7.1` → `0.7.2`.** Routine per
+`docs/upgrade.md` ("no action needed" — stable per-CR credential Secret
+naming replaces the old per-run naming, `helm upgrade` adds the RBAC
+`secrets` delete verb the cleanup needs). Directly relevant here: Phase 3's
+`Maintenance` CR runs on a recurring cron with `credentialProjection`
+enabled — exactly the leak this release fixes (0.7.1 minted a fresh
+credential Secret copy per run, unbounded).
+
 ## Phase 2 — Adopt the repository via `kubectl kopiur migrate volsync`
 
 In `kopiur-system`:

--- a/kubernetes/apps/kopiur-system/kopiur/app/ocirepository.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/app/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 0.7.1
+    tag: 0.7.2
   url: oci://ghcr.io/home-operations/charts/kopiur


### PR DESCRIPTION
## Summary
- Routine per kopiur's own \`docs/upgrade.md\` ("no action needed"): stable per-CR credential Secret naming replaces the old per-run naming, \`helm upgrade\` adds the RBAC \`secrets\` delete verb the cleanup needs.
- Directly relevant here: Phase 3's \`Maintenance\` CR runs on a recurring cron with \`credentialProjection\` enabled — exactly the leak 0.7.2 fixes. 0.7.1 minted a fresh credential Secret copy per run with no delete path (\`{maintenance}-q|f-{slot_ts}\`), unbounded accumulation on an hourly-ish cron.
- No breaking changes (unlike 0.5.x->0.6.0, which needs a manual CRD-migration dance — not applicable, we installed fresh at 0.7.1).

## Test plan
- [x] \`flate test all\` passes (277/277, same 2 pre-existing unrelated warnings)
- [ ] Confirm on merge: kopiur-controller/webhook roll cleanly, ClusterRepository/Maintenance stay Ready