### PR TITLE
feat(web3): add observe-only xmrig guard

### DIFF
--- a/docs/superpowers/plans/2026-07-15-xmrig-guard-telemetry-inventory.md
+++ b/docs/superpowers/plans/2026-07-15-xmrig-guard-telemetry-inventory.md
@@ -1,0 +1,167 @@
+# XMRig Guard Telemetry Inventory
+
+**Inventory time:** 2026-07-15T20:13:39Z
+**Datasource:** Grafana UID `victoriametrics`
+**Scope:** Task 1 live, read-only telemetry evidence. No cluster state was changed.
+
+## Result and enforcement gate
+
+Live VictoriaMetrics evidence establishes the NVMe sensor identities and the
+`control-1` CPU metric contract below. It does **not** authorize label or
+eviction enforcement: the separate Node authorization/NodeRestriction evidence
+in this document remains unresolved. Keep enforcement observe-only.
+
+## Discovery evidence
+
+Metric-name discovery over the prior two hours returned all requested metrics:
+
+```text
+container_cpu_usage_seconds_total
+node_cpu_seconds_total
+node_hwmon_temp_celsius
+```
+
+Relevant live label names and values:
+
+| Metric | Relevant labels | Observed values |
+| --- | --- | --- |
+| `node_hwmon_temp_celsius` | `kubernetes_node`, `nodename`, `chip`, `sensor` | nodes `control-1`, `control-2`, `control-3`; sensors `temp0`–`temp4`; NVMe chips `nvme_nvme0`, `nvme_nvme1` |
+| `node_cpu_seconds_total` | `kubernetes_node`, `nodename`, `cpu`, `mode` | nodes `control-1`, `control-2`, `control-3`; modes include `idle`, `iowait`, `irq`, `nice`, `softirq`, `steal`, `system`, `user` |
+| `container_cpu_usage_seconds_total` | `node`, `namespace`, `pod`, `container` | nodes `control-1`, `control-2`, `control-3`; namespace `web3`; regular container values exclude the empty and `POD` sandbox values |
+
+## NVMe temperature contract
+
+### Stable allowlists
+
+The following identities were present continuously in 60-second range-query
+samples for the last 15 minutes. The `chip`/`sensor` pair, together with the
+immutable node name, is the controller allowlist identity; `instance` and
+node-exporter pod names are scrape-target details and must not be configured as
+identities.
+
+```yaml
+control-2:
+  - {chip: nvme_nvme0, sensor: temp1}
+  - {chip: nvme_nvme0, sensor: temp2}
+  - {chip: nvme_nvme0, sensor: temp3}
+  - {chip: nvme_nvme1, sensor: temp1}
+  - {chip: nvme_nvme1, sensor: temp2}
+  - {chip: nvme_nvme1, sensor: temp3}
+  - {chip: nvme_nvme1, sensor: temp4}
+control-3:
+  - {chip: nvme_nvme0, sensor: temp1}
+  - {chip: nvme_nvme0, sensor: temp2}
+  - {chip: nvme_nvme0, sensor: temp3}
+  - {chip: nvme_nvme0, sensor: temp4}
+  - {chip: nvme_nvme1, sensor: temp1}
+  - {chip: nvme_nvme1, sensor: temp2}
+  - {chip: nvme_nvme1, sensor: temp3}
+  - {chip: nvme_nvme1, sensor: temp4}
+```
+
+`control-1` remains NVMe-exempt and has no NVMe allowlist.
+
+The controller must query exactly the configured identities, require the
+complete expected set, and take its maximum; an extra, missing, malformed, or
+stale expected series is invalid/unsafe. The inventory does not infer a device
+path beyond node-exporter's stable `nvme_nvme0`/`nvme_nvme1` chip identity.
+
+### Instant-query evidence
+
+At source time `2026-07-15T20:13:01Z` (`1784146381.093`), the live values were:
+
+| Node | `nvme_nvme0` °C | `nvme_nvme1` °C | Maximum °C |
+| --- | --- | --- | ---: |
+| `control-2` | `temp1=42.85`, `temp2=42.85`, `temp3=49.85` | `temp1=51.85`, `temp2=59.85`, `temp3=55.85`, `temp4=51.85` | 59.85 |
+| `control-3` | `temp1=48.85`, `temp2=57.85`, `temp3=53.85`, `temp4=48.85` | `temp1=55.85`, `temp2=64.85`, `temp3=59.85`, `temp4=55.85` | 64.85 |
+
+The full label shape on those series was:
+
+```text
+__name__, chip, container=node-exporter, endpoint=metrics, instance,
+job=node-exporter, kubernetes_node, namespace=observability, nodename, pod,
+prometheus=observability/victoria-metrics, sensor, service=node-exporter
+```
+
+The 15-minute range queries returned each allowlisted series at 60-second
+steps. `control-2` returned 13 points from `1784145687.228` through
+`1784146407.228`; `control-3` returned 16 points from `1784145507.325` through
+`1784146407.228`. This is live evidence of a roughly 60-second source cadence,
+not a promise of future freshness.
+
+### Configured timing values
+
+Use the observed cadence conservatively:
+
+```yaml
+evaluationInterval: 60s
+sourceSampleMaxAge: 120s
+cpuRateWindow: 5m
+maxReactionLatency: 180s # one evaluation interval plus max source age
+```
+
+The controller must retain and compare each telemetry source timestamp. A
+repeated query response with the same source timestamp is not a new observation
+and cannot advance a dwell timer.
+
+## `control-1` non-XMRig CPU contract
+
+### Source labels and observed values
+
+At `2026-07-15T20:13:02Z` (`1784146382.061`),
+`node_cpu_seconds_total{kubernetes_node="control-1",mode!="idle"}` returned
+the node-exporter label shape shown above for CPUs `0`–`11` and all non-idle
+modes. Example source values were `cpu="0",mode="user" = 195692.4` and
+`cpu="0",mode="system" = 23072.91` seconds.
+
+At `2026-07-15T20:13:01Z` (`1784146381.096`), the requested cAdvisor selector
+on `control-1`/`web3` returned a regular `p2pool` container, proving the
+cAdvisor source and labels:
+
+```text
+container=app, cpu=total, instance=control-1, job=kubelet,
+kubernetes_io_hostname=control-1, metrics_path=/metrics/cadvisor,
+namespace=web3, node=control-1, pod=p2pool-865cf6d757-7xdf9
+```
+
+Its value was `1486.478276` seconds. A node-wide non-sandbox cAdvisor count at
+`2026-07-15T20:13:27Z` was `138`. No running `pod=~"xmrig-.*"` series was
+returned; that is the expected zero-XMRig case, not missing cAdvisor telemetry.
+
+### Exact PromQL
+
+The controller's `control-1` non-XMRig CPU-percent result is the following
+single scalar instant query (fixed 5-minute rate window):
+
+```promql
+clamp_max(clamp_min(100 * ((sum(rate(node_cpu_seconds_total{kubernetes_node="control-1",mode!="idle"}[5m])) / count(count(node_cpu_seconds_total{kubernetes_node="control-1",mode="idle"}) by (cpu))) - ((sum(rate(container_cpu_usage_seconds_total{node="control-1",namespace="web3",pod=~"xmrig-.*",container!="",container!="POD"}[5m])) or vector(0)) / count(count(node_cpu_seconds_total{kubernetes_node="control-1",mode="idle"}) by (cpu)))), 0), 100)
+```
+
+It derives host busy percent from all non-idle node CPU modes, divides by the
+12 observed host CPUs, subtracts XMRig's non-sandbox cAdvisor CPU share, uses
+zero only when the XMRig selector is absent, and clamps the result to 0–100.
+The controller must separately verify that host and non-sandbox cAdvisor
+sources exist and are fresh; it must not treat an absent generic cAdvisor
+source as the zero-XMRig case.
+
+The expression evaluated successfully at `2026-07-15T20:13:27Z`
+(`1784146407.258`) and returned `37.05277777777771` percent. Its XMRig operand
+was absent at that instant, so the `or vector(0)` branch was exercised.
+
+## NodeRestriction gate remains unresolved
+
+Repository evidence remains insufficient to claim Node authorization and the
+NodeRestriction admission plugin are enabled. `talos/patches/controller/cluster.yaml`
+deletes explicit `admissionControl` configuration, and no generated apiserver
+configuration was available. Therefore neither
+`node-restriction.kubernetes.io/xmrig-nvme-safe` nor
+`node-restriction.kubernetes.io/xmrig-cpu-available` may be enforced until
+read-only generated/live apiserver evidence positively confirms both controls.
+
+## Tooling evidence
+
+Read-only Grafana MCP discovery and query operations were run against
+`victoriametrics`: metric-name discovery; label-name/value discovery; instant
+queries for all three requested metrics; 15-minute NVMe range queries; and the
+composed CPU contract query. No live-cluster mutation, reconciliation, or
+enforcement action was performed.

--- a/kubernetes/apps/web3/kustomization.yaml
+++ b/kubernetes/apps/web3/kustomization.yaml
@@ -9,3 +9,4 @@ components:
 
 resources:
   - ./monero/ks.yaml
+  - ./xmrig-guard/ks.yaml

--- a/kubernetes/apps/web3/monero/xmrig/helmrelease.yaml
+++ b/kubernetes/apps/web3/monero/xmrig/helmrelease.yaml
@@ -12,6 +12,9 @@ spec:
   values:
     controllers:
       xmrig:
+        pod:
+          labels:
+            app.kubernetes.io/component: thermal-guarded
         containers:
           app:
             image:
@@ -62,6 +65,7 @@ spec:
         globalMounts:
           - path: /dev/hugepages
     defaultPodOptions:
+      terminationGracePeriodSeconds: 15
       priorityClassName: low-priority-mining
       affinity:
         nodeAffinity:

--- a/kubernetes/apps/web3/xmrig-guard/app/helmrelease.yaml
+++ b/kubernetes/apps/web3/xmrig-guard/app/helmrelease.yaml
@@ -1,0 +1,82 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: xmrig-guard
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  interval: 1h
+  values:
+    controllers:
+      xmrig-guard:
+        replicas: 1
+        annotations:
+          reloader.stakater.com/auto: "true"
+        serviceAccount:
+          identifier: xmrig-guard
+        containers:
+          app:
+            image:
+              repository: python
+              tag: 3.14-slim@sha256:d3400aa122fa42cf0af0dbe8ec3091b047eac5c8f7e3539f7135e86d855dc015
+            command: [python3, /config/controller.py]
+            ports:
+              - name: http
+                containerPort: 8080
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop: [ALL]
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /healthz
+                    port: http
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /readyz
+                    port: http
+            resources:
+              requests:
+                cpu: 10m
+                memory: 32Mi
+              limits:
+                cpu: 100m
+                memory: 128Mi
+    defaultPodOptions:
+      terminationGracePeriodSeconds: 15
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault
+    service:
+      app:
+        controller: xmrig-guard
+        ports:
+          http:
+            port: 8080
+    persistence:
+      config:
+        type: configMap
+        name: xmrig-guard
+        globalMounts:
+          - path: /config
+            readOnly: true
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp

--- a/kubernetes/apps/web3/xmrig-guard/app/kustomization.yaml
+++ b/kubernetes/apps/web3/xmrig-guard/app/kustomization.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrelease.yaml
+  - rbac.yaml
+  - servicemonitor.yaml
+configMapGenerator:
+  - name: xmrig-guard
+    files:
+      - controller.py=./resources/controller.py
+      - config.json=./resources/config.json
+    options:
+      annotations:
+        kustomize.toolkit.fluxcd.io/substitute: disabled
+generatorOptions:
+  disableNameSuffixHash: true

--- a/kubernetes/apps/web3/xmrig-guard/app/rbac.yaml
+++ b/kubernetes/apps/web3/xmrig-guard/app/rbac.yaml
@@ -1,0 +1,57 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: xmrig-guard
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: xmrig-guard
+rules:
+  - apiGroups: [""]
+    resources: [nodes]
+    verbs: [get]
+    resourceNames: [control-1, control-2, control-3]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: xmrig-guard
+rules:
+  - apiGroups: [""]
+    resources: [pods]
+    verbs: [list]
+  - apiGroups: [apps]
+    resources: [replicasets]
+    verbs: [get]
+  - apiGroups: [apps]
+    resources: [deployments]
+    verbs: [get]
+    resourceNames: [xmrig]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: xmrig-guard
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: xmrig-guard
+subjects:
+  - kind: ServiceAccount
+    name: xmrig-guard
+    namespace: web3
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: xmrig-guard
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: xmrig-guard
+subjects:
+  - kind: ServiceAccount
+    name: xmrig-guard
+    namespace: web3

--- a/kubernetes/apps/web3/xmrig-guard/app/resources/config.json
+++ b/kubernetes/apps/web3/xmrig-guard/app/resources/config.json
@@ -1,0 +1,23 @@
+{
+  "mode": "observe",
+  "victoriaMetricsEndpoint": "http://vmauth-victoria-metrics.observability.svc.cluster.local:8427",
+  "auditedNodes": ["control-1", "control-2", "control-3"],
+  "sensors": {
+    "control-1": [],
+    "control-2": [
+      {"chip": "nvme_nvme0", "sensor": "temp1"}, {"chip": "nvme_nvme0", "sensor": "temp2"}, {"chip": "nvme_nvme0", "sensor": "temp3"},
+      {"chip": "nvme_nvme1", "sensor": "temp1"}, {"chip": "nvme_nvme1", "sensor": "temp2"}, {"chip": "nvme_nvme1", "sensor": "temp3"}, {"chip": "nvme_nvme1", "sensor": "temp4"}
+    ],
+    "control-3": [
+      {"chip": "nvme_nvme0", "sensor": "temp1"}, {"chip": "nvme_nvme0", "sensor": "temp2"}, {"chip": "nvme_nvme0", "sensor": "temp3"}, {"chip": "nvme_nvme0", "sensor": "temp4"},
+      {"chip": "nvme_nvme1", "sensor": "temp1"}, {"chip": "nvme_nvme1", "sensor": "temp2"}, {"chip": "nvme_nvme1", "sensor": "temp3"}, {"chip": "nvme_nvme1", "sensor": "temp4"}
+    ]
+  },
+  "thresholds": {"nvmeRecovery": 60, "nvmeTrip": 70, "cpuRecovery": 50, "cpuTrip": 70},
+  "dwellSeconds": {"recovery": 600, "trip": 120},
+  "evaluationIntervalSeconds": 60,
+  "sourceSampleMaxAgeSeconds": 120,
+  "maxSourceGapSeconds": 120,
+  "cpuRateWindow": "5m",
+  "httpTimeoutSeconds": 10
+}

--- a/kubernetes/apps/web3/xmrig-guard/app/resources/controller.py
+++ b/kubernetes/apps/web3/xmrig-guard/app/resources/controller.py
@@ -1,0 +1,412 @@
+"""Small, dependency-free, observe-only XMRig guard.
+
+The controller deliberately treats telemetry as untrusted input.  A complete
+set of fresh samples is required before a node can become safe.
+"""
+import json
+import math
+import os
+import ssl
+import threading
+import time
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+SENSORS = {
+    "control-1": (),
+    "control-2": (("nvme_nvme0", "temp1"), ("nvme_nvme0", "temp2"), ("nvme_nvme0", "temp3"), ("nvme_nvme1", "temp1"), ("nvme_nvme1", "temp2"), ("nvme_nvme1", "temp3"), ("nvme_nvme1", "temp4")),
+    "control-3": (("nvme_nvme0", "temp1"), ("nvme_nvme0", "temp2"), ("nvme_nvme0", "temp3"), ("nvme_nvme0", "temp4"), ("nvme_nvme1", "temp1"), ("nvme_nvme1", "temp2"), ("nvme_nvme1", "temp3"), ("nvme_nvme1", "temp4")),
+}
+
+
+def _dt(value):
+    value = float(value)
+    if not math.isfinite(value):
+        raise ValueError("non-finite timestamp")
+    return datetime.fromtimestamp(value, timezone.utc)
+
+
+def _fresh(timestamp, evaluation, max_age):
+    """Return whether a source timestamp is not future-dated or too old."""
+    age = (evaluation - timestamp).total_seconds()
+    return 0 <= age <= max_age
+
+
+class Config:
+    REQUIRED = {"mode", "victoriaMetricsEndpoint", "auditedNodes", "sensors", "thresholds", "dwellSeconds", "evaluationIntervalSeconds", "sourceSampleMaxAgeSeconds", "maxSourceGapSeconds", "cpuRateWindow", "httpTimeoutSeconds"}
+
+    def __init__(self, values):
+        if set(values) != self.REQUIRED:
+            raise ValueError("complete configuration is required")
+        self.endpoint = values["victoriaMetricsEndpoint"].rstrip("/")
+        self.mode = values["mode"]
+        self.nodes = tuple(values["auditedNodes"])
+        self.sensors = {node: tuple((item["chip"], item["sensor"]) for item in values["sensors"].get(node, ())) for node in self.nodes}
+        self.thresholds = values["thresholds"]
+        self.dwell = values["dwellSeconds"]
+        self.evaluation_interval = float(values["evaluationIntervalSeconds"])
+        self.max_age = float(values["sourceSampleMaxAgeSeconds"])
+        self.max_gap = float(values["maxSourceGapSeconds"])
+        self.cpu_rate_window = values["cpuRateWindow"]
+        self.http_timeout = float(values["httpTimeoutSeconds"])
+        self.validate()
+
+    @classmethod
+    def load(cls, values):
+        return cls(values)
+
+    def validate(self):
+        parsed = urllib.parse.urlparse(self.endpoint)
+        if parsed.scheme not in ("http", "https") or not parsed.netloc or self.mode != "observe":
+            raise ValueError("only observe mode and a valid endpoint are supported")
+        if set(self.nodes) != set(SENSORS) or self.sensors != SENSORS:
+            raise ValueError("sensor allowlist is audited and immutable")
+        if self.thresholds != {"nvmeRecovery": 60, "nvmeTrip": 70, "cpuRecovery": 50, "cpuTrip": 70}:
+            raise ValueError("thresholds do not match the audited policy")
+        if self.dwell != {"recovery": 600, "trip": 120} or self.evaluation_interval <= 0 or self.max_age <= 0 or self.max_gap <= 0 or self.cpu_rate_window != "5m" or self.http_timeout <= 0:
+            raise ValueError("invalid timing configuration")
+
+
+class DwellPolicy:
+    def __init__(self, recovery_limit, trip_limit, recovery_dwell, trip_dwell, max_gap_seconds=120):
+        self.recovery_limit, self.trip_limit = recovery_limit, trip_limit
+        self.recovery_dwell, self.trip_dwell = recovery_dwell, trip_dwell
+        self.max_gap = float(max_gap_seconds)
+        self.safe = False
+        self._last_source = None
+        self._pending = None
+        self._since = None
+
+    def invalidate(self):
+        self.safe = False
+        self._last_source = self._pending = self._since = None
+
+    def observe(self, value, source_time, monotonic_now):
+        if not isinstance(value, (int, float)) or not math.isfinite(value) or not isinstance(source_time, datetime):
+            self.invalidate()
+            return False
+        source_seconds = source_time.timestamp()
+        if self._last_source is not None:
+            gap = source_seconds - self._last_source
+            if gap <= 0:
+                return self.safe  # duplicate/out-of-order samples cannot advance dwell
+            if gap > self.max_gap:
+                self._pending = self._since = None
+        self._last_source = source_seconds
+        kind = "recover" if value <= self.recovery_limit else "trip" if value >= self.trip_limit else None
+        if kind is None:
+            self._pending = self._since = None
+            return self.safe
+        if (kind == "recover") == self.safe:
+            self._pending = self._since = None
+            return self.safe
+        if kind != self._pending:
+            self._pending, self._since = kind, monotonic_now
+        else:
+            dwell = self.recovery_dwell if kind == "recover" else self.trip_dwell
+            if monotonic_now - self._since >= dwell:
+                self.safe = kind == "recover"
+                self._pending = self._since = None
+        return self.safe
+
+
+@dataclass(frozen=True)
+class Source:
+    value: float
+    timestamp: datetime
+
+
+@dataclass(frozen=True)
+class CPUObservation:
+    host: Source
+    cadvisor: Source
+    ksm: Source
+    xmrig: Source | None
+
+
+def cpu_value(observation):
+    if not all(isinstance(x, Source) for x in (observation.host, observation.cadvisor, observation.ksm)):
+        raise ValueError("host, cAdvisor, and KSM sources are required")
+    xmrig = observation.xmrig.value if observation.xmrig else 0.0
+    return max(0.0, min(100.0, observation.host.value - xmrig))
+
+
+class VictoriaMetricsClient:
+    def __init__(self, endpoint, transport=None):
+        self.endpoint = endpoint.rstrip("/")
+        self.transport = transport or _HTTPTransport(10)
+
+    def _query(self, expression, evaluation):
+        params = {"query": expression, "time": evaluation.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")}
+        payload = self.transport.get(self.endpoint + "/api/v1/query", params)
+        if payload.get("status") != "success" or payload.get("data", {}).get("resultType") != "vector" or not isinstance(payload["data"].get("result"), list):
+            raise ValueError("invalid VictoriaMetrics response")
+        return payload["data"]["result"]
+
+    @staticmethod
+    def _sources(rows, identity=None, raw_timestamp=False):
+        out = {}
+        for row in rows:
+            metric = row.get("metric", {})
+            key = identity(metric) if identity else tuple(sorted(metric.items()))
+            if key in out or not isinstance(row.get("value"), list) or len(row["value"]) != 2:
+                raise ValueError("malformed or duplicate telemetry")
+            try:
+                value = float(row["value"][1])
+                timestamp = _dt(row["value"][1] if raw_timestamp else row["value"][0])
+            except (TypeError, ValueError, OverflowError) as exc:
+                raise ValueError("malformed telemetry value") from exc
+            if not math.isfinite(value):
+                raise ValueError("non-finite telemetry value")
+            out[key] = Source(value, timestamp)
+        return out
+
+    def query_nvme(self, node, sensors, evaluation):
+        parts = [f'node_hwmon_temp_celsius{{kubernetes_node="{node}",chip="{chip}",sensor="{sensor}"}}' for chip, sensor in sensors]
+        expression = " or ".join(parts)
+        rows = self._query(expression, evaluation)
+        timestamps = self._query("timestamp(" + expression + ")", evaluation)
+        key = lambda m: (m.get("chip"), m.get("sensor"))
+        if any(row.get("metric", {}).get("kubernetes_node") != node for row in rows + timestamps):
+            raise ValueError("NVMe node identity changed")
+        found = self._sources(rows, key)
+        stamped = self._sources(timestamps, key, raw_timestamp=True)
+        if set(found) != set(sensors):
+            raise ValueError("incomplete or changed NVMe identity set")
+        if set(stamped) != set(sensors):
+            raise ValueError("incomplete or changed NVMe timestamp identity set")
+        result = []
+        for item in sensors:
+            if not -40 <= found[item].value <= 150:
+                raise ValueError("implausible NVMe temperature")
+            result.append(Source(found[item].value, stamped[item].timestamp))
+        return result
+
+    def query_cpu(self, node, evaluation, window="5m"):
+        host_raw = f'node_cpu_seconds_total{{kubernetes_node="{node}",mode!="idle"}}'
+        idle_raw = f'node_cpu_seconds_total{{kubernetes_node="{node}",mode="idle"}}'
+        cadvisor_raw = f'container_cpu_usage_seconds_total{{node="{node}",namespace="web3",container!="",container!="POD"}}'
+        host_query = f'sum(rate({host_raw}[{window}])) / count(count({idle_raw}) by (cpu)) * 100'
+        cadvisor_query = f'sum(rate({cadvisor_raw}[{window}]))'
+        ksm_raw = 'kube_pod_info{namespace="web3"}'
+        ksm_query = f'count({ksm_raw})'
+        label_selector = 'namespace="web3",label_app_kubernetes_io_component="thermal-guarded"'
+        xmrig_presence_raw = f'kube_pod_labels{{{label_selector}}}'
+        xmrig_presence_query = f'count({xmrig_presence_raw}) or vector(0)'
+        xmrig_query = f'100 * sum by (namespace,pod) (rate({cadvisor_raw}[{window}])) / count(count({idle_raw}) by (cpu)) * on(namespace,pod) group_left() kube_pod_labels{{{label_selector}}}'
+        def one(query, optional=False, raw_timestamp=False):
+            rows = self._query(query, evaluation)
+            if not rows and optional:
+                return None
+            values = self._sources(rows, raw_timestamp=raw_timestamp)
+            if len(values) != 1:
+                raise ValueError("CPU source must be one scalar")
+            return next(iter(values.values()))
+        def source(query, raw_selector, optional=False):
+            value = one(query, optional)
+            stamp_rows = self._query("timestamp(" + raw_selector + ")", evaluation)
+            if value is None:
+                if optional:
+                    return None
+                raise ValueError("incomplete CPU source")
+            if not stamp_rows:
+                raise ValueError("missing raw CPU timestamps")
+            stamps = self._sources(stamp_rows, raw_timestamp=True)
+            return Source(value.value, min(item.timestamp for item in stamps.values()))
+        ksm = source(ksm_query, ksm_raw)
+        presence_rows = self._query(xmrig_presence_query, evaluation)
+        presence_values = self._sources(presence_rows)
+        if len(presence_values) != 1 or next(iter(presence_values.values())).value < 0:
+            raise ValueError("invalid labelled XMRig presence source")
+        presence = next(iter(presence_values.values()))
+        xmrig = source(xmrig_query, cadvisor_raw, True)
+        if presence.value > 0 and xmrig is None:
+            raise ValueError("XMRig pod exists but labelled CPU join is empty")
+        return CPUObservation(source(host_query, host_raw), source(cadvisor_query, cadvisor_raw), ksm, xmrig)
+
+
+class _HTTPTransport:
+    def __init__(self, timeout=10, headers=None, context=None):
+        self.timeout, self.headers, self.context = timeout, headers or {}, context
+
+    def get(self, url, params):
+        request = urllib.request.Request(url + "?" + urllib.parse.urlencode(params), headers=self.headers)
+        with urllib.request.urlopen(request, timeout=self.timeout, context=self.context) as response:
+            return json.load(response)
+
+    def request(self, request):
+        for key, value in self.headers.items():
+            request.add_header(key, value)
+        with urllib.request.urlopen(request, timeout=self.timeout, context=self.context) as response:
+            return json.load(response)
+
+
+class KubernetesClient:
+    def __init__(self, host=None, token_path="/var/run/secrets/kubernetes.io/serviceaccount/token", ca_path="/var/run/secrets/kubernetes.io/serviceaccount/ca.crt", transport=None):
+        self.host = host or os.environ.get("KUBERNETES_SERVICE_HOST", "https://kubernetes.default.svc")
+        if not self.host.startswith("http"):
+            self.host = "https://" + self.host + ":" + os.environ.get("KUBERNETES_SERVICE_PORT", "443")
+        token = open(token_path, encoding="utf-8").read().strip() if os.path.exists(token_path) else ""
+        self.auth_header = {"Authorization": "Bearer " + token} if token else {}
+        context = ssl.create_default_context(cafile=ca_path) if os.path.exists(ca_path) else None
+        self.transport = transport or _HTTPTransport(10, self.auth_header, context)
+
+    def request(self, method, path, body=None):
+        url = self.host.rstrip("/") + path
+        data = None if body is None else json.dumps(body).encode()
+        headers = {"Content-Type": "application/json", **self.auth_header}
+        request = urllib.request.Request(url, data=data, method=method, headers=headers)
+        return self.transport.request(request)
+
+
+class GuardController:
+    def __init__(self, config, kube, telemetry, clock=time.monotonic, wall_clock=lambda: datetime.now(timezone.utc)):
+        self.config, self.kube, self.telemetry = config, kube, telemetry
+        self.clock, self.wall_clock = clock, wall_clock
+        self.policies = {"control-2": DwellPolicy(60, 70, 600, 120, config.max_gap), "control-3": DwellPolicy(60, 70, 600, 120, config.max_gap)}
+        self.cpu_policy = DwellPolicy(50, 70, 600, 120, config.max_gap)
+        self.ready = False
+        self.metrics = {
+            "evaluations": 0, "errors": 0, "query_errors": {node: 0 for node in config.nodes},
+            "safe": {node: 0 for node in config.nodes}, "state_transitions": 0,
+            "nvme_temp_max": {node: 0.0 for node in config.nodes if node != "control-1"},
+            "source_age_seconds": {node: 0.0 for node in config.nodes},
+            "expected_sensor_count": {node: len(config.sensors[node]) for node in config.nodes if node != "control-1"},
+            "selected_sensor_count": {node: 0 for node in config.nodes if node != "control-1"},
+            "cpu_non_xmrig": 0.0,
+        }
+        self._last_source_stamps = {node: () for node in config.nodes}
+
+    def _new_source_set(self, node, sources):
+        stamps = tuple(source.timestamp.timestamp() for source in sources)
+        previous = self._last_source_stamps[node]
+        if previous and len(previous) != len(stamps):
+            raise ValueError("CPU source membership changed")
+        if previous and len(previous) == len(stamps) and any(current - old > self.config.max_gap for current, old in zip(stamps, previous)):
+            raise ValueError("source gap exceeded maximum")
+        if previous and len(previous) == len(stamps) and any(current <= old for current, old in zip(stamps, previous)):
+            return False
+        self._last_source_stamps[node] = stamps
+        return True
+
+    def evaluate(self, evaluation=None):
+        evaluation = evaluation or self.wall_clock()
+        now = self.clock()
+        for node, sensors in self.config.sensors.items():
+            try:
+                if node == "control-1":
+                    obs = self.telemetry.query_cpu(node, evaluation, self.config.cpu_rate_window)
+                    sources = (obs.host, obs.cadvisor, obs.ksm) + ((obs.xmrig,) if obs.xmrig else ())
+                    if not all(_fresh(source.timestamp, evaluation, self.config.max_age) for source in sources):
+                        raise ValueError("stale or future CPU source")
+                    if self._new_source_set(node, sources):
+                        safe = self.cpu_policy.observe(cpu_value(obs), min(source.timestamp for source in sources), now)
+                    else:
+                        safe = self.cpu_policy.safe
+                    self.metrics["cpu_non_xmrig"] = cpu_value(obs)
+                    self.metrics["source_age_seconds"][node] = max(0.0, evaluation.timestamp() - min(source.timestamp for source in sources).timestamp())
+                else:
+                    samples = self.telemetry.query_nvme(node, sensors, evaluation)
+                    if not samples or not all(_fresh(sample.timestamp, evaluation, self.config.max_age) for sample in samples):
+                        raise ValueError("stale or future NVMe source")
+                    if self._new_source_set(node, samples):
+                        safe = self.policies[node].observe(max(sample.value for sample in samples), max(sample.timestamp for sample in samples), now)
+                    else:
+                        safe = self.policies[node].safe
+                    self.metrics["nvme_temp_max"][node] = max(sample.value for sample in samples)
+                    self.metrics["selected_sensor_count"][node] = len(samples)
+                    self.metrics["source_age_seconds"][node] = max(0.0, evaluation.timestamp() - min(sample.timestamp for sample in samples).timestamp())
+                if int(safe) != self.metrics["safe"][node]:
+                    self.metrics["state_transitions"] += 1
+                self.metrics["safe"][node] = int(safe)
+            except Exception:
+                self.metrics["errors"] += 1
+                self.metrics["query_errors"][node] += 1
+                policy = self.cpu_policy if node == "control-1" else self.policies[node]
+                policy.invalidate()
+                self._last_source_stamps[node] = ()
+                if self.metrics["safe"][node]:
+                    self.metrics["state_transitions"] += 1
+                self.metrics["safe"][node] = 0
+                self.metrics["source_age_seconds"][node] = float("nan")
+                if node == "control-1":
+                    self.metrics["cpu_non_xmrig"] = float("nan")
+                else:
+                    self.metrics["nvme_temp_max"][node] = float("nan")
+                if node != "control-1":
+                    self.metrics["selected_sensor_count"][node] = 0
+        self.metrics["evaluations"] += 1
+        self.ready = True
+        return dict(self.metrics["safe"])
+
+    def run_once(self, evaluation=None):
+        """Run exactly one complete evaluation; useful for probes and tests."""
+        return self.evaluate(evaluation)
+
+    def reconcile(self, node, temperature, source_time, wall_now=None):
+        if node not in self.policies:
+            return True
+        wall_now = wall_now or self.wall_clock()
+        if source_time > wall_now or (wall_now - source_time).total_seconds() > self.config.max_age:
+            self.policies[node].invalidate()
+            return False
+        return self.policies[node].observe(temperature, source_time, self.clock())
+
+
+def render_metrics(controller):
+    m = controller.metrics
+    lines = [
+        f'xmrig_guard_evaluations_total {m["evaluations"]}',
+        f'xmrig_guard_errors_total {m["errors"]}',
+        f'xmrig_guard_state_transitions_total {m["state_transitions"]}',
+        f'xmrig_guard_cpu_non_xmrig_percent {m["cpu_non_xmrig"]}',
+    ]
+    for metric, values in (
+        ("safe", m["safe"]),
+        ("query_errors_total", m["query_errors"]),
+        ("source_age_seconds", m["source_age_seconds"]),
+        ("nvme_temp_max_celsius", m["nvme_temp_max"]),
+        ("nvme_expected_sensor_count", m["expected_sensor_count"]),
+        ("nvme_selected_sensor_count", m["selected_sensor_count"]),
+    ):
+        metric_name = "xmrig_guard_" + metric
+        lines.extend(f'{metric_name}{{node="{node}"}} {value}' for node, value in values.items())
+    return "\n".join(lines) + "\n"
+
+
+class _StatusHandler(BaseHTTPRequestHandler):
+    controller = None  # assigned before the server starts
+    def do_GET(self):
+        if self.path == "/healthz":
+            self._send(200, "ok\n", "text/plain")
+        elif self.path == "/readyz":
+            self._send(200 if self.controller.ready else 503, "ready\n" if self.controller.ready else "not ready\n", "text/plain")
+        elif self.path == "/metrics":
+            body = render_metrics(self.controller)
+            self._send(200, body, "text/plain; version=0.0.4")
+        else:
+            self._send(404, "not found\n", "text/plain")
+    def _send(self, status, body, content_type):
+        data = body.encode()
+        self.send_response(status); self.send_header("Content-Type", content_type); self.send_header("Content-Length", str(len(data))); self.end_headers(); self.wfile.write(data)
+    def log_message(self, format, *args):
+        return
+
+
+def main():
+    with open("/config/config.json", encoding="utf-8") as stream:
+        config = Config.load(json.load(stream))
+    controller = GuardController(config, KubernetesClient(), VictoriaMetricsClient(config.endpoint))
+    _StatusHandler.controller = controller
+    server = ThreadingHTTPServer(("0.0.0.0", 8080), _StatusHandler)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    while True:
+        controller.evaluate()
+        time.sleep(config.evaluation_interval)
+
+
+if __name__ == "__main__":
+    main()

--- a/kubernetes/apps/web3/xmrig-guard/app/resources/test_controller.py
+++ b/kubernetes/apps/web3/xmrig-guard/app/resources/test_controller.py
@@ -1,0 +1,230 @@
+import json
+import math
+import os
+import sys
+import unittest
+from datetime import datetime, timedelta, timezone
+from unittest.mock import Mock
+
+sys.path.insert(0, os.path.dirname(__file__))
+import controller
+
+UTC = timezone.utc
+ROOT = os.path.dirname(__file__)
+
+
+def config():
+    with open(os.path.join(ROOT, "config.json"), encoding="utf-8") as stream:
+        return controller.Config.load(json.load(stream))
+
+
+class ConfigTests(unittest.TestCase):
+    def test_complete_audited_configuration(self):
+        cfg = config()
+        self.assertEqual(len(cfg.sensors["control-2"]), 7)
+        self.assertEqual(len(cfg.sensors["control-3"]), 8)
+
+    def test_missing_or_changed_policy_is_rejected(self):
+        values = {"mode": "observe"}
+        with self.assertRaises(ValueError):
+            controller.Config.load(values)
+        values = json.loads(json.dumps(config_values()))
+        values["sensors"]["control-2"] = []
+        with self.assertRaises(ValueError):
+            controller.Config.load(values)
+
+
+def config_values():
+    with open(os.path.join(ROOT, "config.json"), encoding="utf-8") as stream:
+        return json.load(stream)
+
+
+class PolicyTests(unittest.TestCase):
+    def test_monotonic_dwell_and_duplicate_source(self):
+        p = controller.DwellPolicy(60, 70, 10, 2, 60)
+        source = datetime(2026, 1, 1, tzinfo=UTC)
+        self.assertFalse(p.observe(59, source, 100.0))
+        self.assertFalse(p.observe(59, source, 1000.0))
+        self.assertTrue(p.observe(59, source + timedelta(seconds=1), 110.0))
+
+    def test_invalid_and_gap_reset_safe_state(self):
+        p = controller.DwellPolicy(60, 70, 1, 1, 2)
+        source = datetime(2026, 1, 1, tzinfo=UTC)
+        p.observe(59, source, 0)
+        p.observe(59, source + timedelta(seconds=1), 1)
+        self.assertTrue(p.safe)
+        self.assertFalse(p.observe(float("nan"), source + timedelta(seconds=2), 2))
+        self.assertFalse(p.safe)
+        p.observe(59, source + timedelta(seconds=10), 3)
+        self.assertFalse(p.safe)
+
+
+class TelemetryTests(unittest.TestCase):
+    def test_nvme_requires_exact_set_and_fixed_evaluation_time(self):
+        transport = Mock()
+        now = datetime(2026, 1, 1, tzinfo=UTC)
+        metric = {"kubernetes_node": "control-2", "chip": "nvme_nvme0", "sensor": "temp1"}
+        transport.get.return_value = {"status": "success", "data": {"resultType": "vector", "result": [{"metric": metric, "value": [str(now.timestamp()), "42"]}]}}
+        client = controller.VictoriaMetricsClient("http://vm", transport)
+        self.assertEqual(client.query_nvme("control-2", [("nvme_nvme0", "temp1")], now)[0].value, 42)
+        self.assertEqual(transport.get.call_args.args[1]["time"], now.isoformat().replace("+00:00", "Z"))
+        with self.assertRaises(ValueError):
+            client.query_nvme("control-2", [("nvme_nvme0", "temp1"), ("nvme_nvme0", "temp2")], now)
+
+    def test_cpu_query_contains_label_join_and_separate_sources(self):
+        transport = Mock()
+        now = datetime(2026, 1, 1, tzinfo=UTC)
+        response = {"status": "success", "data": {"resultType": "vector", "result": [{"metric": {}, "value": [str(now.timestamp()), "37"]}]}}
+        transport.get.return_value = response
+        client = controller.VictoriaMetricsClient("http://vm", transport)
+        client.query_cpu("control-1", now)
+        queries = [call.args[1]["query"] for call in transport.get.call_args_list]
+        self.assertTrue(any("kube_pod_labels" in query and "group_left" in query for query in queries))
+        self.assertGreaterEqual(len(queries), 4)
+
+    def test_nvme_uses_raw_timestamp_companion_and_temperature_validation(self):
+        transport = Mock()
+        evaluation = datetime(2026, 1, 1, tzinfo=UTC)
+        metric = {"kubernetes_node": "control-2", "chip": "nvme_nvme0", "sensor": "temp1"}
+        def response(_url, params):
+            value = str(evaluation.timestamp() - 30) if "timestamp(" in params["query"] else "42"
+            return {"status": "success", "data": {"resultType": "vector", "result": [{"metric": metric, "value": [str(evaluation.timestamp()), value]}]}}
+        transport.get.side_effect = response
+        client = controller.VictoriaMetricsClient("http://vm", transport)
+        sample = client.query_nvme("control-2", [("nvme_nvme0", "temp1")], evaluation)[0]
+        self.assertEqual(sample.timestamp, datetime.fromtimestamp(evaluation.timestamp() - 30, UTC))
+        with self.assertRaises(ValueError):
+            client.query_nvme("control-3", [("nvme_nvme0", "temp1")], evaluation)
+
+    def test_cpu_requires_independent_sources_but_allows_zero_xmrig(self):
+        transport = Mock()
+        now = datetime(2026, 1, 1, tzinfo=UTC)
+        response = {"status": "success", "data": {"resultType": "vector", "result": [{"metric": {}, "value": [str(now.timestamp()), "37"]}]}}
+        def cpu_response(_url, params):
+            query = params["query"]
+            if query.startswith("count(kube_pod_labels"):
+                return response | {"data": {"resultType": "vector", "result": [{"metric": {}, "value": [str(now.timestamp()), "0"]}]}}
+            if query.startswith("100 * sum by"):
+                return response | {"data": {"resultType": "vector", "result": []}}
+            return response
+        transport.get.side_effect = cpu_response
+        observation = controller.VictoriaMetricsClient("http://vm", transport).query_cpu("control-1", now)
+        self.assertIsNone(observation.xmrig)
+        self.assertEqual(controller.cpu_value(observation), 37)
+        self.assertGreaterEqual(len(transport.get.call_args_list), 8)
+
+    def test_existing_xmrig_with_broken_label_join_is_invalid(self):
+        transport = Mock()
+        now = datetime(2026, 1, 1, tzinfo=UTC)
+        response = {"status": "success", "data": {"resultType": "vector", "result": [{"metric": {}, "value": [str(now.timestamp()), "1"]}]}}
+        def broken(_url, params):
+            if params["query"].startswith("100 * sum by"):
+                return response | {"data": {"resultType": "vector", "result": []}}
+            if params["query"].startswith("count(kube_pod_labels"):
+                return response | {"data": {"resultType": "vector", "result": [{"metric": {}, "value": [str(now.timestamp()), "1"]}]}}
+            return response
+        transport.get.side_effect = broken
+        with self.assertRaises(ValueError):
+            controller.VictoriaMetricsClient("http://vm", transport).query_cpu("control-1", now)
+
+
+class ControllerTests(unittest.TestCase):
+    def test_evaluation_failure_is_fail_closed_and_readiness_is_bounded(self):
+        telemetry = Mock()
+        telemetry.query_nvme.side_effect = ValueError("broken")
+        guard = controller.GuardController(config(), Mock(), telemetry, clock=lambda: 100, wall_clock=lambda: datetime(2026, 1, 1, tzinfo=UTC))
+        self.assertEqual(set(guard.evaluate()), {"control-1", "control-2", "control-3"})
+        self.assertTrue(guard.ready)
+        self.assertEqual(sum(guard.metrics["safe"].values()), 0)
+
+    def test_observe_never_writes(self):
+        kube = Mock()
+        guard = controller.GuardController(config(), kube, Mock())
+        guard.reconcile("control-2", 50, datetime.now(UTC))
+        kube.assert_not_called()
+
+    def test_kubernetes_auth_request_construction(self):
+        transport = Mock()
+        client = controller.KubernetesClient(host="https://api", token_path="/missing", ca_path="/missing", transport=transport)
+        client.request("GET", "/api/v1/nodes")
+        request = transport.request.call_args.args[0]
+        self.assertEqual(request.full_url, "https://api/api/v1/nodes")
+        self.assertEqual(request.method, "GET")
+
+    def test_nodes_fail_independently_and_completed_evaluation_is_ready(self):
+        telemetry = Mock()
+        source = datetime(2026, 1, 1, tzinfo=UTC)
+        def nvme(node, sensors, _evaluation):
+            if node == "control-2":
+                raise ValueError("control-2")
+            return [controller.Source(40, source)] * len(sensors)
+        telemetry.query_nvme.side_effect = nvme
+        telemetry.query_cpu.return_value = controller.CPUObservation(
+            controller.Source(30, datetime(2026, 1, 1, tzinfo=UTC)),
+            controller.Source(1, datetime(2026, 1, 1, tzinfo=UTC)),
+            controller.Source(1, datetime(2026, 1, 1, tzinfo=UTC)), None)
+        guard = controller.GuardController(config(), Mock(), telemetry, clock=lambda: 100, wall_clock=lambda: datetime(2026, 1, 1, tzinfo=UTC))
+        result = guard.evaluate()
+        self.assertTrue(guard.ready)
+        self.assertEqual(result["control-2"], 0)
+        self.assertIn("control-3", result)
+        self.assertEqual(guard.metrics["query_errors"]["control-3"], 0)
+
+    def test_health_metrics_are_bounded_and_run_once_evaluates(self):
+        telemetry = Mock()
+        telemetry.query_nvme.side_effect = ValueError("offline")
+        telemetry.query_cpu.side_effect = ValueError("offline")
+        guard = controller.GuardController(config(), Mock(), telemetry)
+        guard.run_once()
+        self.assertEqual(guard.metrics["evaluations"], 1)
+        self.assertLessEqual(len(guard.metrics), 12)
+
+    def test_one_source_gap_resets_only_that_node_and_metrics_are_named(self):
+        telemetry = Mock()
+        first = datetime(2026, 1, 1, tzinfo=UTC)
+        second = first + timedelta(seconds=180)
+        def nvme(node, sensors, evaluation):
+            if evaluation == first:
+                return [controller.Source(40, first) for _ in sensors]
+            # control-2 has one 180-second source gap, while every source is
+            # still fresh at the second evaluation (age is 120 seconds max).
+            return [controller.Source(40, first + timedelta(seconds=(150 if node == "control-2" and i == 0 else 60))) for i in range(len(sensors))]
+        def cpu(node, evaluation, _window):
+            stamp = evaluation - timedelta(seconds=60)
+            source = controller.Source(30, stamp)
+            return controller.CPUObservation(source, source, source, None)
+        telemetry.query_nvme.side_effect = nvme
+        telemetry.query_cpu.side_effect = cpu
+        guard = controller.GuardController(config(), Mock(), telemetry, clock=lambda: 1, wall_clock=lambda: first)
+        guard.evaluate(first)
+        guard.evaluate(second)
+        self.assertEqual(guard.metrics["selected_sensor_count"]["control-2"], 0)
+        self.assertEqual(guard.metrics["query_errors"]["control-2"], 1)
+        self.assertEqual(guard.metrics["selected_sensor_count"]["control-3"], 8)
+        self.assertEqual(guard.metrics["query_errors"]["control-3"], 0)
+        text = controller.render_metrics(guard)
+        self.assertIn("xmrig_guard_nvme_temp_max_celsius", text)
+        self.assertIn("xmrig_guard_source_age_seconds", text)
+        self.assertIn("xmrig_guard_query_errors_total", text)
+
+    def test_cpu_membership_change_is_fail_closed(self):
+        guard = controller.GuardController(config(), Mock(), Mock())
+        stamp = datetime(2026, 1, 1, tzinfo=UTC)
+        sources = [controller.Source(1, stamp)] * 3
+        self.assertTrue(guard._new_source_set("control-1", sources))
+        with self.assertRaises(ValueError):
+            guard._new_source_set("control-1", sources + [controller.Source(1, stamp)])
+
+    def test_failure_invalidates_values_and_counts_safe_transition(self):
+        telemetry = Mock()
+        telemetry.query_nvme.side_effect = ValueError("offline")
+        guard = controller.GuardController(config(), Mock(), telemetry)
+        guard.metrics["safe"]["control-2"] = 1
+        guard.evaluate(datetime.now(UTC))
+        self.assertEqual(guard.metrics["state_transitions"], 1)
+        self.assertTrue(math.isnan(guard.metrics["nvme_temp_max"]["control-2"]))
+        self.assertTrue(math.isnan(guard.metrics["source_age_seconds"]["control-2"]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/kubernetes/apps/web3/xmrig-guard/app/servicemonitor.yaml
+++ b/kubernetes/apps/web3/xmrig-guard/app/servicemonitor.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/monitoring.coreos.com/servicemonitor_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: xmrig-guard
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: xmrig-guard
+      app.kubernetes.io/instance: xmrig-guard
+  endpoints:
+    - port: http
+      path: /metrics

--- a/kubernetes/apps/web3/xmrig-guard/ks.yaml
+++ b/kubernetes/apps/web3/xmrig-guard/ks.yaml
@@ -1,0 +1,17 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: xmrig-guard
+  namespace: &namespace web3
+spec:
+  path: ./kubernetes/apps/web3/xmrig-guard/app
+  targetNamespace: *namespace
+  wait: true
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  interval: 30m


### PR DESCRIPTION
## Summary
- add a ConfigMap-mounted Python guard using the pinned Python 3.14 slim image
- record live NVMe/CPU telemetry evidence and deploy the guard in strict observe-only mode
- add XMRig thermal-guard labelling and explicit termination grace period

## Validation
- python3 -m unittest discover -s kubernetes/apps/web3/xmrig-guard/app/resources -p 'test_*.py'
- python3 -m py_compile kubernetes/apps/web3/xmrig-guard/app/resources/controller.py
- git diff --check

## Safety
- no label patching, pod eviction, taints, or required thermal affinity is enabled
- read-only RBAC only; promotion remains gated on NodeRestriction, KSM, and live observe-mode evidence