### PR TITLE
feat(kube-system): add etcd-defrag CronJob via app-template

### DIFF
--- a/kubernetes/apps/kube-system/etcd-defrag/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/etcd-defrag/app/helmrelease.yaml
@@ -1,0 +1,83 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: etcd-defrag
+spec:
+  interval: 30m
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+
+  values:
+    defaultPodOptions:
+      # Must use host network to access etcd on localhost:2379
+      hostNetwork: true
+      hostPID: true
+      securityContext:
+        runAsGroup: 0
+        runAsNonRoot: false
+        runAsUser: 0
+      # Ensure this only runs on the control plane node
+      nodeSelector:
+        node-role.kubernetes.io/control-plane: ""
+      tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
+
+    controllers:
+      etcd-defrag:
+        type: cronjob
+        cronjob:
+          # Run weekly on Sunday at 3 AM
+          schedule: "0 3 * * 0"
+          concurrencyPolicy: Forbid
+          failedJobsHistory: 1
+          successfulJobsHistory: 1
+        containers:
+          app:
+            image:
+              repository: ghcr.io/ahrtr/etcd-defrag
+              tag: v0.42.0@sha256:5138a12eda39067dabcf1d420d66f54f29f1e9297109a6b36574e010b45d58cc
+            args:
+              - --endpoints=https://127.0.0.1:2379
+              - --cluster
+              - --cacert=/certs/ca.crt
+              - --cert=/certs/server.crt
+              - --key=/certs/server.key
+              # Defrag when DB quota usage > 50% OR free space > 100MB
+              - --defrag-rule=dbQuotaUsage > 0.5 || dbSizeFree > 100*1024*1024
+              # Move leader during defrag (safe for single-node)
+              - --move-leader
+              # Wait 30s between defrags (only matters if you had multiple members)
+              - --wait-between-defrags=30s
+              # Match the quota-backend-bytes we set in Talos config
+              - --etcd-storage-quota-bytes=8589934592
+              # Auto-disalarm space quota alarms
+              - --auto-disalarm
+              - --disalarm-threshold=0.8
+            resources:
+              requests:
+                cpu: 25m
+                memory: 128Mi
+              limits:
+                memory: 128Mi
+            securityContext:
+              privileged: true
+
+    persistence:
+      certs:
+        type: hostPath
+        hostPath: /system/secrets/etcd
+        globalMounts:
+          - path: /certs
+            readOnly: true
+      tmpfs:
+        type: emptyDir
+        advancedMounts:
+          etcd-defrag:
+            app:
+              - path: /tmp
+                subPath: tmp

--- a/kubernetes/apps/kube-system/etcd-defrag/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/etcd-defrag/app/helmrelease.yaml
@@ -12,7 +12,8 @@ spec:
 
   values:
     defaultPodOptions:
-      # Must use host network to access etcd on localhost:2379
+      # Must use host network and PID namespace to access Talos etcd on localhost:2379.
+      automountServiceAccountToken: false
       hostNetwork: true
       hostPID: true
       securityContext:
@@ -31,9 +32,11 @@ spec:
       etcd-defrag:
         type: cronjob
         cronjob:
-          # Run weekly on Sunday at 3 AM
+          # Run weekly on Sunday at 3 AM local time.
+          timeZone: ${TIMEZONE}
           schedule: "0 3 * * 0"
           concurrencyPolicy: Forbid
+          backoffLimit: 1
           failedJobsHistory: 1
           successfulJobsHistory: 1
         containers:
@@ -49,12 +52,12 @@ spec:
               - --key=/certs/server.key
               # Defrag when DB quota usage > 50% OR free space > 100MB
               - --defrag-rule=dbQuotaUsage > 0.5 || dbSizeFree > 100*1024*1024
-              # Move leader during defrag (safe for single-node)
+              # Move the leader before defragmenting it.
               - --move-leader
-              # Wait 30s between defrags (only matters if you had multiple members)
+              # --cluster defragments all three control-plane etcd members.
               - --wait-between-defrags=30s
-              # Match the quota-backend-bytes we set in Talos config
-              - --etcd-storage-quota-bytes=8589934592
+              # Talos uses etcd's default --quota-backend-bytes value (2 GiB).
+              - --etcd-storage-quota-bytes=2147483648
               # Auto-disalarm space quota alarms
               - --auto-disalarm
               - --disalarm-threshold=0.8
@@ -63,13 +66,16 @@ spec:
                 cpu: 25m
                 memory: 128Mi
               limits:
+                cpu: 100m
                 memory: 128Mi
             securityContext:
+              # Talos etcd's client key is root-readable only on the host.
               privileged: true
 
     persistence:
       certs:
         type: hostPath
+        # Talos EtcdPKIPath.
         hostPath: /system/secrets/etcd
         globalMounts:
           - path: /certs

--- a/kubernetes/apps/kube-system/etcd-defrag/app/kustomization.yaml
+++ b/kubernetes/apps/kube-system/etcd-defrag/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrelease.yaml

--- a/kubernetes/apps/kube-system/etcd-defrag/ks.yaml
+++ b/kubernetes/apps/kube-system/etcd-defrag/ks.yaml
@@ -1,0 +1,17 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: etcd-defrag
+  namespace: &namespace kube-system
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/kube-system/etcd-defrag/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  wait: false

--- a/kubernetes/apps/kube-system/kustomization.yaml
+++ b/kubernetes/apps/kube-system/kustomization.yaml
@@ -15,3 +15,4 @@ resources:
   - ./reloader/ks.yaml
   - ./snapshot-controller/ks.yaml
   - ./spegel/ks.yaml
+  - ./etcd-defrag/ks.yaml


### PR DESCRIPTION
Port of [billimek/k8s-gitops etcd-defrag](https://github.com/billimek/k8s-gitops/blob/master/kubernetes/kube-system/etcd/etcd-defrag/etcd-defrag.yaml).

Runs weekly on Sunday at 3 AM via `ghcr.io/ahrtr/etcd-defrag` with hostNetwork access to the control-plane etcd socket. Defrags when quota usage > 50% or free space > 100MB.

### Changes
- `kubernetes/apps/kube-system/etcd-defrag/app/helmrelease.yaml` — app-template CronJob
- `kubernetes/apps/kube-system/etcd-defrag/app/kustomization.yaml` — Kustomize resources
- `kubernetes/apps/kube-system/etcd-defrag/ks.yaml` — Flux Kustomization
- `kubernetes/apps/kube-system/kustomization.yaml` — register new ks.yaml