### PR TITLE
fix(gatus): correct probe backend port

### DIFF
--- a/kubernetes/apps/observability/gatus/app/httproute.yaml
+++ b/kubernetes/apps/observability/gatus/app/httproute.yaml
@@ -19,4 +19,4 @@ spec:
           method: GET
       backendRefs:
         - name: gatus
-          port: 80
+          port: 8080


### PR DESCRIPTION
## Summary
- route the Gatus external probe to the Service port exposed by Gatus

## Root cause
The HTTPRoute used port 80, but `Service/observability/gatus` exposes port 8080, causing Envoy to return HTTP 500.

## Validation
- [x] `git diff --check`
- [x] Focused review against live Service-port evidence
- [ ] Full rendered validation (blocked locally: mise, flate, and kustomize unavailable)