### PR TITLE
fix(cnpg): protect rw pooler from eviction

### DIFF
--- a/kubernetes/apps/database/cloudnative-pg/cluster/pooler.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/pooler.yaml
@@ -13,6 +13,19 @@ spec:
     name: postgres16
   instances: 3
   type: rw
+  # Avoid BestEffort eviction: losing pooler replicas concentrates all client
+  # traffic on the survivor and can exhaust its PgBouncer wait queue.
+  template:
+    spec:
+      containers:
+        - name: pgbouncer
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              cpu: "1"
+              memory: 256Mi
   pgbouncer:
     poolMode: transaction
     parameters:


### PR DESCRIPTION
## Summary
- give the shared RW PgBouncer pooler explicit Burstable resources
- prevent BestEffort eviction from concentrating traffic on one replica
- retain existing connection and timeout settings

## Validation
- `git diff --check`
- YAML parsed with PyYAML
- `bash .agents/skills/pr-review/scripts/validate-pr.sh` (rendering skipped: `flate`/`kustomize` unavailable)