### PR TITLE
fix(kopiur): give movers a resource floor, out of BestEffort QoS

### DIFF
--- a/kubernetes/apps/kopiur-system/kopiur/repository/clusterrepository.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/repository/clusterrepository.yaml
@@ -45,5 +45,12 @@ spec:
       securityContext:
         runAsUser: 568
         runAsGroup: 568
+  # Movers ran BestEffort (no resources) — Talos OOM killer's first victims
+  # under node memory pressure (bootstrap/mover exit 137, 07-20 outage).
+  moverDefaults:
+    resources:
+      requests:
+        cpu: 50m
+        memory: 128Mi
   scheduleDefaults:
     timezone: ${TIMEZONE}


### PR DESCRIPTION
Bootstrap/snapshot/restore/maintenance movers ran with no resources set, so they got BestEffort QoS — the kubelet OOM killer's first targets under node memory pressure. During the 07-20 outage, bootstrap/mover pods were killed (exit 137) within seconds of node memory pressure.

Sets `moverDefaults.resources.requests` (50m/128Mi) on the ClusterRepository, which the CRD documents as inherited by every mover the repository spawns (bootstrap, snapshot, restore, maintenance) — one change covers all mover types rather than patching each SnapshotPolicy. No limits set, matching the pattern used elsewhere for movers of variable/unbounded working-set size. No per-app mover resource overrides exist in the repo today, so nothing is clobbered.

Verification: `kustomize build --enable-helm kubernetes/apps/kopiur-system/kopiur/repository/` renders the ClusterRepository with `moverDefaults.resources.requests` present and unchanged otherwise. After merge, confirm a mover pod (e.g. next maintenance run) actually shows Burstable QoS (`kubectl get pod <mover> -o jsonpath='{.status.qosClass}'`) and that request values aren't so low they get immediately throttled/OOM on real data volumes.