### PR TITLE
feat(observability): prevent iGPU GTT starvation wedges

### DIFF
--- a/kubernetes/apps/ai/llmkube/models/qwen3-embedding.yaml
+++ b/kubernetes/apps/ai/llmkube/models/qwen3-embedding.yaml
@@ -81,3 +81,88 @@ spec:
     memory: 4Gi
   endpoint:
     path: /v1/embeddings
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: embedder-recycle
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: embedder-recycle
+rules:
+  - apiGroups: [apps]
+    resources: [deployments]
+    resourceNames: [qwen3-embedding, vmcp-embedding]
+    verbs: [patch]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: embedder-recycle
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: embedder-recycle
+subjects:
+  - kind: ServiceAccount
+    name: embedder-recycle
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/batch/cronjob_v1.json
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: embedder-recycle
+spec:
+  # both embedders (qwen3-embedding + vmcp-embedding) leak pinned iGPU GTT memory
+  # cgroups cannot see (wedged control-2 twice); a nightly controlled rollout restart caps
+  # the accumulation. Embeddings are dragonfly-cached, so a restart costs one reload.
+  timeZone: ${TIMEZONE}
+  schedule: "30 4 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 1
+  startingDeadlineSeconds: 1800
+  jobTemplate:
+    spec:
+      activeDeadlineSeconds: 180
+      backoffLimit: 1
+      template:
+        spec:
+          serviceAccountName: embedder-recycle
+          restartPolicy: Never
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            runAsGroup: 65532
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: recycle
+              image: curlimages/curl:8.21.0@sha256:1ab04d023ece37e6ec991bf3306ad04e0ef0084e94a5c6b6563cfcb9563169db
+              command:
+                - sh
+                - -ec
+                - >-
+                  timestamp="$(date -u +%Y-%m-%dT%H:%M:%SZ)"; for deployment in
+                  qwen3-embedding vmcp-embedding; do curl -fsS --connect-timeout 10
+                  --max-time 30
+                  --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+                  -H "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)"
+                  -H "Content-Type: application/merge-patch+json" -X PATCH
+                  --data "{\"spec\":{\"template\":{\"metadata\":{\"annotations\":{\"kubectl.kubernetes.io/restartedAt\":\"$${timestamp}\"}}}}}"
+                  "https://kubernetes.default.svc/apis/apps/v1/namespaces/ai/deployments/$${deployment}"
+                  > /dev/null; done
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop: [ALL]
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 32Mi
+                limits:
+                  cpu: 100m
+                  memory: 32Mi

--- a/kubernetes/apps/observability/exporters/node-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/exporters/node-exporter/app/helmrelease.yaml
@@ -11,6 +11,10 @@ spec:
   interval: 1h
   values:
     fullnameOverride: *app
+    extraArgs:
+      # amdgpu GTT is pinned memory invisible to cgroups — the embedder leak
+      # that wedged control-2 twice is only observable through this collector
+      - --collector.drm
     prometheus:
       monitor:
         enabled: true

--- a/kubernetes/apps/observability/exporters/node-exporter/app/kustomization.yaml
+++ b/kubernetes/apps/observability/exporters/node-exporter/app/kustomization.yaml
@@ -5,3 +5,4 @@ kind: Kustomization
 resources:
   - helmrelease.yaml
   - ocirepository.yaml
+  - prometheusrule.yaml

--- a/kubernetes/apps/observability/exporters/node-exporter/app/prometheusrule.yaml
+++ b/kubernetes/apps/observability/exporters/node-exporter/app/prometheusrule.yaml
@@ -1,0 +1,59 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: node-exporter-rules
+spec:
+  groups:
+    - name: node-exporter.rules
+      rules:
+        - alert: NodeMemoryAvailableLow
+          # kubelet starved at ~444MB in the 2026-07-20 control-2 wedge; 2GiB gives
+          # runway to intervene regardless of what is eating the node
+          expr: |-
+            node_memory_MemAvailable_bytes{kubernetes_node!=""} < 2147483648
+          for: 10m
+          annotations:
+            summary: >-
+              {{ $labels.kubernetes_node }} has under 2GiB memory available —
+              kubelet starvation follows if this keeps falling
+          labels:
+            severity: critical
+        - alert: NodeGTTMemoryHigh
+          # pinned iGPU memory the OOM killer cannot reclaim; normal embedder
+          # footprint is 1-2GB, the control-2 wedge had 4.7GB
+          expr: |-
+            node_drm_memory_gtt_used_bytes{kubernetes_node=~"control-[23]"} > 4294967296
+          for: 15m
+          annotations:
+            summary: >-
+              {{ $labels.kubernetes_node }} has over 4GiB of pinned GTT GPU memory —
+              likely the embedder leak; recycle both qwen3-embedding and vmcp-embedding pods
+          labels:
+            severity: warning
+        - alert: NodeGTTTelemetryContract
+          # Alert separately for each expected control node so one missing target
+          # cannot make the telemetry contract look healthy for the other node.
+          expr: |-
+            (
+              node_drm_memory_gtt_size_bytes{kubernetes_node=~"control-[23]"} <= 0
+            )
+            or (
+              label_replace(vector(1), "kubernetes_node", "control-2", "", "")
+              unless on(kubernetes_node)
+              node_drm_memory_gtt_size_bytes{kubernetes_node="control-2"}
+            )
+            or (
+              label_replace(vector(1), "kubernetes_node", "control-3", "", "")
+              unless on(kubernetes_node)
+              node_drm_memory_gtt_size_bytes{kubernetes_node="control-3"}
+            )
+            or node_scrape_collector_success{collector="drm", kubernetes_node=~"control-[23]"} == 0
+          for: 10m
+          annotations:
+            summary: >-
+              GTT telemetry contract is unhealthy on {{ $labels.kubernetes_node }} —
+              verify node-exporter DRM collection and node metrics
+          labels:
+            severity: warning


### PR DESCRIPTION
## Summary

- recycle both Vulkan embedder Deployments nightly before pinned GTT growth can starve the node
- restrict the CronJob to patching exactly the two LLMKube-owned Deployments, with bounded request, job, and missed-schedule deadlines
- enable node-exporter DRM metrics and alert on high GTT use, missing GTT telemetry, and low node memory

## Why

The qwen3 and vmcp embedders accumulate driver-managed AMD iGPU GTT memory that cgroups cannot see. control-2 wedged twice after pinned GTT reached roughly 4.7 GiB; restarting the inference processes releases it. LLMKube currently has no maximum pod lifetime field, so this uses a least-privilege scheduled Deployment template patch as the mitigation.

Upstream tracking:
- defilantech/LLMKube#1173
- ggml-org/llama.cpp#5380

## Safety

- RBAC permits `patch` only on `qwen3-embedding` and `vmcp-embedding` Deployments
- Flux shell variables are escaped and LLMKube preserves `kubectl.kubernetes.io/restartedAt`
- curl requests time out after 30 seconds; Jobs after 180 seconds
- missed schedules expire after 30 minutes
- GTT alerts target only the iGPU nodes and separately detect either missing telemetry target

## Validation

- `git diff --check`
- YAML parse: 6 documents in the modified model manifest
- extracted CronJob shell: `sh -n`
- final independent review: clean
- repository validation script completed; local `mise`/`flate` and shellcheck binaries were unavailable, so rendered CI validation remains authoritative