### PR TITLE
feat(security): add pod-security baseline warn/audit labels, disable nextcloud SA automount

### DIFF
--- a/kubernetes/apps/default/nextcloud/app/helmrelease.yaml
+++ b/kubernetes/apps/default/nextcloud/app/helmrelease.yaml
@@ -22,6 +22,19 @@ spec:
       valuesKey: FROM_ADDRESS
       targetPath: nextcloud.mail.fromAddress
 
+  # Chart has no automountServiceAccountToken value; nextcloud is the only
+  # internet-exposed app still auto-mounting its default SA token.
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              kind: Deployment
+              name: nextcloud
+            patch: |-
+              - op: add
+                path: /spec/template/spec/automountServiceAccountToken
+                value: false
+
   values:
     prometheus:
       rules:

--- a/kubernetes/apps/default/nextcloud/app/helmrelease.yaml
+++ b/kubernetes/apps/default/nextcloud/app/helmrelease.yaml
@@ -34,6 +34,13 @@ spec:
               - op: add
                 path: /spec/template/spec/automountServiceAccountToken
                 value: false
+          - target:
+              kind: CronJob
+              name: nextcloud-cron
+            patch: |-
+              - op: add
+                path: /spec/jobTemplate/spec/template/spec/automountServiceAccountToken
+                value: false
 
   values:
     prometheus:

--- a/kubernetes/components/common/namespace.yaml
+++ b/kubernetes/components/common/namespace.yaml
@@ -5,3 +5,6 @@ metadata:
   name: not-used
   annotations:
     kustomize.toolkit.fluxcd.io/prune: disabled
+  labels:
+    pod-security.kubernetes.io/warn: baseline
+    pod-security.kubernetes.io/audit: baseline


### PR DESCRIPTION
Adds pod-security.kubernetes.io/warn and audit: baseline labels to the shared namespace template (kubernetes/components/common/namespace.yaml) so every Flux-managed app namespace gets non-enforcing pod-security visibility; no enforce label added. Also disables Nextcloud's default ServiceAccount token automount via a postRenderer patch on the Deployment, since the upstream chart exposes no automountServiceAccountToken value and Nextcloud is the only internet-exposed app still auto-mounting it.

Verification: confirmed kopiur's privileged-movers component only patches a namespace annotation (not enforce), so it won't conflict with the new warn/audit labels — verified via `kustomize build --enable-helm kubernetes/apps/default`, which renders the default namespace with both labels plus the kopiur annotation intact. Confirmed via `helm template` that the release name `nextcloud` produces a Deployment named `nextcloud`, matching the postRenderer patch target. After merge, watch pod-security audit/warn events across namespaces for any baseline violations worth following up on (none expected, enforce is not set).