### PR TITLE
feat(observability): add node hardware alert rules

### DIFF
--- a/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
@@ -370,22 +370,6 @@ spec:
                 for: 5m
                 labels:
                   severity: critical
-              - alert: NVMeTemperatureWarning
-                annotations:
-                  summary: NVMe {{ $labels.chip }} on {{ $labels.nodename }} is running hot ({{ $value }}°C)
-                  description: "{{ $labels.chip }} on {{ $labels.nodename }} has been above 78°C for 10 minutes ({{ $value }}°C). Crash latch is ~92°C and needs a cold power cycle."
-                expr: max by (nodename, chip) (node_hwmon_temp_celsius{chip=~"nvme.*"}) > 78
-                for: 10m
-                labels:
-                  severity: warning
-              - alert: NVMeTemperatureCritical
-                annotations:
-                  summary: NVMe {{ $labels.chip }} on {{ $labels.nodename }} is critically hot ({{ $value }}°C)
-                  description: "{{ $labels.chip }} on {{ $labels.nodename }} has been above 85°C for 5 minutes ({{ $value }}°C). Crash latch is ~92°C and needs a cold power cycle."
-                expr: max by (nodename, chip) (node_hwmon_temp_celsius{chip=~"nvme.*"}) > 85
-                for: 5m
-                labels:
-                  severity: critical
               - alert: NodeCPUPressureSustained
                 annotations:
                   summary: Sustained CPU pressure on {{ $labels.nodename }}

--- a/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
@@ -358,3 +358,55 @@ spec:
                 for: 5m
                 labels:
                   severity: critical
+      node-hardware-rules:
+        groups:
+          - name: node-hardware
+            rules:
+              - alert: NVMeCriticalWarning
+                annotations:
+                  summary: NVMe {{ $labels.device }} on {{ $labels.instance }} reports a critical warning
+                  description: smartctl_device_critical_warning is nonzero on {{ $labels.device }} ({{ $labels.instance }}) — confirmed precursor to an XFS forced-shutdown crash.
+                expr: smartctl_device_critical_warning > 0
+                for: 5m
+                labels:
+                  severity: critical
+              - alert: NVMeTemperatureWarning
+                annotations:
+                  summary: NVMe {{ $labels.chip }} on {{ $labels.nodename }} is running hot ({{ $value }}°C)
+                  description: "{{ $labels.chip }} on {{ $labels.nodename }} has been above 78°C for 10 minutes ({{ $value }}°C). Crash latch is ~92°C and needs a cold power cycle."
+                expr: max by (nodename, chip) (node_hwmon_temp_celsius{chip=~"nvme.*"}) > 78
+                for: 10m
+                labels:
+                  severity: warning
+              - alert: NVMeTemperatureCritical
+                annotations:
+                  summary: NVMe {{ $labels.chip }} on {{ $labels.nodename }} is critically hot ({{ $value }}°C)
+                  description: "{{ $labels.chip }} on {{ $labels.nodename }} has been above 85°C for 5 minutes ({{ $value }}°C). Crash latch is ~92°C and needs a cold power cycle."
+                expr: max by (nodename, chip) (node_hwmon_temp_celsius{chip=~"nvme.*"}) > 85
+                for: 5m
+                labels:
+                  severity: critical
+              - alert: NodeCPUPressureSustained
+                annotations:
+                  summary: Sustained CPU pressure on {{ $labels.nodename }}
+                  description: CPU PSI wait on {{ $labels.nodename }} has been above 0.5s/s for 15 minutes ({{ $value }}s/s) — precedes cold-reload storms and runner starvation.
+                expr: rate(node_pressure_cpu_waiting_seconds_total[5m]) > 0.5
+                for: 15m
+                labels:
+                  severity: warning
+              - alert: NodeMemoryPressureSustained
+                annotations:
+                  summary: Sustained memory pressure on {{ $labels.nodename }}
+                  description: Memory PSI wait on {{ $labels.nodename }} has been above 0.3s/s for 15 minutes ({{ $value }}s/s).
+                expr: rate(node_pressure_memory_waiting_seconds_total[5m]) > 0.3
+                for: 15m
+                labels:
+                  severity: warning
+              - alert: NodeVarFillingUp
+                annotations:
+                  summary: /var on {{ $labels.nodename }} is filling up
+                  description: "/var on {{ $labels.nodename }} has less than 15% free space ({{ $value | humanizePercentage }})." # plain threshold; predict_linear false-fires on fresh series
+                expr: node_filesystem_avail_bytes{mountpoint="/var"} / node_filesystem_size_bytes{mountpoint="/var"} < 0.15
+                for: 30m
+                labels:
+                  severity: warning


### PR DESCRIPTION
Adds NVMe thermal/critical-warning alerts, sustained CPU/memory PSI pressure alerts, and a /var fill alert to victoria-metrics `extraRules`, alongside the existing dockerhub-rules/oom-rules entries. Motivated by control-3's Micron 7450 peaking at 94.8C over 14 days with `smartctl_device_critical_warning` tripped on 12/14 days and zero alerting on any of it; thresholds are 78C/85C (crash latch is ~92C, cold power cycle required), PSI wait >0.5s/s (CPU) and >0.3s/s (memory) sustained 15m, and /var <15% free for 30m (plain threshold — the bundled predict_linear rule false-fires on fresh series).

Verification: `kustomize build --enable-helm` on the app dir succeeds and the rendered HelmRelease contains the new `node-hardware-rules` block; confirmed via live instant queries against vmsingle that `smartctl_device_critical_warning`, `node_hwmon_temp_celsius{chip=~"nvme.*"}`, `node_pressure_cpu_waiting_seconds_total`, `node_pressure_memory_waiting_seconds_total`, and `node_filesystem_avail_bytes{mountpoint="/var"}` all have live series with the `nodename` label. After merge, check that vmalert picks up the new `node-hardware-rules` PrometheusRule and that the NVMe temperature thresholds don't false-fire against current baseline temps (control-3 NVMe already runs in the 60s-70s C range under load).