### PR TITLE
fix(cnpg): enforce pgbouncer-rw one-per-node spread

### DIFF
--- a/kubernetes/apps/database/cloudnative-pg/cluster/pooler.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/pooler.yaml
@@ -26,11 +26,11 @@ spec:
             limits:
               cpu: "1"
               memory: 256Mi
-      # Soft spread so losing one node doesn't strand all 3 replicas on the other two.
+      # Hard spread (one per node): soft ScheduleAnyway let all 3 rw pods pile onto one node after a flap.
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: kubernetes.io/hostname
-          whenUnsatisfiable: ScheduleAnyway
+          whenUnsatisfiable: DoNotSchedule
           labelSelector:
             matchLabels:
               cnpg.io/poolerName: pgbouncer-rw


### PR DESCRIPTION
## Problem

`pgbouncer-rw`'s node spread was `whenUnsatisfiable: ScheduleAnyway` (soft). After a control-2 flap, all 3 rw pooler replicas landed on control-1 — a single node loss would then take down every RW pooler at once, the exact concentration the constraint was meant to prevent. Found while verifying the 07-20 merge batch against live cluster state.

## Fix

Flip to `whenUnsatisfiable: DoNotSchedule`. With `maxSkew: 1` and 3 instances across 3 nodes it forces one-per-node while all nodes are healthy, and still allows 2+1 during a single-node outage (no pending replica). One-line change; comment updated to match.

Live pods were manually rebalanced off control-1 after merge-time (topologySpread is scheduling-time only, so the pre-existing stack doesn't self-correct).
