### PR TITLE
feat(ai): add sglang and embedding alerting rules

### DIFF
--- a/kubernetes/apps/ai/sglang/app/kustomization.yaml
+++ b/kubernetes/apps/ai/sglang/app/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   - helmrelease.yaml
   - pvc.yaml
   - grafanadashboard.yaml
+  - prometheusrule.yaml
 
 configMapGenerator:
   - name: sglang-dashboard

--- a/kubernetes/apps/ai/sglang/app/prometheusrule.yaml
+++ b/kubernetes/apps/ai/sglang/app/prometheusrule.yaml
@@ -1,0 +1,41 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: sglang-rules
+spec:
+  groups:
+    - name: sglang.rules
+      rules:
+        - alert: SGLangDown
+          expr: |-
+            up{job="sglang"} == 0
+          for: 10m
+          annotations:
+            summary: >-
+              sglang has not been scraped for 10m — inference is unavailable
+          labels:
+            severity: critical
+
+        - alert: SGLangQueueStuck
+          expr: |-
+            sglang:num_queue_reqs >= 32
+          for: 30m
+          annotations:
+            summary: >-
+              sglang request queue has been at the configured max-queued-requests cap (32) for 30m — new requests are being rejected
+          labels:
+            severity: warning
+
+    - name: ai.rules
+      rules:
+        - alert: AIEmbeddingPending
+          expr: |-
+            kube_pod_status_phase{namespace="ai", phase="Pending"} == 1
+          for: 5m
+          annotations:
+            summary: >-
+              A pod in the ai namespace has been Pending for 5m — check for the qwen3-embedding hard-affinity deadlock
+          labels:
+            severity: warning


### PR DESCRIPTION
Adds a PrometheusRule to close the gap between the rich sglang metrics/dashboard and zero alerting: SGLangDown (`up{job="sglang"} == 0` for 10m, critical — job label verified via instant query), SGLangQueueStuck (`sglang:num_queue_reqs >= 32` for 30m, warning — chosen over num_running_reqs because the queue metric directly signals rejected requests once it hits the configured `--max-queued-requests 32` cap), and AIEmbeddingPending (`kube_pod_status_phase{namespace="ai", phase="Pending"} == 1` for 5m, warning — catches the documented qwen3-embedding hard-affinity deadlock before it silently takes Hermes tool-less).

Verification: validated job label and metric names against live vmsingle (`up{job="sglang"}` present, `sglang:num_queue_reqs`/`sglang:num_running_reqs` confirmed as the relevant series); `kustomize build --enable-helm kubernetes/apps/ai/sglang/app` renders cleanly. After merge, confirm the rule loads in vmalert/AlertManager and trigger a manual Pending test if possible.