### PR TITLE
feat(kube-system): add cilium network segmentation policies

### DIFF
--- a/kubernetes/apps/kube-system/kustomization.yaml
+++ b/kubernetes/apps/kube-system/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
   - ./descheduler/ks.yaml
   - ./generic-device-plugin/ks.yaml
   - ./metrics-server/ks.yaml
+  - ./network-policies/ks.yaml
   - ./reloader/ks.yaml
   - ./snapshot-controller/ks.yaml
   - ./spegel/ks.yaml

--- a/kubernetes/apps/kube-system/network-policies/app/database-ingress.yaml
+++ b/kubernetes/apps/kube-system/network-policies/app/database-ingress.yaml
@@ -1,0 +1,32 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: database-ingress-allowlist
+  namespace: database
+spec:
+  # endpointSelector {} => default-deny ingress for every pod in the namespace
+  # (postgres, poolers, dragonfly, cnpg + dragonfly operators). Egress stays
+  # default-allow (backups to NFS/S3, operator->apiserver keep working).
+  endpointSelector: {}
+  ingress:
+    # Namespaces that actually consume postgres/pgbouncer/dragonfly, discovered
+    # from cnpg databases/ CRs + dragonfly host refs. observability = vmagent
+    # scraping the exporters; database = intra-ns (operator, poolers, replicas).
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: ai
+        - matchLabels:
+            io.kubernetes.pod.namespace: default
+        - matchLabels:
+            io.kubernetes.pod.namespace: media
+        - matchLabels:
+            io.kubernetes.pod.namespace: observability
+        - matchLabels:
+            io.kubernetes.pod.namespace: security
+        - matchLabels:
+            io.kubernetes.pod.namespace: database
+    # cnpg serves validating/mutating webhooks the apiserver must reach.
+    - fromEntities:
+        - kube-apiserver

--- a/kubernetes/apps/kube-system/network-policies/app/deny-apiserver-egress.yaml
+++ b/kubernetes/apps/kube-system/network-policies/app/deny-apiserver-egress.yaml
@@ -1,0 +1,58 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/cilium.io/ciliumnetworkpolicy_v2.json
+# Internet-exposed app namespaces must not reach the kube-apiserver. enableDefaultDeny
+# egress:false keeps this a pure deny overlay — DNS/internet/cluster egress stay
+# default-allow. kopiur movers (managed-by=kopiur) legitimately need the apiserver, so
+# they are excluded via NotIn (also matches label-absent app pods => they ARE denied).
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: deny-kube-apiserver-egress
+  namespace: media
+spec:
+  endpointSelector:
+    matchExpressions:
+      - key: app.kubernetes.io/managed-by
+        operator: NotIn
+        values: [kopiur]
+  enableDefaultDeny:
+    egress: false
+  egressDeny:
+    - toEntities:
+        - kube-apiserver
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: deny-kube-apiserver-egress
+  namespace: default
+spec:
+  endpointSelector:
+    matchExpressions:
+      - key: app.kubernetes.io/managed-by
+        operator: NotIn
+        values: [kopiur]
+  enableDefaultDeny:
+    egress: false
+  egressDeny:
+    - toEntities:
+        - kube-apiserver
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: deny-kube-apiserver-egress
+  namespace: web3
+spec:
+  endpointSelector:
+    matchExpressions:
+      - key: app.kubernetes.io/managed-by
+        operator: NotIn
+        values: [kopiur]
+  enableDefaultDeny:
+    egress: false
+  egressDeny:
+    - toEntities:
+        - kube-apiserver

--- a/kubernetes/apps/kube-system/network-policies/app/kustomization.yaml
+++ b/kubernetes/apps/kube-system/network-policies/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# No namespace transformer: each policy declares its own metadata.namespace.
+resources:
+  - database-ingress.yaml
+  - deny-apiserver-egress.yaml

--- a/kubernetes/apps/kube-system/network-policies/ks.yaml
+++ b/kubernetes/apps/kube-system/network-policies/ks.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: network-policies
+  namespace: &namespace kube-system
+spec:
+  interval: 1h
+  # No targetNamespace: policies fan out to database/media/default/web3 by their
+  # own metadata.namespace.
+  path: ./kubernetes/apps/kube-system/network-policies/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false


### PR DESCRIPTION
First network policies on a previously flat pod network (zero policies existed cluster-wide; Cilium `enable-policy: default`, so unselected pods stay default-allow). Two static, maintenance-free CiliumNetworkPolicies wired via `kube-system/network-policies`.

## Policy 1 — `database-ingress-allowlist` (namespace: database)
`endpointSelector: {}` puts every database pod (postgres, pgbouncer poolers, dragonfly, cnpg + dragonfly operators) into **default-deny ingress**. Allowed ingress:
- **From namespaces** `ai`, `default`, `media`, `observability`, `security`, `database` — the only postgres/pgbouncer/dragonfly consumers (derived from the cnpg `databases/` CRs + dragonfly host refs). `observability` covers vmagent scraping the exporters; `database` covers intra-ns operator/pooler/replica traffic.
- **From entity `kube-apiserver`** — cnpg serves validating/mutating webhooks the apiserver must reach.
- Kubelet health probes keep working via Cilium `allow-localhost: auto` (host-firewall is off); egress from DB pods is untouched (only ingress rules present), so backups to NFS/S3 and operator→apiserver are unaffected.

**Denies:** ingress from any other namespace (kube-system, network, kopiur-system, actions-runner, cert-manager, rook-ceph, web3, ai-non-consumers, etc.).

## Policy 2 — `deny-kube-apiserver-egress` (namespaces: media, default, web3)
An `egressDeny` to entity `kube-apiserver` on the internet-exposed app namespaces, with `enableDefaultDeny.egress: false` so it is a **pure deny overlay** — DNS, internet, and all other cluster egress remain default-allow. `endpointSelector` uses `matchExpressions: app.kubernetes.io/managed-by NotIn [kopiur]`, which also matches label-absent app pods (so they ARE denied) while excluding kopiur mover pods, which legitimately need the apiserver (`kopiur-mover` SA confirmed present in media/default; web3 has none). Audited running pods in all three namespaces: every workload is an application pod with no apiserver need.

**Denies:** kube-apiserver egress from all app pods in media/default/web3. **Allows:** everything else, plus full egress for kopiur movers.

## Verification
- `kustomize build` on the app dir and parent `kube-system` both succeed; namespaces render correctly (no namespace-transformer clobber — ks.yaml intentionally omits `targetNamespace`).
- `kubectl apply --dry-run=server` accepts all 4 objects against the deployed Cilium CRD (schema 1.32.7): `enableDefaultDeny`, `egressDeny.toEntities: kube-apiserver`, and `NotIn` all valid.
- Confirmed `cilium-config`: `enable-policy: default`, `enable-host-firewall: false`.

**Post-merge checks:** after Flux applies, watch for connection resets on DB consumers (`hubble observe --namespace database --verdict DROPPED`) and confirm kopiur backup/restore jobs in media/default still reach the apiserver. If a consumer namespace was missed, add one `matchLabels: io.kubernetes.pod.namespace` entry to policy 1.

## Rollback
Delete the two policy files (`network-policies/app/database-ingress.yaml`, `deny-apiserver-egress.yaml`) — or remove `./network-policies/ks.yaml` from `kube-system/kustomization.yaml` to drop the whole app; Flux prunes both.