### PR TITLE
fix(ai): run litellm at 2 replicas and raise memory request to 1Gi

### DIFF
--- a/kubernetes/apps/ai/litellm/instance/proxy.yaml
+++ b/kubernetes/apps/ai/litellm/instance/proxy.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   image: ghcr.io/berriai/litellm:v1.93.0@sha256:a1745e629abfb17d434426ff48b115f54f4f4c4a0f5af241de569e93c63c411e
   applyMode: api
+  replicas: 2
   apiAccess:
     masterKeyRef:
       name: litellm-secret
@@ -71,7 +72,7 @@ spec:
   resources:
     requests:
       cpu: 100m
-      memory: 512Mi
+      memory: 1Gi # measured ~1.05GiB usage, was invisible to the scheduler at 512Mi
     limits:
       cpu: 2
       memory: 5Gi


### PR DESCRIPTION
litellm is the single choke point for the whole AI chain (Hermes -> vmcp -> embeddings) and was restarted in today's node flap. The CRD supports `spec.replicas` (confirmed via `kubectl explain litellmproxy.spec`), and litellm is a stateless proxy with dragonfly-backed cache, so 2 replicas is safe. Also raises the memory request 512Mi -> 1Gi to match measured ~1.05GiB usage, which was previously invisible to the scheduler.

Verification: validated the CRD field via `kubectl explain litellmproxy.spec` (replicas: integer) and ran `kustomize build --enable-helm` on the instance dir, which renders cleanly. After merge, check that both pods come up healthy behind the service and that the HTTPRoute still resolves correctly with 2 endpoints.