### PR TITLE
feat(kopiur): enable privileged movers for root-uid apps

### DIFF
--- a/kubernetes/apps/ai/kustomization.yaml
+++ b/kubernetes/apps/ai/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 namespace: ai
 components:
   - ../../components/common
+  - ../../components/kopiur/privileged-movers
 resources:
   - ./hermes/ks.yaml
   - ./litellm/ks.yaml

--- a/kubernetes/apps/default/kustomization.yaml
+++ b/kubernetes/apps/default/kustomization.yaml
@@ -6,6 +6,7 @@ namespace: default
 
 components:
   - ../../components/common
+  - ../../components/kopiur/privileged-movers
 
 resources:
   - ./changedetection/ks.yaml

--- a/kubernetes/apps/media/kustomization.yaml
+++ b/kubernetes/apps/media/kustomization.yaml
@@ -7,6 +7,7 @@ namespace: media
 components:
   - ../../components/common
   - ../../components/affinity-control-1
+  - ../../components/kopiur/privileged-movers
 
 resources:
   - ./bazarr/ks.yaml

--- a/kubernetes/components/kopiur/privileged-movers/kustomization.yaml
+++ b/kubernetes/components/kopiur/privileged-movers/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+patches:
+  - target:
+      kind: Namespace
+      name: not-used
+    patch: |
+      - op: add
+        path: /metadata/annotations/kopiur.home-operations.com~1privileged-movers
+        value: "true"


### PR DESCRIPTION
## Summary
- jellyfin, changedetection, wizarr, odysseus, and opencode all own their data as root, so a mover inheriting their identity via `inheritSecurityContextFrom.pvcConsumer` needs the same privilege — kopiur gates that behind an explicit per-namespace opt-in (`kopiur.home-operations.com/privileged-movers`) since a tenant with access to the namespace could otherwise reuse the mover ServiceAccount to run pods at that privilege.
- Scoped to `media`/`default`/`ai` (the namespaces containing these 5 apps) via a dedicated component (`kubernetes/components/kopiur/privileged-movers`) patching just the `kopiur.home-operations.com/privileged-movers` annotation, rather than touching the shared `components/common` namespace component — which already blanket-enables volsync's equivalent annotation across every namespace. This keeps kopiur's privilege scoped instead of following that precedent.

## Test plan
- [x] `flate build all` clean
- [x] Confirmed via rendered output that the annotation lands on exactly `ai`/`default`/`media` namespaces and no others
- [ ] Live re-verification of the 5 root-uid apps' snapshots after merge