### PR TITLE
feat(dumbassets): cut over to kopiur (canary)

### DIFF
--- a/docs/kopiur-migration-plan.md
+++ b/docs/kopiur-migration-plan.md
@@ -621,8 +621,12 @@ not the stale README):
   fresh cluster with empty repo → empty PVC, existing repo → restore).
 - `pvc.yaml` — same as today's but `dataSourceRef` → `{apiGroup:
   kopiur.home-operations.com, kind: Restore, name: ${APP}-restore}` and
-  `${BACKUP_CAPACITY:=5Gi}` / `${BACKUP_STORAGECLASS:=ceph-block}` /
-  `${BACKUP_ACCESSMODES:=ReadWriteOnce}`.
+  `${PVC_CAPACITY:=5Gi}` / `${PVC_STORAGECLASS:=ceph-block}` /
+  `${PVC_ACCESSMODES:=ReadWriteOnce}` — named for what they actually size
+  (the app's real PVC), not `BACKUP_*`; there's no separate "backup
+  storage" concept in either volsync or kopiur, both mechanisms
+  parameterize the live app volume directly (the old `VOLSYNC_CAPACITY`
+  had the exact same property, just unnoticed).
 - `kustomization.yaml` (Component) wrapping the four.
 
 **Canary: `dumbassets`** (1Gi, `default`, lowest value). Cutover recipe:

--- a/kubernetes/apps/default/dumbassets/ks.yaml
+++ b/kubernetes/apps/default/dumbassets/ks.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   targetNamespace: *namespace
   components:
-    - ../../../../components/volsync
+    - ../../../../components/kopiur
   path: ./kubernetes/apps/default/dumbassets/app
   prune: true
   sourceRef:
@@ -20,4 +20,4 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      VOLSYNC_CAPACITY: 1Gi
+      PVC_CAPACITY: 1Gi

--- a/kubernetes/components/kopiur/pvc.yaml
+++ b/kubernetes/components/kopiur/pvc.yaml
@@ -4,12 +4,12 @@ kind: PersistentVolumeClaim
 metadata:
   name: ${APP}
 spec:
-  accessModes: ["${BACKUP_ACCESSMODES:=ReadWriteOnce}"]
+  accessModes: ["${PVC_ACCESSMODES:=ReadWriteOnce}"]
   dataSourceRef:
     apiGroup: kopiur.home-operations.com
     kind: Restore
     name: ${APP}-restore
   resources:
     requests:
-      storage: ${BACKUP_CAPACITY:=5Gi}
-  storageClassName: ${BACKUP_STORAGECLASS:=ceph-block}
+      storage: ${PVC_CAPACITY:=5Gi}
+  storageClassName: ${PVC_STORAGECLASS:=ceph-block}


### PR DESCRIPTION
## Summary
- Canary migration per docs/kopiur-migration-plan.md Phase 4: swaps `components/volsync` -> `components/kopiur` in dumbassets's `ks.yaml`, picked as the lowest-value app (1Gi, `default` namespace) to prove the mechanism live before the fleet-wide cutover
- Renames the component's `BACKUP_CAPACITY`/`BACKUP_STORAGECLASS`/`BACKUP_ACCESSMODES` vars to `PVC_*` -- they size the app's real PVC, not a separate backup volume
- A final volsync backup was triggered and completed live before this swap, so the kopiur `Restore` populator has a fresh restore point

## Not included here (live cluster steps after merge)
- Deleting the old PVC so the new `Restore` populator can claim the name
- Verifying the restored data + a fresh kopiur-side backup

## Test plan
- [x] `flate test all` — 277/277 passed, no new warnings
- [x] Final volsync backup for dumbassets completed successfully (`lastSyncTime` updated)
- [ ] Post-merge: PVC swap completes, app data intact, new kopiur snapshot lands with matching identity