### PR TITLE
fix(cnpg): spread pgbouncer-rw pooler replicas across nodes

### DIFF
--- a/kubernetes/apps/database/cloudnative-pg/cluster/pooler.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/pooler.yaml
@@ -26,6 +26,14 @@ spec:
             limits:
               cpu: "1"
               memory: 256Mi
+      # Soft spread so losing one node doesn't strand all 3 replicas on the other two.
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              cnpg.io/poolerName: pgbouncer-rw
   pgbouncer:
     poolMode: transaction
     parameters:


### PR DESCRIPTION
The rw Pooler had no topologySpreadConstraints, so the scheduler could pack all 3 pgbouncer-rw replicas onto the two bare-metal nodes with the higher failure rate (control-2/control-3) while control-1 sat idle. PR #4040 added eviction-protection resource requests/limits but no spreading. Adds a soft (`ScheduleAnyway`, `maxSkew: 1`) topology spread by `kubernetes.io/hostname` scoped to `cnpg.io/poolerName: pgbouncer-rw`, mirroring the runner fix in fc9cb314f.

Verification: `kustomize build --enable-helm kubernetes/apps/database/cloudnative-pg/cluster` renders the Pooler with the constraint intact and no other diffs. After merge, check that pgbouncer-rw pods land one per node once CNPG reconciles the change.