### PR TITLE
fix(talos): harden kubelet memory eviction

### DIFF
--- a/talos/patches/global/machine-kubelet.yaml
+++ b/talos/patches/global/machine-kubelet.yaml
@@ -3,7 +3,10 @@ machine:
     extraConfig:
       enableSystemLogHandler: true
       enableSystemLogQuery: true
+      mergeDefaultEvictionSettings: true
       evictionHard:
+        memory.available: "7%"
+      evictionMinimumReclaim:
         memory.available: 1Gi
       # Trigger image GC before Ceph's mon_data_avail_warn default (30% free) fires.
       imageGCHighThresholdPercent: 70


### PR DESCRIPTION
## Summary

- preserve kubelet's default eviction signals when overriding thresholds
- change the hard memory threshold from a fixed 1Gi to 7% of node memory
- require 1Gi of additional reclaim after crossing the threshold

## Why

The previous fixed threshold allowed control-2 to reach severe node-wide memory pressure before kubelet could recover. A percentage threshold adapts to node capacity, and minimum reclaim adds hysteresis so the node does not immediately return to pressure.

## Validation

- `yayamlls validate talos/patches/global/machine-kubelet.yaml`
- `task talos:generate-config`
- `talosctl validate --strict --mode metal` for control-1, control-2, and control-3
- generated configs contain `mergeDefaultEvictionSettings: true`, `memory.available: 7%`, and minimum reclaim `1Gi`
- `git diff --check`

## Rollout note

No live Talos configuration was applied. The new threshold can evict pods earlier during memory pressure, which is the intended protection against another node-wide OOM.
