### PR TITLE
fix(ci): reduce maxRunners from 10 to 5 for n-1 node schedulability

### DIFF
--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/cluster/helmrelease.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/cluster/helmrelease.yaml
@@ -13,7 +13,7 @@ spec:
     githubConfigUrl: https://github.com/tanguille/cluster
     githubConfigSecret: cluster-runner-secret
     minRunners: 1
-    maxRunners: 10
+    maxRunners: 5
     containerMode:
       type: kubernetes
       kubernetesModeWorkVolumeClaim:


### PR DESCRIPTION
With control-1 down (verified live on 07-20), two nodes' request headroom fits only ~4 runner pods (512Mi requests). Setting maxRunners to 5 keeps CI throughput while avoiding the 07-02 starvation geometry that packed all runners onto one node and crashed the cluster.

Verification: YAML syntax validated, kustomize build succeeds, change confirmed in file.