### PR TITLE
fix(security): drop redundant unregister_on_exit overrides

### DIFF
--- a/kubernetes/apps/security/crowdsec/app/helmrelease.yaml
+++ b/kubernetes/apps/security/crowdsec/app/helmrelease.yaml
@@ -80,14 +80,6 @@ spec:
           db_name: $${DB_NAME}
           host: $${DB_HOST}
           port: 5432
-      agent_config.yaml.local: |-
-        api:
-          client:
-            unregister_on_exit: false
-      appsec_config.yaml.local: |-
-        api:
-          client:
-            unregister_on_exit: false
       profiles.yaml: |-
         name: default_ip_remediation
         debug: false

--- a/kubernetes/apps/security/crowdsec/app/helmrelease.yaml
+++ b/kubernetes/apps/security/crowdsec/app/helmrelease.yaml
@@ -87,7 +87,7 @@ spec:
       appsec_config.yaml.local: |-
         api:
           client:
-            unregister_on_exit: true
+            unregister_on_exit: false
       profiles.yaml: |-
         name: default_ip_remediation
         debug: false


### PR DESCRIPTION
crowdsec's `LocalApiClientCfg.UnregisterOnExit` is a plain Go bool with no default assignment (zero-value `false`), and chart 0.20.1 contains no `unregister` key in values or templates — so both `agent_config.yaml.local` (explicit `false` since #3564) and `appsec_config.yaml.local` (the `true` that caused the 07-12 appsec crashloop: one container kill deregistered the LAPI machine while emptyDir credentials survived, wedging every subsequent start at the 5-min backoff cap) only restated or overrode the default. Deleting both blocks yields identical runtime behavior with less config, and removes the trap class entirely.

Verification: `kustomize build --enable-helm` clean; rendered output contains no `unregister` key and no agent/appsec `yaml.local` ConfigMap entries; the LAPI `config.yaml.local` (auto-registration + db) is untouched.