### PR TITLE
fix(sglang): disable failed hicache l3 trial

### DIFF
--- a/docs/llm-hosting/sglang-blockers.md
+++ b/docs/llm-hosting/sglang-blockers.md
@@ -191,50 +191,15 @@ extension probe (`/v1/completions`, request B = A's prompt + A's output + more),
 release newer than v0.5.14 exists; main is ~545 commits ahead with unreleased hicache/mamba fixes —
 the pinned fork tree carries stock v0.5.14 hicache code (no fork patch touches it).
 
-**PVC-backed file L3 restart-recovery experiment (2026-07-15, one-shot only):** the prior local-disk
-trial ran for 6h+ of real traffic and repeated synthetic reuse, logged 0% hits, and cost throughput;
-the working set fit in RAM L2. This bounded experiment is different: it tests only whether an
-identical long prefix can be recovered after one clean SGLang restart from the existing `sglang` PVC.
-The PVC is 80 GiB and already contains about 50 GiB, so the deliberately conservative file cap is
-8 GiB. It uses:
-`--hicache-storage-backend file`, `--hicache-storage-prefetch-policy wait_complete`,
-`--hicache-write-policy write_through`, `--hicache-mem-layout page_first_direct`,
-`SGLANG_HICACHE_FILE_BACKEND_STORAGE_DIR=/cache/sglang/hicache`,
-and `SGLANG_HICACHE_FILE_BACKEND_MAX_SIZE=8GB`. The generic directory intentionally permits
-best-effort reuse across runtime changes at the accepted risk of incompatible or stale cache pages;
-existing versioned directories are not automatically adopted. File pages can contain prompt-derived
-state, so never use this with sensitive prompts. File
-L3 does not restore the in-memory radix tree, so the post-restart probe must reproduce the original
-prefix before its extension can test storage reuse. Do not add `MIN_FREE_SPACE`: its availability
-in the pinned v0.5.15 fork is unverified.
-
-**Acceptance procedure:** this is a one-shot restart measurement, not a traffic soak. Before enabling
-it, at idle, record PVC free space and abort if it is below 16 GiB (2x the 8 GiB cap); this is the
-PVC-free preflight. Wait two minutes, then use the pinned v0.5.15 native `POST /generate` API with
-the identical payload parameters for A, warm B, and cold B: `sampling_params: {temperature: 0,
-max_new_tokens: 128}` plus identical stop parameters. Record A's `input_ids`, generated token IDs,
-cold TTFT, and repeat count. After idle, verify file stability with two identical relative-path/size/
-mtime snapshots, with no `*.tmp.*` files and nonzero KV and Mamba component files; files being merely
-present is insufficient. Cleanly restart the pod once, then send warm B with
-`input_ids = A.input_ids + A.generated_token_ids + pre_tokenized_extension_ids`; do not reconstruct
-B from text. Immediately before B, take a Prometheus scrape and wait for the 1-minute ServiceMonitor
-interval before taking the post-B scrape. Require
-`increase(sglang:cached_tokens_total{cache_source="storage_HiCacheFile"}[5m]) > 0`, corroborated by
-`increase(sglang:prefetched_tokens_total{storage_backend="file",tp_rank="0"}[5m]) > 0`. Record B's
-TTFT and output token IDs. The uncontaminated cold-B control must use the same immutable B `input_ids`
-and request parameters, with file L3 disabled or pointed at a separate empty directory, followed by
-a clean restart; it must not seed the experiment directory. Pass only if the storage-hit metric is
-positive, B beats the cold-prefill TTFT, B's output IDs match the cold-B control, free space never
-falls below 8 GiB, there are zero server aborts above the preflight baseline, and no scheduler stall
-over 60 seconds, hybrid-state crash, or sustained abort increase occurs. Record disk/storage metric,
-cold-TTFT, abort, stall, and repeat-count evidence.
-Prompt-derived data remains on the PVC: delete the generic directory only with explicit operator
-approval.
-
-**Rollback:** immediately after the measurement, remove the four file-L3 flags and two file-backend
-environment variables from the HelmRelease; do not leave the experiment enabled for normal traffic
-or further soak testing. This returns to the validated `direct` I/O plus ratio-sized L2 configuration.
-Leave the directory as evidence unless an operator explicitly approves cleaning it.
+**PVC-backed file L3 restart-recovery experiment (2026-07-15, disabled):** a 61,600-token
+population request took 113.3s. After a clean pod restart, the token-exact post-restart extension took
+70.7s, but the file-backend metric recorded only 4,538 backed-up tokens, with zero storage
+prefetches and zero `storage_HiCacheFile` hits. Aggregate completion throughput for C1/C4/C8 was
+11.16/8.74/14.09 tok/s; the C8 sample overlapped real traffic. L3 remains disabled because it
+failed restart recovery. The validated direct I/O, ratio 1.5 L2, and `write_through_selective`
+policy remain enabled; do not propose unverified cache tweaks. Rollback does not remove
+`/cache/sglang/hicache`; it can contain prompt-derived data and requires explicit operator approval
+before deletion.
 
 **`hicache-write-policy write_back` trialled and reverted (2026-07-09):** kept alongside the L3 removal
 above as a still-valid L1→L2 (GPU→host) optimization — synthetic testing showed 0 aborts and lower

--- a/kubernetes/apps/ai/sglang/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/sglang/app/helmrelease.yaml
@@ -114,14 +114,6 @@ spec:
               HF_HOME: /cache/hf
               HF_HUB_OFFLINE: "1"
               TRITON_CACHE_DIR: /cache/sglang/triton # persisted JIT cache on the PVC
-              # One-shot file-L3 restart experiment only: preflight PVC free space before enabling,
-              # then revert these settings immediately after the measurement. The generic directory
-              # intentionally permits best-effort reuse across runtime changes at the accepted risk
-              # of incompatible or stale cache pages. Persistent pages may contain prompt-derived
-              # state; never use this experiment with sensitive prompts.
-              # Clean the directory only with approval.
-              SGLANG_HICACHE_FILE_BACKEND_STORAGE_DIR: /cache/sglang/hicache
-              SGLANG_HICACHE_FILE_BACKEND_MAX_SIZE: 8GB
               # EXTRA_ARGS append after the preset (last-wins): mamba slots 60 (2026-07-10: raises the
               # //3 running cap 16→20, conc20 agg 84 vs 64 tok/s; KV pool shrinks 237K→183,240 so
               # context-length drops 200K→180K to keep the ctx ≤ KV-pool clean-rejection invariant —
@@ -165,11 +157,9 @@ spec:
               # loop until every pending write-back drains (GPU stream sync) before eviction can proceed.
               # Under real traffic (unique long prompts, not synthetic repeated prefixes) that backlog
               # builds up fast, stalling new-request admission — serialized concurrency to 1 running
-              # request with the queue climbing unbounded. Left off default (write_through) instead.
-              # One-shot file-L3 restart-recovery experiment: write-through + wait-complete; direct
-              # I/O + ratio-sized L2; no write_back. Follow validation in docs/llm-hosting/sglang-blockers.md.
-              # Roll back immediately after measurement; do not leave enabled for traffic or a soak test.
-              EXTRA_ARGS: '--context-length 180000 --max-mamba-cache-size 60 --served-model-name qwen-3.6 --mamba-ssm-dtype bfloat16 --max-queued-requests 32 --weight-loader-drop-cache-after-load --enable-hierarchical-cache --hicache-io-backend direct --hicache-ratio 1.5 --model-loader-extra-config {"num_threads":2} --schedule-conservativeness 0.1 --enable-mixed-chunk --hicache-storage-backend file --hicache-storage-prefetch-policy wait_complete --hicache-write-policy write_through --hicache-mem-layout page_first_direct'
+              # request with the queue climbing unbounded. Keep the pre-existing selective write-through
+              # policy instead.
+              EXTRA_ARGS: '--context-length 180000 --max-mamba-cache-size 60 --served-model-name qwen-3.6 --mamba-ssm-dtype bfloat16 --max-queued-requests 32 --weight-loader-drop-cache-after-load --enable-hierarchical-cache --hicache-io-backend direct --hicache-ratio 1.5 --model-loader-extra-config {"num_threads":2} --schedule-conservativeness 0.1 --enable-mixed-chunk --hicache-write-policy write_through_selective'
             probes:
               startup: &probeBase
                 enabled: true


### PR DESCRIPTION
## Summary
- remove the failed file-L3 configuration and restore validated L2 cache behavior
- record the restart-recovery and concurrency-sweep results
- retain the generic cache directory for manual, approved cleanup

## Validation
- git diff --check
- bash .agents/skills/pr-review/scripts/validate-pr.sh (repository-wide warnings; flate, kustomize, and shellcheck unavailable)
- focused rollback review