### PR TITLE
chore(kubernetes): strip redundant CNPG ensure defaults, dead flux ks fields, stale comments

### DIFF
--- a/kubernetes/apps/database/cloudnative-pg/cluster/cluster.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/cluster.yaml
@@ -28,47 +28,38 @@ spec:
         passwordSecret:
           name: litellm-db
       - name: jellystat
-        ensure: present
         login: true
         passwordSecret:
           name: jellystat-db
       - name: radarr
-        ensure: present
         login: true
         passwordSecret:
           name: radarr-db
       - name: bazarr
-        ensure: present
         login: true
         passwordSecret:
           name: bazarr-db
       - name: sonarr
-        ensure: present
         login: true
         passwordSecret:
           name: sonarr-db
       - name: prowlarr
-        ensure: present
         login: true
         passwordSecret:
           name: prowlarr-db
       - name: memini
-        ensure: present
         login: true
         passwordSecret:
           name: memini-db
       - name: spoolman
-        ensure: present
         login: true
         passwordSecret:
           name: spoolman-db
       - name: gatus
-        ensure: present
         login: true
         passwordSecret:
           name: gatus-db
       - name: nextcloud
-        ensure: present
         login: true
         # Preserve the role's existing CREATEDB privilege; CNPG reconciles every
         # unspecified attribute to its default (NOCREATEDB) when adopting a role.
@@ -76,12 +67,10 @@ spec:
         passwordSecret:
           name: nextcloud-db
       - name: grafana
-        ensure: present
         login: true
         passwordSecret:
           name: grafana-db
       - name: crowdsec
-        ensure: present
         login: true
         passwordSecret:
           name: crowdsec-db

--- a/kubernetes/apps/database/cloudnative-pg/databases/bazarr.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/databases/bazarr.yaml
@@ -9,6 +9,5 @@ spec:
     name: postgres16
   name: bazarr
   owner: bazarr
-  ensure: present
   # Never drop the database if this CR is deleted/pruned — this is an adopted, live DB.
   databaseReclaimPolicy: retain

--- a/kubernetes/apps/database/cloudnative-pg/databases/crowdsec.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/databases/crowdsec.yaml
@@ -9,12 +9,10 @@ spec:
     name: postgres16
   name: crowdsec
   owner: crowdsec
-  ensure: present
   # Never drop the database if this CR is deleted/pruned — this is an adopted, live DB.
   databaseReclaimPolicy: retain
   # vector is the pgvector bundled in the cluster's vchord-scratch image — bump manually
   # when the image bumps; a wrong pin fails visibly via the Database CR going not-Ready.
   extensions:
     - name: vector
-      ensure: present
       version: "0.8.5"

--- a/kubernetes/apps/database/cloudnative-pg/databases/gatus.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/databases/gatus.yaml
@@ -9,6 +9,5 @@ spec:
     name: postgres16
   name: gatus
   owner: gatus
-  ensure: present
   # Never drop the database if this CR is deleted/pruned — this is an adopted, live DB.
   databaseReclaimPolicy: retain

--- a/kubernetes/apps/database/cloudnative-pg/databases/grafana.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/databases/grafana.yaml
@@ -9,6 +9,5 @@ spec:
     name: postgres16
   name: grafana
   owner: grafana
-  ensure: present
   # Never drop the database if this CR is deleted/pruned — this is an adopted, live DB.
   databaseReclaimPolicy: retain

--- a/kubernetes/apps/database/cloudnative-pg/databases/jellystat.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/databases/jellystat.yaml
@@ -9,6 +9,5 @@ spec:
     name: postgres16
   name: jfstat
   owner: jellystat
-  ensure: present
   # Never drop the database if this CR is deleted/pruned — this is an adopted, live DB.
   databaseReclaimPolicy: retain

--- a/kubernetes/apps/database/cloudnative-pg/databases/memini.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/databases/memini.yaml
@@ -9,7 +9,6 @@ spec:
     name: postgres16
   name: memini
   owner: memini
-  ensure: present
   # Never drop the database if this CR is deleted/pruned — this is an adopted, live DB.
   databaseReclaimPolicy: retain
   # Keep vchord and vector paired; Memini's live vchordrq indexes require both.
@@ -18,8 +17,6 @@ spec:
   # A wrong pin fails visibly: CNPG reports the Database CR not-Ready on ALTER EXTENSION.
   extensions:
     - name: vchord
-      ensure: present
       version: "1.1.1"
     - name: vector
-      ensure: present
       version: "0.8.5"

--- a/kubernetes/apps/database/cloudnative-pg/databases/nextcloud.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/databases/nextcloud.yaml
@@ -9,6 +9,5 @@ spec:
     name: postgres16
   name: nextcloud
   owner: nextcloud
-  ensure: present
   # Never drop the database if this CR is deleted/pruned — this is an adopted, live DB.
   databaseReclaimPolicy: retain

--- a/kubernetes/apps/database/cloudnative-pg/databases/prowlarr.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/databases/prowlarr.yaml
@@ -9,6 +9,5 @@ spec:
     name: postgres16
   name: prowlarr
   owner: prowlarr
-  ensure: present
   # Never drop the database if this CR is deleted/pruned — this is an adopted, live DB.
   databaseReclaimPolicy: retain

--- a/kubernetes/apps/database/cloudnative-pg/databases/radarr.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/databases/radarr.yaml
@@ -9,6 +9,5 @@ spec:
     name: postgres16
   name: radarr
   owner: radarr
-  ensure: present
   # Never drop the database if this CR is deleted/pruned — this is an adopted, live DB.
   databaseReclaimPolicy: retain

--- a/kubernetes/apps/database/cloudnative-pg/databases/sonarr.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/databases/sonarr.yaml
@@ -9,6 +9,5 @@ spec:
     name: postgres16
   name: sonarr
   owner: sonarr
-  ensure: present
   # Never drop the database if this CR is deleted/pruned — this is an adopted, live DB.
   databaseReclaimPolicy: retain

--- a/kubernetes/apps/database/cloudnative-pg/databases/spoolman.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/databases/spoolman.yaml
@@ -9,6 +9,5 @@ spec:
     name: postgres16
   name: spoolman
   owner: spoolman
-  ensure: present
   # Never drop the database if this CR is deleted/pruned — this is an adopted, live DB.
   databaseReclaimPolicy: retain

--- a/kubernetes/apps/default/immich/ks.yaml
+++ b/kubernetes/apps/default/immich/ks.yaml
@@ -7,8 +7,6 @@ metadata:
   namespace: default
 spec:
   interval: 1h
-  retryInterval: 2m
-  timeout: 5m
   prune: true
   components:
     - ../../../../components/nfs-scaler
@@ -27,8 +25,6 @@ metadata:
   namespace: default
 spec:
   interval: 1h
-  retryInterval: 2m
-  timeout: 5m
   prune: true
   path: ./kubernetes/apps/default/immich/machine-learning
   sourceRef:

--- a/kubernetes/apps/flux-system/flux-instance/app/helmrelease.yaml
+++ b/kubernetes/apps/flux-system/flux-instance/app/helmrelease.yaml
@@ -41,7 +41,6 @@ spec:
               name: (helm-controller|source-controller)
           - # Individual memory limits per controller based on 30-day usage analysis
             # Peak usage: helm=330MB, kustomize=203MB, source=127MB, notification=96MB, operator=291MB
-            # Previous limit was 2Gi per controller (10Gi total), now optimized to 1.92Gi total
             patch: |
               apiVersion: apps/v1
               kind: Deployment

--- a/kubernetes/apps/media/qbittorrent/tools/qbitrr/helmrelease.yaml
+++ b/kubernetes/apps/media/qbittorrent/tools/qbitrr/helmrelease.yaml
@@ -31,7 +31,6 @@ spec:
         initContainers:
           configure:
             # steinbrueckri/envsubst: public Dockerfile (Alpine + gettext at build); no runtime apk (works without egress to Alpine mirrors).
-            # https://github.com/steinbrueckri/envsubst — pin digest after pull: docker inspect --format='{{index .RepoDigests 0}}' steinbrueckri/envsubst:v2.1.1
             image:
               repository: steinbrueckri/envsubst
               tag: v2.1.7

--- a/kubernetes/apps/observability/exporters/qbittorrent-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/exporters/qbittorrent-exporter/app/helmrelease.yaml
@@ -24,9 +24,7 @@ spec:
               EXPORTER_PORT: &port 8000
               QBITTORRENT_HOST: qbittorrent.media.svc.cluster.local
               QBITTORRENT_PORT: 80
-            # QBITTORRENT_USER/QBITTORRENT_PASS come from the app's sops secret via
-            # envFrom (key names match what the exporter reads). The old explicit
-            # ${VAR} env entries shadowed these with never-resolved substitutions.
+            # QBITTORRENT_USER/QBITTORRENT_PASS come from qbittorrent-exporter-secret via envFrom.
             envFrom:
               - secretRef:
                   name: qbittorrent-exporter-secret


### PR DESCRIPTION
Repo-wide simplify pass. Removes 34 lines of provably inert config; rendered/live behavior is unchanged.

## Changes

- **CNPG `ensure: present` removed (28 lines)** from the 11 `databases/*.yaml` Database CRs, the extensions blocks in memini/crowdsec, and all 11 `managed.roles` entries in `cluster/cluster.yaml`. All three CRD paths default to `present` (verified against the live CRD schemas via `kubectl explain` and the openAPI schema), so the API server defaults the field back at admission — live objects are identical. `litellm` already omitted it; the directory is now uniform.
- **`immich/ks.yaml`: dead `retryInterval`/`timeout` removed (4 lines).** The cluster-level Flux patch in `kubernetes/flux/cluster/ks.yaml` unconditionally sets `timeout: 5m` + `retryInterval: 2m` on every child Kustomization, overwriting these identical values.
- **Stale comments deleted (3 files):** flux-instance's historical "Previous limit was 2Gi…" line, qbitrr's digest-pin instruction referencing v2.1.1 under a v2.1.7 tag, qbittorrent-exporter's 3-line history narrative condensed to a one-line fact.

## Validation

- `kustomize build` passes for every touched directory
- `flate diff helmrelease`: empty
- `flate diff kustomization`: only the `ensure: present` map-entry removals; the immich ks fields show **no** diff (cluster patch re-adds them verbatim), confirming they were dead config