### PR TITLE
feat(kopiur): add components/kopiur, gate credential projection on repo

### DIFF
--- a/docs/kopiur-migration-plan.md
+++ b/docs/kopiur-migration-plan.md
@@ -605,10 +605,30 @@ not the stale README):
    the Risk gate's #233 note. Don't force-reconcile or prune-and-recreate its
    Kustomization without checking for orphaned `prime-*` PVCs afterward.
 
-**Rollback (canary only)**: the volsync history is still in the repo; swap the
-component back, recreate the sops secret, and a `ReplicationDestination`
-restore-once repopulates from the same snapshots.
-**Status**: ☐ not started
+**Component built 2026-07-12** — `kubernetes/components/kopiur/` (4 files +
+`kustomization.yaml`), verified with a standalone `kustomize build` against
+the component before wiring any app. Two deviations from the draft above,
+both confirmed against `crates/api/src/identity.rs` (`resolve_identity`),
+not guessed:
+- **No `spec.identity` override needed at all.** The default `username` is
+  the `SnapshotPolicy`'s own `metadata.name`, the default `hostname` is its
+  `metadata.namespace` — since both objects are named `${APP}` in the app's
+  own namespace, the defaults already resolve to exactly `<app>@<namespace>`,
+  matching the fork's recorded identity with zero config. Only
+  `sources[0].sourcePathOverride: /data` is needed, because kopiur's own
+  default source path is `/pvc/<name>`, not `/data` — the fork's mover
+  always recorded `/data` regardless of the app's real container mount
+  path, so this one field is what actually preserves continuity.
+- Added `ClusterRepository.spec.credentialProjection.allowed: true` (the
+  repository-owner gate) — the draft's per-policy `credentialProjection.
+  enabled: true` is necessary but not sufficient; the CRD requires the gate
+  set on the owning `ClusterRepository` too, or every mover Job 403s
+  copying the credential Secret into its own namespace.
+
+**Rollback (component)**: unreferenced by any app yet — delete the
+directory, nothing live depends on it.
+**Status**: component ☑ done (unwired); canary cutover (dumbassets) ☐ not
+started — next live step.
 
 ## Phase 5 — Fleet-wide cutover (single flip, not staged batches)
 

--- a/kubernetes/apps/kopiur-system/kopiur/repository/clusterrepository.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/repository/clusterrepository.yaml
@@ -26,6 +26,8 @@ spec:
   bootstrap:
     failurePolicy:
       activeDeadlineSeconds: 2700
+  credentialProjection:
+    allowed: true
   moverDefaults:
     securityContext:
       runAsGroup: 568

--- a/kubernetes/components/kopiur/kustomization.yaml
+++ b/kubernetes/components/kopiur/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - pvc.yaml
+  - restore.yaml
+  - snapshotpolicy.yaml
+  - snapshotschedule.yaml

--- a/kubernetes/components/kopiur/pvc.yaml
+++ b/kubernetes/components/kopiur/pvc.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ${APP}
+spec:
+  accessModes: ["${BACKUP_ACCESSMODES:=ReadWriteOnce}"]
+  dataSourceRef:
+    apiGroup: kopiur.home-operations.com
+    kind: Restore
+    name: ${APP}-restore
+  resources:
+    requests:
+      storage: ${BACKUP_CAPACITY:=5Gi}
+  storageClassName: ${BACKUP_STORAGECLASS:=ceph-block}

--- a/kubernetes/components/kopiur/restore.yaml
+++ b/kubernetes/components/kopiur/restore.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kopiur.home-operations.com/restore_v1alpha1.json
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: Restore
+metadata:
+  name: ${APP}-restore
+spec:
+  source:
+    fromPolicy:
+      name: ${APP}
+      offset: 0
+  # Explicit PASSIVE populator mode — claimed by the PVC's dataSourceRef below.
+  target:
+    populator: {}
+  policy:
+    # deploy-or-restore: fresh cluster + empty repo -> empty PVC, existing
+    # repo -> restore the latest snapshot.
+    onMissingSnapshot: Continue
+  credentialProjection:
+    enabled: true

--- a/kubernetes/components/kopiur/snapshotpolicy.yaml
+++ b/kubernetes/components/kopiur/snapshotpolicy.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kopiur.home-operations.com/snapshotpolicy_v1alpha1.json
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: SnapshotPolicy
+metadata:
+  name: ${APP}
+spec:
+  repository:
+    kind: ClusterRepository
+    name: kopia-nas
+  sources:
+    - pvc:
+        name: ${APP}
+      # The fork's mover always recorded /data regardless of the app's real
+      # mount path — kopiur's own default (/pvc/<name>) would start a new
+      # identity strand instead of continuing the adopted history.
+      sourcePathOverride: /data
+  compression:
+    compressor: zstd
+  retention:
+    keepHourly: 24
+    keepDaily: 7
+  volumeSnapshotClassName: ${BACKUP_SNAPSHOTCLASS:=csi-ceph-blockpool}
+  credentialProjection:
+    enabled: true

--- a/kubernetes/components/kopiur/snapshotschedule.yaml
+++ b/kubernetes/components/kopiur/snapshotschedule.yaml
@@ -1,0 +1,12 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kopiur.home-operations.com/snapshotschedule_v1alpha1.json
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: SnapshotSchedule
+metadata:
+  name: ${APP}
+spec:
+  policyRef:
+    name: ${APP}
+  schedule:
+    cron: "H */12 * * *"
+    jitter: 30m


### PR DESCRIPTION
## Summary
- New Kustomize component `kubernetes/components/kopiur/` (SnapshotPolicy/SnapshotSchedule/Restore/PVC), mirroring `components/volsync`'s shape with `BACKUP_*` vars replacing `VOLSYNC_*`
- No `spec.identity` override needed: kopiur's own identity defaults (SnapshotPolicy name -> username, namespace -> hostname) already reproduce the fork's `<app>@<namespace>` identity when both objects share the app's name — verified against `crates/api`'s `resolve_identity`, not guessed
- `sources[0].sourcePathOverride: /data` is the one field that actually matters for continuity, since kopiur's default source path (`/pvc/<name>`) differs from the fork's fixed `/data` convention
- Adds `ClusterRepository.spec.credentialProjection.allowed: true` — the owner-side gate required alongside each consumer's own `credentialProjection.enabled` for mover Jobs in workload namespaces to read the shared repo secret

## Not included
Unwired — no app references this component yet. Zero live-cluster effect. The `dumbassets` canary cutover is a separate, deliberately later step.

## Test plan
- [x] `flate test all` — 277/277 passed, no new warnings
- [x] Standalone `kustomize build` against the component (outside the repo tree) confirms all 4 manifests render with the expected field shapes