### PR TITLE
fix(ci): grant runner os:operator for talosctl image pull

### DIFF
--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/cluster/rbac.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/cluster/rbac.yaml
@@ -9,5 +9,5 @@ kind: ServiceAccount
 metadata:
   name: cluster-runner
 spec:
-  # Only use is 'talosctl image pull' in image-pull.yaml.
-  roles: ["os:reader"]
+  # Only use is 'talosctl image pull' in image-pull.yaml; ImagePull needs os:operator (not os:reader).
+  roles: ["os:operator"]


### PR DESCRIPTION
`os:reader` (set in #4063) lacks the ImagePull API. `/machine.MachineService/ImagePull` requires `os:admin` or `os:operator`, so every image-pull run has failed with `PermissionDenied: not authorized` (e.g. #4084). `os:operator` is the minimal role that includes ImagePull — restores image pre-pull without re-granting admin.