### PR TITLE
fix(qbittorrent): raise liveness/readiness probe timeout to 5s

### DIFF
--- a/kubernetes/apps/media/qbittorrent/app/helmrelease.yaml
+++ b/kubernetes/apps/media/qbittorrent/app/helmrelease.yaml
@@ -38,7 +38,7 @@ spec:
                     port: *port
                   initialDelaySeconds: 0
                   periodSeconds: 10
-                  timeoutSeconds: 1
+                  timeoutSeconds: 5
                   failureThreshold: 3
               readiness: *probes
               startup:


### PR DESCRIPTION
qbittorrent's liveness/readiness timeoutSeconds was 1s, causing probe kills (30-50 restarts/7d) during node load spikes. Raised to 5s to match hermes/jellyfin/radarr's probe timeout convention.

memini and unpackerr have no explicit timeoutSeconds field in their probe config (chart defaults / bare enabled:true), so nothing to change there. kopiur-controller's chart doesn't expose probe settings in values, so it's operator-managed and skipped.

Verification: kustomize build --enable-helm on kubernetes/apps/media/qbittorrent/app rendered cleanly. Merger should watch qbittorrent restart counts over the next few days to confirm the probe kills stop.