### PR TITLE
fix(sglang): pin baked runtime environment

### DIFF
--- a/docs/llm-hosting/sglang-oci-cutover.md
+++ b/docs/llm-hosting/sglang-oci-cutover.md
@@ -2,7 +2,8 @@
 
 Move sglang from the **runtime-from-PVC workaround** (engine built out-of-band onto the
 `sglang` PVC by `scripts/sglang-env-rebuild.sh`, image = bare ROCm base) to a **git-reproducible
-baked image** `ghcr.io/tanguille/sglang-rdna4`. The PVC keeps only the model + Triton cache.
+baked image** `ghcr.io/tanguille/sglang-rdna4`. The PVC keeps `/cache/hf` and
+`/cache/sglang/triton`; the old runtime directories are retired.
 
 **Why now:** the workaround existed because the cluster couldn't pull never-cached images
 (Spegel upstream fall-through was broken). Spegel is healthy again, so the README's documented
@@ -53,12 +54,12 @@ at image-build time — covered by digest-pinned rollback and the Stage 2 valida
    a Recreate rollout (no old pod kept warm), so on failure go straight to **Rollback** below —
    serving is down only for the failed-boot window either way.
 5. **Validate** — `/health` up, a `qwen-3.6` completion with tools+thinking, PPL/needle spot-check, decode tok/s parity with the PVC baseline (≈16 single / ≈99 @conc24).
-6. **Retire** — drop the "Runtime-from-PVC" section from the app README; keep `sglang-env-rebuild.sh`
-   as the documented PVC-rebuild fallback (the Dockerfile is now primary). The PVC's
-   `conda/` + `repo-v0514/` are now dead weight but harmless — clean up later.
+6. **Retire** — the PVC's `/cache/sglang/conda` and `/cache/sglang/repo-v0514` are retired and may
+   be deleted separately. Preserve `/cache/hf` and `/cache/sglang/triton`. Keep
+   `app/scripts/sglang-env-rebuild.sh` as the emergency PVC-environment rebuild path.
 
-**Rollback:** revert the Stage 2 HelmRelease commit → Flux redeploys the ROCm-base + PVC-runtime
-pod (the env is still on the PVC). No rebuild needed.
+**Rollback:** after the retired runtime directories are deleted, rollback requires the baked OCI
+image or rebuilding the emergency PVC environment with `app/scripts/sglang-env-rebuild.sh`.
 
 ## Process Instructions
 

--- a/kubernetes/apps/ai/sglang/README.md
+++ b/kubernetes/apps/ai/sglang/README.md
@@ -40,13 +40,11 @@ into the image** `ghcr.io/tanguille/sglang-rdna4`. The build, the pinned fork pa
 pin/rollback mechanics live in
 [`docker/sglang-rdna4/README.md`](../../../../docker/sglang-rdna4/README.md).
 
-The `sglang` PVC now carries only runtime data: the model (`/cache/hf`,
-`mattbucci/Qwen3.6-27B-AWQ`) and the persisted Triton JIT cache (`/cache/sglang/triton`). It still
-holds the pre-cutover conda env + fork source (`/cache/sglang/conda`, `/cache/sglang/repo-v0514`) as
-the **rollback path** — revert the HelmRelease to the ROCm-base image and it runs from the PVC again
-(rebuildable via [`scripts/sglang-env-rebuild.sh`](app/scripts/sglang-env-rebuild.sh) if lost). Those
-legacy dirs are dead weight once the baked image is trusted; retirement is tracked in
-`docs/llm-hosting/sglang-oci-cutover.md` step 6.
+The `sglang` PVC carries the model (`/cache/hf`, `mattbucci/Qwen3.6-27B-AWQ`) and the persisted
+Triton JIT cache (`/cache/sglang/triton`). The pre-cutover conda env + fork source
+(`/cache/sglang/conda`, `/cache/sglang/repo-v0514`) are retired legacy data and must be deleted
+separately; they are no longer a runtime or rollback path. The rebuild script remains only as an
+emergency fallback: [`scripts/sglang-env-rebuild.sh`](app/scripts/sglang-env-rebuild.sh).
 
 ## Performance & bottleneck
 

--- a/kubernetes/apps/ai/sglang/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/sglang/app/helmrelease.yaml
@@ -104,6 +104,9 @@ spec:
               TZ: ${TIMEZONE}
               # --- launch.sh / common.sh overrides (most gfx1201 env is set by common.sh;
               # --- CONDA_BASE/ENV_NAME/REPO_DIR come baked from the image) ---
+              # Explicitly pin the baked OCI environment so stale Deployment env cannot select
+              # the retired PVC runtime at /cache/sglang/conda.
+              CONDA_BASE: /opt/conda
               TP: "1" # single R9700; the fork defaults to 2 (its dual-card box)
               MODEL: mattbucci/Qwen3.6-27B-AWQ # resolved offline from HF_HOME cache
               # Pin every device-visibility var to card 0 (common.sh defaults them to "0,1").
@@ -247,8 +250,8 @@ spec:
 
     persistence:
       # The `sglang` PVC carries the Qwen3.6 AWQ model (/cache/hf), the persisted Triton JIT cache,
-      # and the legacy runtime-from-PVC conda env + fork source — kept as the rollback path for the
-      # baked image (retirement owned by docs/llm-hosting/sglang-oci-cutover.md step 6).
+      # and the retired runtime-from-PVC conda env + fork source; delete those legacy directories
+      # separately once no longer needed.
       cache:
         enabled: true
         existingClaim: sglang

--- a/kubernetes/apps/ai/sglang/app/pvc.yaml
+++ b/kubernetes/apps/ai/sglang/app/pvc.yaml
@@ -7,9 +7,9 @@ metadata:
 spec:
   accessModes: ["ReadWriteOnce"]
   storageClassName: openebs-hostpath
-  # Model (Qwen3.6-27B-AWQ), persisted Triton JIT cache, and the legacy runtime-from-PVC
-  # conda env + fork source (~50 GB used). The env is rollback-only since the baked-image
-  # cutover (see README); rebuild via scripts/sglang-env-rebuild.sh if lost.
+  # Model (Qwen3.6-27B-AWQ), persisted Triton JIT cache, and retired legacy runtime-from-PVC
+  # conda env + fork source (~50 GB used). Delete the legacy directories separately; rebuild via
+  # scripts/sglang-env-rebuild.sh only as an emergency fallback.
   resources:
     requests:
       storage: 80Gi


### PR DESCRIPTION
## Summary
- explicitly set `CONDA_BASE=/opt/conda` so SGLang cannot select the retired PVC environment
- document the PVC runtime directories as retired and preserve only model/Triton data
- correct OCI rollback documentation after legacy runtime cleanup

## Validation
- git diff --check
- bash .agents/skills/pr-review/scripts/validate-pr.sh (render tools unavailable locally; repository-wide warnings only)
- focused architecture review approved the baked-environment pin

## Follow-up
After merge and rollout, verify `/get_server_info` reports the baked package and then delete only `/cache/sglang/conda` and `/cache/sglang/repo-v0514`; preserve `/cache/hf` and `/cache/sglang/triton`.