### PR TITLE
feat(cloudnative-pg): alert on instance restart loops and cluster not-ready

### DIFF
--- a/kubernetes/apps/database/cloudnative-pg/cluster/prometheusrule.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/prometheusrule.yaml
@@ -89,3 +89,22 @@ spec:
           for: 5m
           labels:
             severity: warning
+        - alert: CNPGInstanceRestartLoop
+          annotations:
+            description: Pod {{ $labels.pod }} is restarting repeatedly.
+            summary: A CloudNativePG instance is stuck in a restart loop.
+          # kube-state-metrics doesn't expose the cnpg.io/cluster pod label, match by pod name prefix instead
+          expr: |-
+            rate(kube_pod_container_status_restarts_total{namespace="database", pod=~"postgres16-.*"}[30m]) > 0
+          for: 30m
+          labels:
+            severity: warning
+        - alert: CNPGClusterNotReady
+          annotations:
+            description: Instance {{ $labels.pod }} of cluster {{ $labels.cluster }} has been down for more than 15 minutes.
+            summary: A CloudNativePG instance is not ready.
+          expr: |-
+            cnpg_collector_up == 0
+          for: 15m
+          labels:
+            severity: critical


### PR DESCRIPTION
Adds two PrometheusRule alerts that would have paged the 07-04 13h replica crashloop: CNPGInstanceRestartLoop (warning, restart rate > 0 sustained 30m, matched by postgres16-* pod prefix since kube-state-metrics doesn't expose the cnpg.io/cluster label) and CNPGClusterNotReady (critical, cnpg_collector_up == 0 for 15m — no cluster-level ready metric exists, so per-instance up/down is the closest available signal).

Verification: validated with kustomize build --enable-helm against the app dir, and confirmed both cnpg_collector_up (with cluster/pod labels) and kube_pod_container_status_restarts_total against the live VictoriaMetrics instance via a throwaway curl pod. Merger should confirm the postgres16-* pod prefix stays accurate if the cluster is ever renamed.