### PR TITLE
fix(ci): strip unused CI-runner privileges

### DIFF
--- a/.github/workflows/image-pull.yaml
+++ b/.github/workflows/image-pull.yaml
@@ -54,7 +54,11 @@ jobs:
           echo 'EOF' >> $GITHUB_OUTPUT
 
   pull:
-    if: ${{ needs.flate.outputs.images != '[]' }}
+    if: >-
+      ${{
+        needs.flate.outputs.images != '[]' &&
+        github.event.pull_request.head.repo.full_name == github.repository
+      }}
     needs: flate
     name: Image Pull - Pull Images
     runs-on: cluster-runner

--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/cluster/rbac.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/cluster/rbac.yaml
@@ -4,22 +4,10 @@ kind: ServiceAccount
 metadata:
   name: cluster-runner
 ---
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: cluster-runner
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cluster-admin
-subjects:
-  - kind: ServiceAccount
-    name: cluster-runner
-    namespace: actions-runner-system
----
 apiVersion: talos.dev/v1alpha1
 kind: ServiceAccount
 metadata:
   name: cluster-runner
 spec:
-  roles: ["os:admin"]
+  # Only use is 'talosctl image pull' in image-pull.yaml.
+  roles: ["os:reader"]


### PR DESCRIPTION
Removes the cluster-runner ServiceAccount's cluster-admin ClusterRoleBinding — confirmed no workflow in .github/ invokes kubectl, and ARC's containerMode:kubernetes pod/PVC permissions come from its own auto-generated cluster-runner-gha-rs-manager Role, not this binding. Drops the Talos ServiceAccount from os:admin to os:reader, since its only current use is talosctl image pull in image-pull.yaml. Also adds the same-repo gate (already used by agent-pr-review.yaml and labeler.yaml) to the image-pull pull job so fork PRs can't run modified steps on the self-hosted cluster-runner.

Verification: kustomize build --enable-helm on the runners/cluster dir renders cleanly with the cluster-admin binding gone and os:reader in place; confirmed via kubectl that the pod/secret/serviceaccount/role/rolebinding perms for containerMode:kubernetes live on a separate ARC-managed Role/SA. Post-merge: if talosctl image pull starts failing with os:reader, bump to os:operator (talos-mcp already runs fine on os:reader, so os:reader is expected to be sufficient).