### PR TITLE
fix(kopiur): ease kopia probe timing and de-cardinalize snapshot alert

### DIFF
--- a/kubernetes/apps/kopiur-system/kopia/app/helmrelease.yaml
+++ b/kubernetes/apps/kopiur-system/kopia/app/helmrelease.yaml
@@ -44,8 +44,9 @@ spec:
                     port: *port
                   initialDelaySeconds: 0
                   periodSeconds: 10
-                  timeoutSeconds: 1
-                  failureThreshold: 3
+                  # 07-18 outage: index digest of a 4.7k-blob backlog made / answer >1s, kubelet kill-looped the pod
+                  timeoutSeconds: 10
+                  failureThreshold: 6
               readiness: *probes
             securityContext:
               allowPrivilegeEscalation: false

--- a/kubernetes/apps/kopiur-system/kopiur/app/helmrelease.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/app/helmrelease.yaml
@@ -33,7 +33,7 @@ spec:
       serviceMonitor:
         enabled: true
       prometheusRule:
-        enabled: true # KopiurBackupStale et al. — live BEFORE any data moves
+        enabled: false # rules moved to repo-side prometheusrule.yaml — de-cardinalized KopiurSnapshotFailed, no per-rule override in this chart
       dashboards:
         enabled: true
         grafanaOperator:

--- a/kubernetes/apps/kopiur-system/kopiur/app/kustomization.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/app/kustomization.yaml
@@ -5,3 +5,4 @@ kind: Kustomization
 resources:
   - helmrelease.yaml
   - ocirepository.yaml
+  - prometheusrule.yaml

--- a/kubernetes/apps/kopiur-system/kopiur/app/prometheusrule.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/app/prometheusrule.yaml
@@ -1,0 +1,92 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/monitoring.coreos.com/prometheusrule_v1.json
+# Replaces the chart-rendered kopiur-controller PrometheusRule (monitoring.prometheusRule
+# disabled in helmrelease.yaml) — the chart has no per-rule override, only a global
+# enabled toggle, and KopiurSnapshotFailed needed a cardinality fix the chart can't express.
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: kopiur-controller
+spec:
+  groups:
+    - name: kopiur.rules
+      rules:
+        - alert: KopiurBackupConsecutiveFailures
+          expr: kopiur_snapshot_consecutive_failures >= 3
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Backups for {{ $labels.namespace }}/{{ $labels.name }} are failing"
+            description: "{{ $value }} consecutive backup failures (>=3) for SnapshotPolicy {{ $labels.namespace }}/{{ $labels.name }}."
+        - alert: KopiurBackupStale
+          # kopiur_policy_last_backup_success_timestamp_seconds is store-backed: its
+          # series exists only while a Succeeded Snapshot CR for that (namespace,
+          # policy) still exists. That means `time() - metric > threshold` alone goes
+          # silent — no data, not an alert — for a policy that has never succeeded, or
+          # whose Succeeded Snapshot CRs were all deleted (e.g. pruned by retention
+          # while every recent run has been failing): exactly the case that most needs
+          # to page. kopiur_snapshot_consecutive_failures{namespace,name} is a sync
+          # gauge scoped to the SnapshotPolicy itself (not store-backed like the
+          # Snapshot-derived families), so it keeps reporting even when every one of
+          # the policy's Snapshot CRs is gone, making it the presence/liveness signal
+          # for the second branch. Its label is `name` (the SnapshotPolicy name); the
+          # new family labels the same value `policy`, hence the label_replace to join
+          # on (namespace, policy) via `unless`.
+          expr: >-
+            (
+              time() - kopiur_policy_last_backup_success_timestamp_seconds > 86400
+            )
+            or
+            (
+              label_replace(kopiur_snapshot_consecutive_failures, "policy", "$1", "name", "(.*)") > 0
+              unless on (namespace, policy) kopiur_policy_last_backup_success_timestamp_seconds
+            )
+          for: 30m
+          labels:
+            severity: warning
+          annotations:
+            summary: "No recent successful backup for {{ $labels.namespace }}/{{ $labels.policy }}"
+            description: "Either the last successful backup was over 24h ago, or SnapshotPolicy {{ $labels.namespace }}/{{ $labels.policy }} has never succeeded (or its Succeeded Snapshot CRs were all deleted) and is currently failing."
+        - alert: KopiurRepositoryNotReady
+          # Active-only emission means kopiur_resource_phase never carries a 0-valued
+          # series, so `== 1` is redundant here; left in place because max-by over a
+          # regex phase selector reads more obviously as a boolean gate with it, and
+          # dropping it would change nothing observable.
+          expr: max by (namespace, name) (kopiur_resource_phase{kind=~"Repository|ClusterRepository", phase=~"Degraded|Failed"}) == 1
+          for: 15m
+          labels:
+            severity: critical
+          annotations:
+            summary: "Repository {{ $labels.namespace }}/{{ $labels.name }} is {{ $labels.phase }}"
+            description: "A kopiur repository has been Degraded/Failed for 15m; backups to it will not run."
+        - alert: KopiurSnapshotFailed
+          # Grouped by (exported_namespace, policy) instead of the chart's (namespace,
+          # name): "namespace" there is always kopiur-system (the controller's own
+          # namespace) and "name" is the per-run Snapshot CR — grouping on it fired one
+          # alert per failed CR (730 CRs -> ~4.2M alertmanager posts/day, 12.6% Discord
+          # delivery failures during the 07-18 outage backlog). Collapses to one alert
+          # per policy regardless of how many of its Snapshot CRs are Failed.
+          expr: max by (exported_namespace, policy) (kopiur_resource_phase{kind="Snapshot", phase="Failed"}) == 1
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Snapshots for {{ $labels.exported_namespace }}/{{ $labels.policy }} are failing"
+            description: "SnapshotPolicy {{ $labels.exported_namespace }}/{{ $labels.policy }} has a Snapshot CR in phase=Failed for 10m."
+        - alert: KopiurRestoreFailed
+          expr: max by (namespace, name) (kopiur_resource_phase{kind="Restore", phase="Failed"}) == 1
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Restore {{ $labels.namespace }}/{{ $labels.name }} failed"
+            description: "A Restore CR has been in phase=Failed for 10m."
+        - alert: KopiurReconcileErrorsHigh
+          expr: sum by (kind) (rate(kopiur_controller_reconcile_errors_total[10m])) > 0.2
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: "High reconcile error rate for {{ $labels.kind }}"
+            description: "kopiur controller is erroring on {{ $labels.kind }} reconciles (>0.2/s over 10m)."


### PR DESCRIPTION
Two fixes from the 07-18 to 07-20 backup outage aftermath:

1. **kopia probe timing**: liveness/readiness had `timeoutSeconds: 1`, `failureThreshold: 3`. The kopia server answers `/` slower than 1s while digesting a large index backlog (4.7k blobs post-outage), so kubelet kill-looped it mid-recovery. Raised to `timeoutSeconds: 10`, `failureThreshold: 6`.

2. **Kopiur alert hygiene**: `KopiurSnapshotFailed` grouped by `(namespace, name)` — `namespace` is always the controller's own `kopiur-system` and `name` is the per-run Snapshot CR, so it fired one alert per failed CR (730 CRs, ~4.2M alertmanager posts/day, 12.6% Discord delivery failures during the outage backlog). The kopiur chart's `prometheusRule` only has a global enable toggle and a `backupStaleAfterSeconds` value, no per-rule override, so I disabled the chart-rendered PrometheusRule (`monitoring.prometheusRule.enabled: false`) and added an equivalent repo-side one, with `KopiurSnapshotFailed` regrouped by `(exported_namespace, policy)` (collapses to one alert per policy no matter how many of its Snapshot CRs failed) and `KopiurBackupStale`'s staleness threshold lowered from 172800s to 86400s.

**Verification**: `kustomize build --enable-helm` passes clean on both `kopiur-system/kopia/app` and `kopiur-system/kopiur/app`, confirmed the rendered kopia probe values and confirmed the chart's PrometheusRule no longer renders (repo one takes over). Verified current metric label shapes (`kopiur_resource_phase`, `kopiur_snapshot_consecutive_failures`) live against VictoriaMetrics to confirm the new grouping is correct. After merge: watch alertmanager notification volume for `KopiurSnapshotFailed` over the next backup cycle to confirm the cardinality fix holds, and confirm kopia doesn't get probe-killed on its next large-backlog digest.