### PR TITLE
feat(security): enable chart-native network policies where charts support them

### DIFF
--- a/kubernetes/apps/cert-manager/cert-manager/app/helmrelease.yaml
+++ b/kubernetes/apps/cert-manager/cert-manager/app/helmrelease.yaml
@@ -17,7 +17,14 @@ spec:
     prometheus:
       servicemonitor:
         enabled: true
+    networkPolicy:
+      enabled: true
+    cainjector:
+      networkPolicy:
+        enabled: true
     webhook:
       replicaCount: 2
       podDisruptionBudget:
+        enabled: true
+      networkPolicy:
         enabled: true

--- a/kubernetes/apps/observability/kube-state-metrics/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kube-state-metrics/app/helmrelease.yaml
@@ -11,6 +11,11 @@ spec:
   interval: 1h
   values:
     fullnameOverride: kube-state-metrics
+    # KSM holds cluster-wide list/watch RBAC; lock it to apiserver egress +
+    # metrics-port ingress
+    networkPolicy:
+      enabled: true
+      flavor: cilium
     metricLabelsAllowlist:
       - pods=[app.kubernetes.io/component]
     prometheus:


### PR DESCRIPTION
Follow-up to #4072 answering "can we enable network policies natively in charts?" — surveyed every pinned chart in the repo. Only two have a native knob, both enabled here; both verified rendering via `helm template` against the pinned versions:

- **kube-state-metrics 7.8.1**: `networkPolicy.enabled + flavor: cilium` → a real CiliumNetworkPolicy locking a pod that holds cluster-wide list/watch RBAC to kube-apiserver egress and metrics-port ingress only.
- **cert-manager v1.21.0**: controller + webhook + cainjector `networkPolicy.enabled` → upstream-scoped vanilla policies (metrics/healthz ingress; 80/443 + DNS egress, which covers apiserver via the kubernetes ClusterIP).

Not done, deliberately: app-template's `networkpolicies` block (renders vanilla-only — cannot express the kube-apiserver entity or deny rules from #4072, and per-app allowlists across ~20 media apps is the maintenance burden #4072 was designed to avoid). No other pinned chart (cnpg, dragonfly-operator, rook-ceph, coredns, external-dns, envoy-gateway, crowdsec, grafana-operator) exposes a netpol value.

No interaction risk with #4072: different namespaces entirely, and Cilium deny rules always win over allows regardless.

Verification: `helm template` on both pinned charts with these exact values renders the policies; kustomization YAML parses. Post-merge: confirm cert-manager still completes an ACME order (egress 443/DNS is allowed by the chart's own policy) and KSM metrics keep scraping.