### PR TITLE
fix(kopiur): pin repository mover default to uid 568

### DIFF
--- a/kubernetes/apps/kopiur-system/kopiur/repository/clusterrepository.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/repository/clusterrepository.yaml
@@ -30,6 +30,7 @@ spec:
     allowed: true
   moverDefaults:
     securityContext:
+      runAsUser: 568
       runAsGroup: 568
   scheduleDefaults:
     timezone: ${TIMEZONE}


### PR DESCRIPTION
## Summary
- Pin `ClusterRepository.spec.moverDefaults.securityContext.runAsUser: 568` alongside the existing `runAsGroup: 568`.
- Repo-only movers (maintenance, compaction — anything without a PVC to inherit identity from via `inheritSecurityContextFrom`) fell back to the image's default uid (65532), not the shared 568 the NFS export's Mapall maps everyone to. Whenever Mapall was briefly toggled off for cleanup, these movers wrote fresh content back under 65532, recreating the stale-permission problem the toggle was meant to fix — happened twice during Phase 5 verification.
- This makes these movers write consistently as 568 regardless of Mapall's on/off state, so this class of drift can't recur.

## Test plan
- [x] `flate build ks kopiur-repository` clean, `moverDefaults.securityContext` includes both `runAsUser` and `runAsGroup`
- [x] `flate build all` clean, no collateral breakage