### PR TITLE
fix(ai): move both embedders to cpu to stop the igpu gtt leak

### DIFF
--- a/kubernetes/apps/ai/llmkube/models/qwen3-embedding.yaml
+++ b/kubernetes/apps/ai/llmkube/models/qwen3-embedding.yaml
@@ -16,17 +16,12 @@ spec:
   source: https://huggingface.co/Qwen/Qwen3-Embedding-0.6B-GGUF/resolve/370f27d7550e0def9b39c1f16d3fbaa13aa67728/Qwen3-Embedding-0.6B-Q8_0.gguf
   quantization: Q8_0
   refreshPolicy: OnChange
+  # CPU on purpose: the ggml-Vulkan embedding path leaks pinned GTT (2.1GiB
+  # within 16min measured 2026-07-20, wedged control-2 twice; upstream
+  # ggml-org/llama.cpp#12531/#15054 open). CPU is comparable to the contended
+  # iGPU for this cache-fronted 0.6B model and the memory is cgroup-visible.
   hardware:
-    accelerator: vulkan
-    gpu:
-      enabled: true
-      count: 1
-      vendor: amd
-      runtime: vulkan
-      layers: -1
-      # Slot counts live at the device plugin (kube-system/generic-device-plugin);
-      # nodeSelector below pins this to the iGPU.
-      resourceName: squat.ai/dri
+    accelerator: cpu
 ---
 apiVersion: inference.llmkube.dev/v1alpha1
 kind: InferenceService
@@ -35,49 +30,25 @@ metadata:
 spec:
   modelRef: qwen3-embedding
   mode: embedding
-  image: ghcr.io/ggml-org/llama.cpp:server-vulkan@sha256:5672ed099865337417b3f2d0fd360839740168efb96acf44c80770b7808d896c
-  # Two slots are the Vulkan-safe floor; more interleaving did not improve
-  # throughput on this compute-bound iGPU. VMCP has its own embedder now.
-  parallelSlots: 2 # Vulkan warmup hangs at parallel=1 (llama.cpp #24307)
+  image: ghcr.io/ggml-org/llama.cpp:server@sha256:e10504c7f5c5bacece7e7e5957760eee53868642d853fe5ecfe8611065929a24
+  # Two slots so find_tool queries can flow past an in-flight session batch.
+  parallelSlots: 2
   contextSize: 8192
-  # Raise the logical batch ceiling without increasing the 2048-token Vulkan
-  # micro-batch; benchmark against the prior implicit 2048 default.
   batchSize: 4096
   uBatchSize: 2048
   extraArgs:
     - "--alias"
     - "qwen3-embedding" # served model name memini sends in /v1/embeddings
+    - "--threads"
+    - "4" # match the cpu reservation; default is nproc (12) on a shared node
 
-  # Pin to the iGPU node; without this the scheduler could place it on the dGPU
-  # node (which also advertises squat.ai/dri) and steal a dGPU slot from sglang.
-  nodeSelector:
-    amd.com/igpu: "true"
-
-  # Mutual half of qwen35-2b's anti-affinity (see qwen35-2b.yaml). Anti-affinity
-  # is checked only at the moving pod's scheduling time, so the rule must exist
-  # on both sides: 2026-07-03 a reshuffle rolled this pod onto qwen35-2b's node,
-  # filling its 2 dri slots and re-stranding vmcp-embedding (which hard-follows
-  # this pod) in Pending.
-  affinity:
-    podAntiAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution:
-        - labelSelector:
-            matchLabels:
-              app: qwen35-2b
-          topologyKey: kubernetes.io/hostname
-
-  # Render/video host groups for /dev/dri — the documented Vulkan-runtime path.
-  podSecurityContext:
-    runAsUser: 0
-    runAsGroup: 0
-    supplementalGroups:
-      - 44
-      - 226
+  # No nodeSelector/affinity: CPU-only now, no iGPU slot or /dev/dri access
+  # needed — also retires the qwen35-2b anti-affinity + vmcp co-location dance
+  # (the 2026-07-03 Pending-deadlock class).
 
   resources:
-    cpu: "500m" # inference is on the iGPU; CPU only tokenises/schedules
-    # Current 84746bcc6 revision peaked at ~3.1 GiB working set over 7 days;
-    # reserve 4 GiB so the scheduler accounts for the model's UMA usage.
-    memory: 4Gi
+    cpu: "4"
+    # 639MB Q8_0 weights + ctx/compute buffers as ordinary RSS now
+    memory: 2Gi
   endpoint:
     path: /v1/embeddings

--- a/kubernetes/apps/ai/llmkube/models/qwen35-2b.yaml
+++ b/kubernetes/apps/ai/llmkube/models/qwen35-2b.yaml
@@ -40,24 +40,10 @@ spec:
     - "--alias"
     - "qwen3.5-2b" # served model name litellm sends in /v1/chat/completions
 
-  # Both iGPU nodes advertise 2 squat.ai/dri slots; the embedders pair up on
-  # qwen3-embedding's node (via podAffinity there), leaving the other iGPU
-  # node's slots for this model — amd.com/igpu narrows it to those two nodes.
+  # Only iGPU nodes; the embedders are CPU-only now, so this model has both
+  # iGPU nodes' dri slots to itself and needs no anti-affinity against them.
   nodeSelector:
     amd.com/igpu: "true"
-
-  # Keep off the embedder pair's node. vmcp-embedding hard-requires
-  # qwen3-embedding's node, so if this model shares it (happened 2026-07-03:
-  # a reshuffle put both on control-2), it takes the second dri slot and
-  # vmcp-embedding goes Pending — hanging vmcp-unified's tools/list on the
-  # optimizer's 120s embed timeout.
-  affinity:
-    podAntiAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution:
-        - labelSelector:
-            matchLabels:
-              app: qwen3-embedding
-          topologyKey: kubernetes.io/hostname
 
   # Render/video host groups for /dev/dri — the documented Vulkan-runtime path.
   podSecurityContext:

--- a/kubernetes/apps/ai/llmkube/models/vmcp-embedding.yaml
+++ b/kubernetes/apps/ai/llmkube/models/vmcp-embedding.yaml
@@ -28,17 +28,11 @@ spec:
   # rolled-back bge-small gguf after the switch to harrier — llmkube only
   # flags SourceDrifted, it never re-downloads under the default IfNotPresent).
   refreshPolicy: OnChange
+  # CPU on purpose: the ggml-Vulkan embedding path leaks pinned GTT (this
+  # 270M model held a 2GiB compute buffer after 5h, measured 2026-07-20;
+  # see qwen3-embedding.yaml for the full rationale).
   hardware:
-    accelerator: vulkan
-    gpu:
-      enabled: true
-      count: 1
-      vendor: amd
-      runtime: vulkan
-      layers: -1
-      # iGPU slot via squat/generic-device-plugin (count: 2 on iGPU nodes);
-      # nodeSelector below keeps this off the dGPU node.
-      resourceName: squat.ai/dri
+    accelerator: cpu
 ---
 apiVersion: inference.llmkube.dev/v1alpha1
 kind: InferenceService
@@ -47,12 +41,8 @@ metadata:
 spec:
   modelRef: vmcp-embedding
   mode: embedding
-  image: ghcr.io/ggml-org/llama.cpp:server-vulkan@sha256:5672ed099865337417b3f2d0fd360839740168efb96acf44c80770b7808d896c
-  # 2 slots (the Vulkan floor — warmup hangs at parallel=1, llama.cpp #24307):
-  # the iGPU is compute-bound, so extra slots add interleave, not throughput
-  # (measured on qwen3-embedding: 4 slots didn't move latency, Q8_0 did). Two
-  # slots let find_tool queries flow past an in-flight session-build batch while
-  # halving the UMA buffer allocation on the shared iGPU.
+  image: ghcr.io/ggml-org/llama.cpp:server@sha256:e10504c7f5c5bacece7e7e5957760eee53868642d853fe5ecfe8611065929a24
+  # Two slots so find_tool queries can flow past an in-flight session batch.
   parallelSlots: 2
   # 8192 tokens/slot — the real batch's largest single tool description is
   # 2155 tokens under harrier's Gemma3 tokenizer (~1.85x qwen3's count for the
@@ -65,38 +55,18 @@ spec:
   extraArgs:
     - "--alias"
     - "vmcp-embedding" # served model name litellm/vmcp-unified send in /v1/embeddings
+    - "--threads"
+    - "2" # match the cpu reservation; default is nproc (12) on a shared node
 
-  # Defense-in-depth: keeps the iGPU pin even if qwen3-embedding's own pin is
-  # ever loosened (the podAffinity below would otherwise follow it anywhere).
-  nodeSelector:
-    amd.com/igpu: "true"
-
-  # Render/video host groups for /dev/dri — the documented Vulkan-runtime path.
-  podSecurityContext:
-    runAsUser: 0
-    runAsGroup: 0
-    supplementalGroups:
-      - 44
-      - 226
-
-  # Co-locate with qwen3-embedding's pod (same node, whichever iGPU node that
-  # currently is — qwen3-embedding itself isn't hard-pinned to one, see
-  # qwen3-embedding.yaml): the two embedders deliberately share that node's iGPU
-  # (one squat.ai/dri slot each of the node's 2), and same-node networking for
-  # litellm/unified comes along for free.
-  affinity:
-    podAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution:
-        - labelSelector:
-            matchLabels:
-              app: qwen3-embedding
-          topologyKey: kubernetes.io/hostname
+  # No nodeSelector/affinity: CPU-only now — retires the hard podAffinity on
+  # qwen3-embedding that caused the post-eviction Pending deadlock class
+  # (vmcp-embedding stuck → litellm 500 → Hermes tool-less).
 
   # No probeOverrides: the operator's llamacpp defaults already probe /health
-  # with a more forgiving startup window (180x10s). GPU allocation comes from
-  # Model.hardware.gpu.count (resources.gpu/gpuMemory are dead fields at 0.8.26).
+  # with a more forgiving startup window (180x10s).
   resources:
-    cpu: "500m" # inference is on the iGPU; CPU only tokenises/schedules
-    memory: 512Mi # 292MB Q8_0 weights via UMA; measured 436Mi working set
+    cpu: "2"
+    # 292MB Q8_0 weights + 16K-ctx compute buffers as ordinary RSS now
+    memory: 1Gi
   endpoint:
     path: /v1/embeddings


### PR DESCRIPTION
The better solution for the GTT leak that #4073's nightly recycle mitigates. Root cause (debugfs-measured on control-2): ggml-Vulkan's **embedding** path pins compute buffers it never frees — qwen3-embedding held 2.1GiB of GTT **16 minutes** after start, vmcp-embedding 2.4GiB after 5h (a single 2GiB buffer for a 270M model), while the generative qwen35-2b on the same image/iGPU holds 32MiB after 7h. The recycle CronJob also only targets qwen3-embedding — vmcp-embedding leaks identically and can wedge control-2 between recycles on its own. Upstream has no fix to bump to (we're on the newest build; ggml-org/llama.cpp#12531/#15054 open).

**Change**: `Model.spec.hardware.accelerator: cpu` (first-class in the llmkube CRD) + the CPU server image for both embedders. This removes the Vulkan/GTT path entirely; embedder memory becomes ordinary cgroup-accounted RSS (honest requests: 2Gi/4cpu and 1Gi/2cpu, --threads matched). It also deletes the whole placement dance — the iGPU nodeSelectors, the vmcp→qwen3 hard podAffinity (the documented post-eviction Pending-deadlock class that took Hermes tool-less), qwen35-2b's mutual anti-affinity, and the `runAsUser: 0` + /dev/dri groups (embedders can run non-root under operator defaults). qwen35-2b now has both iGPU nodes' dri slots to itself.

**Perf expectation**: both models are tiny and dragonfly-cached (#3646) — only cache misses hit the servers; 12 Zen3+ threads are comparable to the *contended* iGPU (19–52s under 3× concurrency historically). Worst case is slower cold lookups, never a node wedge.

**Kept for now**: the nightly qwen3-embedding recycle CronJob and the GTT alert from #4073 — the alert becomes the canary that nothing silently reverts to Vulkan. Follow-up after a clean multi-day soak: delete the CronJob + its RBAC.

Verification: kustomize build + YAML parse clean; CPU image digest resolved from ghcr (`server` tag, same Renovate pin format as the vulkan one). Post-merge: watch first find_tool/session-build latencies and `node_drm_memory_gtt_used_bytes` on control-2 dropping to ~0 after the old pods terminate.