### PR TITLE
fix(ci): restore runner os:admin so talosctl image pull works

### DIFF
--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/cluster/rbac.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/cluster/rbac.yaml
@@ -9,5 +9,6 @@ kind: ServiceAccount
 metadata:
   name: cluster-runner
 spec:
-  # Only use is 'talosctl image pull' in image-pull.yaml; ImagePull needs os:operator (not os:reader).
-  roles: ["os:operator"]
+  # Only use is 'talosctl image pull'; ImagePull needs more than os:reader, and the
+  # kubernetesTalosAPIAccess allowlist (talos/patches) permits only os:admin/os:reader.
+  roles: ["os:admin"]


### PR DESCRIPTION
`os:operator` (#4088) is rejected by the Talos `kubernetesTalosAPIAccess` allowlist (`allowedRoles: [os:admin, os:reader]` in `talos/patches/controller/kubernetes-talos-api-access.yaml`), so the SA controller mints no talosconfig (`ErrRolesNotAllowed`) and image-pull stays broken. `os:admin` is the only allowlisted role that can pull images without a machine-config change. Fixes the image-pull failures on #4084/#4085/#4086 and #4073.