### PR TITLE
feat(opencode): add VM server route

### DIFF
--- a/kubernetes/apps/ai/opencode/app/config/opencode.jsonc
+++ b/kubernetes/apps/ai/opencode/app/config/opencode.jsonc
@@ -46,13 +46,6 @@
         "baseURL": "http://litellm.ai.svc.cluster.local/v1",
         "apiKey": "{env:LITELLM_API_KEY}"
       }
-    },
-    "lmstudio": {
-      "npm": "@ai-sdk/openai-compatible",
-      "name": "LM Studio",
-      "options": {
-        "baseURL": "http://192.168.0.26:1234/v1"
-      }
     }
   }
 }

--- a/kubernetes/apps/ai/opencode/app/kustomization.yaml
+++ b/kubernetes/apps/ai/opencode/app/kustomization.yaml
@@ -4,6 +4,10 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - helmrelease.yaml
+  - opencode-vm-service.yaml
+  - opencode-vm-endpointslice.yaml
+  - opencode-vm-httproute.yaml
+  - opencode-vm-cors.yaml
 
 configMapGenerator:
   - name: opencode-config

--- a/kubernetes/apps/ai/opencode/app/opencode-vm-cors.yaml
+++ b/kubernetes/apps/ai/opencode/app/opencode-vm-cors.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: opencode-vm-cors
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: opencode-vm
+  cors:
+    allowOrigins:
+      - https://opencode.${SECRET_DOMAIN}
+    allowCredentials: true
+    allowMethods:
+      - GET
+      - POST
+      - PUT
+      - PATCH
+      - DELETE
+      - OPTIONS
+    allowHeaders:
+      - Authorization
+      - Content-Type
+      - Accept
+      - Last-Event-ID

--- a/kubernetes/apps/ai/opencode/app/opencode-vm-endpointslice.yaml
+++ b/kubernetes/apps/ai/opencode/app/opencode-vm-endpointslice.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  name: opencode-vm
+  labels:
+    kubernetes.io/service-name: opencode-vm
+addressType: IPv4
+endpoints:
+  - addresses:
+      - 192.168.0.181
+ports:
+  - port: 4096
+    name: http
+    protocol: TCP

--- a/kubernetes/apps/ai/opencode/app/opencode-vm-httproute.yaml
+++ b/kubernetes/apps/ai/opencode/app/opencode-vm-httproute.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: opencode-vm
+spec:
+  hostnames:
+    - opencode-vm.${SECRET_DOMAIN}
+  parentRefs:
+    - name: envoy-internal
+      namespace: network
+  rules:
+    - backendRefs:
+        - name: opencode-vm
+          port: 4096

--- a/kubernetes/apps/ai/opencode/app/opencode-vm-service.yaml
+++ b/kubernetes/apps/ai/opencode/app/opencode-vm-service.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: opencode-vm
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - port: 4096
+      targetPort: 4096
+      name: http
+      protocol: TCP


### PR DESCRIPTION
## Summary
- expose the LAN OpenCode VM through an internal HTTPS route
- allow the in-cluster OpenCode UI origin with a route-scoped CORS policy
- remove the obsolete LM Studio provider

## Validation
- JSON/YAML syntax parsing
- `git diff --check`
- `bash .agents/skills/pr-review/scripts/validate-pr.sh` (rendering tools are unavailable locally; existing repository warnings remain)

## Security note
The VM backend remains plaintext and unauthenticated by explicit choice; this PR scopes browser CORS but does not provide backend authorization or encryption.