### PR TITLE
fix(ai): right-size embedding memory request

### DIFF
--- a/kubernetes/apps/ai/llmkube/models/qwen3-embedding.yaml
+++ b/kubernetes/apps/ai/llmkube/models/qwen3-embedding.yaml
@@ -76,6 +76,8 @@ spec:
 
   resources:
     cpu: "500m" # inference is on the iGPU; CPU only tokenises/schedules
-    memory: 1Gi # 639MB Q8_0 weights via UMA; measured 692Mi working set
+    # Current 84746bcc6 revision peaked at ~3.1 GiB working set over 7 days;
+    # reserve 4 GiB so the scheduler accounts for the model's UMA usage.
+    memory: 4Gi
   endpoint:
     path: /v1/embeddings


### PR DESCRIPTION
## Summary

- increase the qwen3-embedding memory request from 1Gi to 4Gi
- replace the stale 692Mi working-set comment with current revision evidence

## Why

The current `84746bcc6` revision reached a 3.038Gi seven-day working-set peak while requesting only 1Gi. The 4Gi request makes scheduler accounting reflect the model's UMA-backed memory usage and reduces node overcommit risk.

LiteLLM, p2pool, and vmsingle also showed request/peak gaps, but remain unchanged until revision-specific averages and placement impact can be checked completely.

## Validation

- `yayamlls validate kubernetes/apps/ai/llmkube/models/qwen3-embedding.yaml`
- `flate test ks llmkube-models`
- rendered InferenceService contains `resources.memory: 4Gi`
- `git diff --check`
