### PR TITLE
fix(cnpg): extend pooler eviction protection and spread to ro and session

### DIFF
--- a/kubernetes/apps/database/cloudnative-pg/cluster/pooler-ro.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/pooler-ro.yaml
@@ -10,6 +10,26 @@ spec:
     name: postgres16
   instances: 2
   type: ro
+  # Same protections as pgbouncer-rw: out of BestEffort (Talos OOM controller
+  # kills request-less pods first) and spread across nodes.
+  template:
+    spec:
+      containers:
+        - name: pgbouncer
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              cpu: "1"
+              memory: 256Mi
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              cnpg.io/poolerName: pgbouncer-ro
   pgbouncer:
     poolMode: transaction
     parameters:

--- a/kubernetes/apps/database/cloudnative-pg/cluster/pooler-session.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/pooler-session.yaml
@@ -10,6 +10,26 @@ spec:
     name: postgres16
   instances: 2
   type: rw
+  # Same protections as pgbouncer-rw: out of BestEffort (Talos OOM controller
+  # kills request-less pods first) and spread across nodes.
+  template:
+    spec:
+      containers:
+        - name: pgbouncer
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              cpu: "1"
+              memory: 256Mi
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              cnpg.io/poolerName: pgbouncer-session
   pgbouncer:
     poolMode: session
     # Per-DB server cap through this deployment ≈ instances × max_db_connections below.


### PR DESCRIPTION
Follow-up to #4040 and #4066, which covered only `pgbouncer-rw`: `pgbouncer-ro` and `pgbouncer-session` were still BestEffort with no topology spread — verified via the manifests (no `template` block at all) and consistent with the live OOM-controller kills observed on both bare-metal nodes on 07-20. This applies the identical protections: 50m/128Mi requests + 1/256Mi limits (out of BestEffort) and a soft hostname spread with each pooler's own `cnpg.io/poolerName` selector.

Note on the anchor idea: the three Poolers live in separate YAML documents/files, and YAML anchors are document-scoped — they can't deduplicate across them (and the labelSelector differs per pooler), so the blocks are explicit copies by necessity.

Verification: `kustomize build --enable-helm` clean on the cluster dir.