### PR TITLE
fix(kopiur): inherit mover security context from PVC consumer

### DIFF
--- a/kubernetes/apps/ai/hermes/app/snapshotpolicy.yaml
+++ b/kubernetes/apps/ai/hermes/app/snapshotpolicy.yaml
@@ -24,9 +24,11 @@ spec:
   credentialProjection:
     enabled: true
   # hermes's data is owned 10000:10000 (not the cluster's usual 568/65532
-  # convention) — the mover needs to match to read it, same reason the
-  # volsync fork carries VOLSYNC_PUID/PGID: "10000" for this app.
+  # convention), same reason the volsync fork carries VOLSYNC_PUID/PGID:
+  # "10000" for this app. A hardcoded runAsUser/runAsGroup here fixed
+  # source-PVC reads but broke repo-connect (repo blobs are owned by the
+  # shared uid, not 10000) — inherit from the live pod instead, same as
+  # every other app.
   mover:
-    securityContext:
-      runAsUser: 10000
-      runAsGroup: 10000
+    inheritSecurityContextFrom:
+      pvcConsumer: {}

--- a/kubernetes/components/kopiur/backup/snapshotpolicy.yaml
+++ b/kubernetes/components/kopiur/backup/snapshotpolicy.yaml
@@ -15,6 +15,9 @@ spec:
       # mount path — kopiur's own default (/pvc/<name>) would start a new
       # identity strand instead of continuing the adopted history.
       sourcePathOverride: /data
+  mover:
+    inheritSecurityContextFrom:
+      pvcConsumer: {}
   compression:
     compressor: zstd
   retention:


### PR DESCRIPTION
## Summary
- Wire `spec.mover.inheritSecurityContextFrom.pvcConsumer: {}` into the shared kopiur backup SnapshotPolicy template, and onto hermes's hand-authored one (replacing its hardcoded `runAsUser/runAsGroup: 10000`, which fixed source-PVC reads but broke repo-connect).
- Follows the TrueNAS Mapall change on the kopia NFS export (now uniformly presents every mover as the shared repo uid), which fixes repo-connect for all identities. The mover still needs each app's own uid to read its source PVC, which this field handles by copying the live pod's securityContext.

## Test plan
- [x] `flate build ks <app>` clean for jellyfin and hermes
- [x] `flate build all` clean, no collateral breakage
- [ ] Live re-verification of the 9 previously-blocked apps + hermes via `kubectl kopiur snapshot now --wait` after merge