### PR TITLE
feat(observability): add alerts for silent failure modes found in 07-20 audit

### DIFF
--- a/kubernetes/apps/kube-system/cilium/app/prometheusrule.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/prometheusrule.yaml
@@ -42,3 +42,19 @@ spec:
             severity: critical
             component: cilium
             type: loadbalancer
+
+    - name: cilium.bpf.rules
+      rules:
+        - alert: CiliumCTMapPressureHigh
+          expr: |
+            max(cilium_bpf_map_pressure) > 0.7
+          for: 15m
+          annotations:
+            summary: Cilium BPF map {{ $labels.map_name }} pressure above 70% for 15 minutes
+            description: >-
+              Connection-tracking or related BPF map pressure has stayed above 70% for 15 minutes.
+              PR #3662 fixed CT map sizing; sustained high pressure means it needs revisiting.
+          labels:
+            severity: warning
+            component: cilium
+            type: bpf-map

--- a/kubernetes/apps/kube-system/coredns/app/kustomization.yaml
+++ b/kubernetes/apps/kube-system/coredns/app/kustomization.yaml
@@ -5,3 +5,4 @@ kind: Kustomization
 resources:
   - helmrelease.yaml
   - ocirepository.yaml
+  - prometheusrule.yaml

--- a/kubernetes/apps/kube-system/coredns/app/prometheusrule.yaml
+++ b/kubernetes/apps/kube-system/coredns/app/prometheusrule.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: coredns-custom-rules
+spec:
+  groups:
+    - name: coredns.custom.rules
+      rules:
+        - alert: CoreDNSUpstreamServfailDecay
+          expr: |-
+            sum(rate(coredns_dns_responses_total{rcode="SERVFAIL"}[5m])) > 1
+          for: 10m
+          annotations:
+            summary: >-
+              CoreDNS SERVFAIL rate elevated for 10 minutes, likely an upstream resolver stall
+          labels:
+            severity: warning

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/kustomization.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/kustomization.yaml
@@ -5,3 +5,4 @@ kind: Kustomization
 resources:
   - helmrelease.yaml
   - ocirepository.yaml
+  - prometheusrule.yaml

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/prometheusrule.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/prometheusrule.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: rook-ceph-custom-rules
+spec:
+  groups:
+    - name: rook-ceph.custom.rules
+      rules:
+        - alert: CephOSDSustainedHighLatency
+          expr: |-
+            avg_over_time(ceph_osd_apply_latency_ms[30m]) > 100
+          for: 30m
+          annotations:
+            summary: >-
+              OSD {{ $labels.ceph_daemon }} apply latency has averaged over 100ms for 30 minutes
+              (CephSlowOps only fires on healthcheck-level stalls, not this)
+          labels:
+            severity: warning


### PR DESCRIPTION
Adds three PrometheusRule alerts for gaps found in the 07-20 audit: sustained Ceph OSD apply latency (avg_over_time > 100ms for 30m — CephSlowOps only catches healthcheck-level stalls and missed osd.0's 10-33s stalls), CoreDNS SERVFAIL rate (>1/s for 10m — upstream Unbound stalls pushed p99 to 1.26s and crashlooped external-dns/cloudflared with no page), and Cilium BPF CT map pressure (>70% for 15m — PR #3662 sized the CT maps but the pressure watch it called for was never added; 14d peak already hit 51%).

Verification: confirmed all three source metrics are present and scraped by querying vmsingle-victoria-metrics directly (ceph_osd_apply_latency_ms, coredns_dns_responses_total{rcode="SERVFAIL"}, cilium_bpf_map_pressure all returned live series). Validated all changed/new YAML with `kustomize build` (rook-ceph cluster dir with --enable-helm, coredns app, cilium app) — all three render cleanly. After merge, check that the rendered PrometheusRule CRs actually load into VictoriaMetrics (ruleSelector match) and that severity:warning routes to the expected receiver.