### PR TITLE
fix(coredns): fix dead pdb key and add priority class and 3rd replica

### DIFF
--- a/kubernetes/apps/kube-system/coredns/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/coredns/app/helmrelease.yaml
@@ -13,7 +13,8 @@ spec:
     fullnameOverride: coredns
     image:
       repository: mirror.gcr.io/coredns/coredns
-    replicaCount: 2
+    replicaCount: 3
+    priorityClassName: system-cluster-critical
     k8sAppLabelOverride: kube-dns
     serviceAccount:
       create: true
@@ -53,9 +54,8 @@ spec:
           - name: log
             configBlock: |-
               class error
-    pdb:
-      enabled: true
-      minAvailable: 1
+    podDisruptionBudget:
+      maxUnavailable: 1
     affinity:
       nodeAffinity:
         requiredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
The chart's real PDB key is `podDisruptionBudget`, not `pdb` — the old block silently rendered nothing (confirmed: no coredns PDB in the cluster, chart 1.46.1 `helm show values` has no `pdb` field). CoreDNS also had no priorityClassName, making it evictable at priority 0 during the cluster's documented OOM cascades, and replicaCount 2 left one of the three control-plane nodes without a local replica.

Fix: `podDisruptionBudget.maxUnavailable: 1`, `priorityClassName: system-cluster-critical`, `replicaCount: 3`.

Verification: `helm template` against chart 1.46.1 confirms the PDB and priorityClassName now render correctly; `kustomize build --enable-helm` on the app dir passes. After merge, check `kubectl get pdb -n kube-system` shows a coredns entry and all 3 pods schedule across the 3 control-plane nodes.