### PR TITLE
fix(descheduler): restrict evictor protections and drop LowNodeUtilization

### DIFF
--- a/kubernetes/apps/kube-system/descheduler/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/descheduler/app/helmrelease.yaml
@@ -22,20 +22,6 @@ spec:
                 podProtections:
                   defaultDisabled:
                     - FailedBarePods
-                    - PodsWithLocalStorage
-                    - SystemCriticalPods
-            - name: LowNodeUtilization
-              args:
-                metricsUtilization:
-                  source: KubernetesMetrics
-                thresholds:
-                  cpu: 20
-                  memory: 20
-                  pods: 20
-                targetThresholds:
-                  cpu: 50
-                  memory: 50
-                  pods: 50
             - name: RemoveFailedPods
               args:
                 reasons:
@@ -58,7 +44,6 @@ spec:
           plugins:
             balance:
               enabled:
-                - LowNodeUtilization
                 - RemovePodsViolatingTopologySpreadConstraint
             deschedule:
               enabled:


### PR DESCRIPTION
DefaultEvictor's `defaultDisabled` list currently licenses eviction of SystemCriticalPods and PodsWithLocalStorage — removed so those stay protected. LowNodeUtilization is also removed from the balance plugins: on this 3-node everything-on-control-plane cluster at ~100% memory allocation it just churns pods without freeing real headroom.

Verification: validated YAML parse + `kustomize build --enable-helm` on the app dir, output renders cleanly. Merger should confirm the descheduler CronJob/Deployment still runs its next cycle without errors and no longer evicts system-critical pods.