### PR TITLE
fix(toolhive): restrict flux-operator MCP to read+reconcile tools

### DIFF
--- a/kubernetes/apps/ai/toolhive/config/flux-operator.yaml
+++ b/kubernetes/apps/ai/toolhive/config/flux-operator.yaml
@@ -4,4 +4,17 @@ kind: MCPToolConfig
 metadata:
   name: flux-operator
 spec:
-  toolsFilter: []
+  # Allowlist: read/report + reconcile only. Excludes apply/delete/install/
+  # suspend/resume so anonymous LAN callers can't mutate the cluster.
+  toolsFilter:
+    - get_flux_instance
+    - get_kubernetes_resources
+    - get_kubernetes_logs
+    - get_kubernetes_metrics
+    - get_kubernetes_api_versions
+    - get_kubeconfig_contexts
+    - reconcile_flux_resourceset
+    - reconcile_flux_source
+    - reconcile_flux_kustomization
+    - reconcile_flux_helmrelease
+    - search_flux_docs


### PR DESCRIPTION
The `flux-operator` MCPToolConfig had an empty `toolsFilter` (`[]`), which exposes **all** flux-operator-mcp tools — including `apply_kubernetes_manifest`, `delete_kubernetes_resource`, and `install_flux_instance`. Since this MCP is reachable anonymously on the LAN gateway, any LAN device could mutate or delete cluster resources.

This sets an explicit allowlist of read/report + reconcile tools only:

- get_flux_instance
- get_kubernetes_resources
- get_kubernetes_logs
- get_kubernetes_metrics
- get_kubernetes_api_versions
- get_kubeconfig_contexts
- reconcile_flux_resourceset
- reconcile_flux_source
- reconcile_flux_kustomization
- reconcile_flux_helmrelease
- search_flux_docs

Excluded (mutating): `apply_kubernetes_manifest`, `delete_kubernetes_resource`, `install_flux_instance`, `suspend_flux_reconciliation`, `resume_flux_reconciliation`, `set_kubeconfig_context`. The Hermes agent's legitimate use (reconciling Flux objects) is preserved.

Both the primary (`flux` group) and opt (`all` group) copies in resourceset.yaml share `toolConfigRef.name: flux-operator`, so this single file covers both — no second filter needed.

This is defense-in-depth; route-level auth on the gateway is a separate decision, not addressed here.

Verification: `kustomize build --enable-helm kubernetes/apps/ai/toolhive/config` passes. Tool names verified against flux-operator-mcp docs (repo controlplaneio-fluxcd/flux-operator, image v0.55.0). After merge, confirm the flux-operator MCP pods restart and `get_*`/`reconcile_*` calls still succeed while `apply`/`delete` are rejected.