### PR TITLE
fix(talos): add DNS fallback and raise apiserver memory request

### DIFF
--- a/talos/patches/controller/cluster.yaml
+++ b/talos/patches/controller/cluster.yaml
@@ -6,6 +6,9 @@ cluster:
     extraArgs:
       # https://kubernetes.io/docs/tasks/extend-kubernetes/configure-aggregation-layer/
       enable-aggregator-routing: true
+    resources:
+      requests:
+        memory: 2Gi # observed usage 2.3-2.8Gi vs prior 512Mi request; 07-02 OOM-cascade
   controllerManager:
     extraArgs:
       bind-address: 0.0.0.0

--- a/talos/patches/global/machine-network.yaml
+++ b/talos/patches/global/machine-network.yaml
@@ -2,6 +2,7 @@ machine:
   network:
     nameservers:
       - 192.168.0.1 # OPNsense Unbound
+      - 9.9.9.9 # fallback; Unbound stalls intermittently (CoreDNS p99 1.26s). No split-horizon resolution during router outages.
   features:
     hostDNS:
       enabled: true


### PR DESCRIPTION
Adds 9.9.9.9 as a second nameserver alongside the OPNsense Unbound resolver (192.168.0.1), which intermittently stalls and drives CoreDNS p99 to 1.26s and crashloops external-dns/cloudflared. Also raises `cluster.apiServer.resources.requests.memory` from the Talos-default 512Mi to 2Gi, since the static pod actually uses 2.3-2.8Gi and the gap is what let the 07-02 OOM-cascade recur. Note the fallback resolver has no split-horizon visibility, so internal-only names will fail to resolve via it during a router/Unbound outage.

These are Talos machine-config patches, not app manifests — Flux does not apply them. After merge, run `mise exec -- task talos:generate-config` to render the change with talhelper, then `mise exec -- task talos:apply-node IP=<node-ip>` per node (control-1/2/3) to push it live, per `talos/AGENTS.md`.

Verification: validated both patches parse and merge correctly via `talhelper genconfig --dry-run` against the live talconfig — confirmed the rendered machine config carries both nameservers on all three nodes and `apiServer.resources.requests.memory: 2Gi` on the generated static pod config. Not applied to any live node.