### PR TITLE
fix(network): harden envoy data/control-plane resilience

### DIFF
--- a/kubernetes/apps/network/envoy-gateway/app/envoy.yaml
+++ b/kubernetes/apps/network/envoy-gateway/app/envoy.yaml
@@ -20,6 +20,19 @@ spec:
               memory: 256Mi
             limits:
               memory: 2Gi
+        patch:
+          type: StrategicMerge
+          value:
+            spec:
+              template:
+                spec:
+                  # externalTrafficPolicy: Local means a probe-kill blacks out that node's LB traffic; widen the margin
+                  priorityClassName: system-cluster-critical
+                  containers:
+                    - name: envoy
+                      livenessProbe:
+                        timeoutSeconds: 5
+                        failureThreshold: 6
       envoyService:
         externalTrafficPolicy: Local
   shutdown:

--- a/kubernetes/apps/network/envoy-gateway/app/helmrelease.yaml
+++ b/kubernetes/apps/network/envoy-gateway/app/helmrelease.yaml
@@ -12,6 +12,9 @@ spec:
   values:
     global:
       imageRegistry: mirror.gcr.io
+    deployment:
+      # xDS control plane; avoid config-push stalls when the sole replica's node is disrupted
+      replicas: 2
     config:
       envoyGateway:
         extensionApis:


### PR DESCRIPTION
Widens the envoy DaemonSet liveness probe (timeoutSeconds 1->5, failureThreshold 3->6) and sets priorityClassName: system-cluster-critical via the EnvoyProxy CR's envoyDaemonSet patch — externalTrafficPolicy: Local means a probe-kill blacks out that node's LB traffic, and envoy-internal-tls has seen 39 restarts/7d. Also scales the envoy-gateway controller (xDS control plane) to 2 replicas so config pushes don't stall when the sole replica's node is disrupted.

Verification: `kustomize build --enable-helm kubernetes/apps/network/envoy-gateway/app` renders both files cleanly (exit 0), and the EnvoyProxy CRD's patch.value field shape (StrategicMerge, RawExtension) was confirmed against the live cluster CRD. Live probe/priorityClassName state and the envoy-gateway deployment's current 1 replica were confirmed via kubectl before writing the patch. After merge, confirm the strategic-merge patch actually lands on the rendered DaemonSet spec for the deployed Envoy Gateway version (1.8.2) — the container-array merge-by-name semantics should hold, but verify with `kubectl get ds envoy-internal-tls -o jsonpath='{.spec.template.spec.containers[0].livenessProbe}'` post-reconcile.