### PR TITLE
fix(volsync): align fork mover default UID with kopiur (568 -> 65532)

### DIFF
--- a/docs/kopiur-migration-plan.md
+++ b/docs/kopiur-migration-plan.md
@@ -124,6 +124,26 @@ Mitigations baked into this plan:
   content the same way. This is why the fork's `KopiaMaintenance` is
   disabled in Phase 3 rather than left running dual-write. Full writeup in
   Phase 2/3 below.
+  **Live incident, 2026-07-12**: disabling `KopiaMaintenance` wasn't
+  sufficient — the fork's regular `ReplicationSource` backups hit the same
+  bug independently, because `kopia.maintenance.f` (rewritten by kopiur's
+  own maintenance every ~6h) is read on **every** repository connect,
+  regardless of which app is backing up. 4 concurrently-running fork
+  backups (dumbassets, changedetection, karakeep, nextcloud) were all
+  silently stuck at "Connecting to filesystem repository" simultaneously.
+  Unblocked immediately with the same repo-wide chmod (this time as uid
+  `65532` via a throwaway pod — `kubectl exec` as root failed with
+  `Operation not permitted`, because the NFS export has `root_squash`;
+  only the actual owning UID can chmod its own files over NFS). **Durable
+  fix**: `components/volsync`'s `moverSecurityContext.runAsUser` default
+  changed `568` → `65532` (`replicationsource.yaml` +
+  `replicationdestination.yaml`; `runAsGroup`/`fsGroup` stay `568`), so the
+  fork's mover now shares kopiur's own UID. This closes the gap in both
+  directions at once: the fork can read kopiur's `65532`-owned files (UID
+  match), and if the fork's *own* v0.22.3 kopia binary also defaults to a
+  restrictive create mode, its new writes become `65532:568` too — readable
+  by kopiur for the same reason. Only hermes overrides `VOLSYNC_PUID`
+  explicitly (`10000`), unaffected by this default change.
 
 ## Current state (inventoried 2026-07-03, re-verified 2026-07-11)
 

--- a/kubernetes/components/volsync/replicationdestination.yaml
+++ b/kubernetes/components/volsync/replicationdestination.yaml
@@ -20,7 +20,7 @@ spec:
     copyMethod: Snapshot
     enableFileDeletion: true
     moverSecurityContext:
-      runAsUser: ${VOLSYNC_PUID:=568}
+      runAsUser: ${VOLSYNC_PUID:=65532}
       runAsGroup: ${VOLSYNC_PGID:=568}
       fsGroup: ${VOLSYNC_PGID:=568}
     moverVolumes:

--- a/kubernetes/components/volsync/replicationsource.yaml
+++ b/kubernetes/components/volsync/replicationsource.yaml
@@ -14,7 +14,7 @@ spec:
     compression: zstd-fastest
     copyMethod: Snapshot
     moverSecurityContext:
-      runAsUser: ${VOLSYNC_PUID:=568}
+      runAsUser: ${VOLSYNC_PUID:=65532}
       runAsGroup: ${VOLSYNC_PGID:=568}
       fsGroup: ${VOLSYNC_PGID:=568}
     moverVolumes:


### PR DESCRIPTION
## Summary
- Disabling `KopiaMaintenance` (PR #3834) wasn't sufficient: the fork's regular `ReplicationSource` backups hit the same `PermissionDenied` retry-forever bug independently, since `kopia.maintenance.f` (rewritten by kopiur's own maintenance every ~6h) is read on every repository connect, regardless of which app is backing up
- Live incident: 4 concurrent fork backups (dumbassets, changedetection, karakeep, nextcloud) were all silently stuck at once — unblocked immediately with a repo-wide chmod (as uid 65532, via a throwaway pod; NFS `root_squash` means even root-in-pod can't override another UID's file perms)
- Durable fix: `components/volsync`'s `moverSecurityContext.runAsUser` default changes `568` -> `65532` (matching kopiur's own mover UID) on both `ReplicationSource` and `ReplicationDestination`; `runAsGroup`/`fsGroup` stay `568`
- Closes the gap in both directions: the fork can now read kopiur's `65532`-owned files, and if the fork's own kopia binary also defaults to a restrictive create mode, its writes become `65532:568` too, readable by kopiur for the same reason
- Only hermes overrides `VOLSYNC_PUID` explicitly (`10000`), unaffected by this default change

## Test plan
- [x] `flate test all` — 277/277 passed, no new warnings
- [ ] Confirm the next scheduled fork backup for a non-hermes app runs as uid 65532 and completes without hanging