### PR TITLE
fix(siren): add high availability

### DIFF
--- a/kubernetes/apps/observability/siren/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/siren/app/helmrelease.yaml
@@ -2,7 +2,7 @@
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
-  name: siren
+  name: &app siren
 spec:
   interval: 1h
   chartRef:
@@ -11,6 +11,8 @@ spec:
   values:
     controllers:
       siren:
+        replicas: 2
+        strategy: RollingUpdate
         annotations:
           reloader.stakater.com/auto: "true"
         containers:
@@ -61,6 +63,13 @@ spec:
         runAsNonRoot: true
         runAsUser: 1000
         runAsGroup: 1000
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: *app
     service:
       app:
         ports:


### PR DESCRIPTION
## Summary

- run two Siren replicas with rolling updates
- spread replicas across hostnames using the established app-template pattern
- keep the service stateless and preserve existing probes and resources

## Why

Siren was unavailable when its only pod was evicted during node memory pressure. A second replica removes that single-node availability dependency.

## Validation

- `yayamlls validate kubernetes/apps/observability/siren/app/helmrelease.yaml`
- `flate test hr siren` renders Siren successfully; the command retains the same two unrelated main-branch unused-values warnings for CoreDNS and external-dns
- rendered Deployment: 2 replicas, RollingUpdate, hostname topology spread, matching `app.kubernetes.io/name: siren` selector
- `git diff --check`

## Rollout note

`ScheduleAnyway` prefers separate nodes while still allowing scheduling during temporary capacity constraints.
