### PR TITLE
feat(kube-system): add node-problem-detector for kernel-event node conditions

### DIFF
--- a/kubernetes/apps/kube-system/kustomization.yaml
+++ b/kubernetes/apps/kube-system/kustomization.yaml
@@ -13,6 +13,7 @@ resources:
   - ./generic-device-plugin/ks.yaml
   - ./metrics-server/ks.yaml
   - ./network-policies/ks.yaml
+  - ./node-problem-detector/ks.yaml
   - ./reloader/ks.yaml
   - ./snapshot-controller/ks.yaml
   - ./spegel/ks.yaml

--- a/kubernetes/apps/kube-system/node-problem-detector/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/node-problem-detector/app/helmrelease.yaml
@@ -1,0 +1,32 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app node-problem-detector
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: node-problem-detector
+  values:
+    fullnameOverride: *app
+    settings:
+      # Talos has no dockerd/journald — only the kmsg-based monitors apply.
+      log_monitors:
+        - /config/kernel-monitor.json
+        - /config/readonly-monitor.json
+    metrics:
+      enabled: true
+      serviceMonitor:
+        enabled: true
+        additionalRelabelings:
+          # problem_counter/problem_gauge carry no node label; map it from pod metadata.
+          - sourceLabels: [__meta_kubernetes_pod_node_name]
+            targetLabel: node
+    resources:
+      requests:
+        cpu: 10m
+        memory: 64Mi
+      limits:
+        memory: 256Mi

--- a/kubernetes/apps/kube-system/node-problem-detector/app/kustomization.yaml
+++ b/kubernetes/apps/kube-system/node-problem-detector/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrelease.yaml
+  - ocirepository.yaml
+  - prometheusrule.yaml

--- a/kubernetes/apps/kube-system/node-problem-detector/app/ocirepository.yaml
+++ b/kubernetes/apps/kube-system/node-problem-detector/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: node-problem-detector
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 2.4.1
+  url: oci://ghcr.io/deliveryhero/helm-charts/node-problem-detector

--- a/kubernetes/apps/kube-system/node-problem-detector/app/prometheusrule.yaml
+++ b/kubernetes/apps/kube-system/node-problem-detector/app/prometheusrule.yaml
@@ -1,0 +1,32 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: node-problem-detector-rules
+spec:
+  groups:
+    - name: node-problem-detector.rules
+      rules:
+        # kube-state-metrics exports NPD-written Node conditions automatically.
+        - alert: NodeProblemCondition
+          expr: |-
+            kube_node_status_condition{condition=~"KernelDeadlock|ReadonlyFilesystem|XfsHasShutdown",status="true"} == 1
+          for: 1m
+          annotations:
+            summary: >-
+              Node {{ $labels.node }} reports permanent problem condition {{ $labels.condition }}
+            description: >-
+              node-problem-detector saw a fatal kernel-log event on {{ $labels.node }} — the condition
+              persists in the API server even after a cold power cycle wipes the kernel ring buffer.
+          labels:
+            severity: critical
+        # OOMKilling excluded — already covered by the OomKilled/OomStorm rules in victoria-metrics.
+        - alert: NodeKernelProblemEvents
+          expr: |-
+            sum by (node, reason) (increase(problem_counter{reason=~"TaskHung|KernelOops|IOError|Ext4Error|MemoryReadError|UnregisterNetDevice|CperHardwareErrorFatal"}[10m])) > 0
+          annotations:
+            summary: >-
+              {{ $value }} {{ $labels.reason }} kernel events on {{ $labels.node }} in the last 10 minutes
+          labels:
+            severity: warning

--- a/kubernetes/apps/kube-system/node-problem-detector/ks.yaml
+++ b/kubernetes/apps/kube-system/node-problem-detector/ks.yaml
@@ -1,0 +1,17 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: node-problem-detector
+  namespace: &namespace kube-system
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/kube-system/node-problem-detector/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  wait: false


### PR DESCRIPTION
Closes the last detection gap from the 07-20 node-health audit: nothing in the cluster sees the kernel log (victoria-logs collector is pod-logs-only, no Talos logging destinations configured). Kernel faults like the recurring NVMe-thermal → XFS forced-shutdown crashes only surface as a delayed NotReady, and the evidence in the kernel ring buffer is wiped by the cold power cycle those incidents require.

## What

New `kube-system` app: [deliveryhero node-problem-detector chart 2.4.1](https://github.com/deliveryhero/helm-charts/tree/master/stable/node-problem-detector) (NPD v1.35.1) as a DaemonSet reading `/dev/kmsg`, posting Node conditions/events to the API server.

- **Monitors**: `kernel-monitor.json` + `readonly-monitor.json` only — the chart's default `docker-monitor.json` is dropped (Talos runs containerd, no dockerd; journald monitors don't apply either).
- **Conditions**: `XfsHasShutdown` (default upstream pattern `XFS .* Shutting down filesystem` — exactly the Micron incident signature), `ReadonlyFilesystem`, `KernelDeadlock` become *permanent* Node conditions — they persist in the API server across the cold power cycle, so root cause survives even when `talosctl dmesg` comes back empty.
- **Metrics**: `problem_counter`/`problem_gauge` on :20257 via ServiceMonitor, with `__meta_kubernetes_pod_node_name → node` relabeling since NPD metrics carry no node label.
- **Alerts** (own PrometheusRule, chart's bundled rules stay off):
  - `NodeProblemCondition` (critical): any permanent condition true, via `kube_node_status_condition` — kube-state-metrics exports NPD's custom conditions automatically (its node collector iterates conditions dynamically).
  - `NodeKernelProblemEvents` (warning): transient TaskHung/KernelOops/IOError/Ext4Error/MemoryReadError/UnregisterNetDevice/CperHardwareErrorFatal events. `OOMKilling` is excluded — existing `OomKilled`/`OomStorm` rules already cover it.
- Chart defaults kept where they fit: `privileged: true` (required for `/dev/kmsg`; upstream has no capability-only mode), `system-node-critical` priority, NoSchedule toleration. Resources set explicitly since the chart ships none (10m/64Mi requests, 256Mi limit; ~3m/50Mi observed in the wild).

## Validation

- `kustomize build` passes for the app and kube-system overlay
- `flate diff kustomization`: new Kustomization renders with the cluster-level patch applied (timeout/retryInterval/substituteFrom injected — none set in ks.yaml)
- `flate diff helmrelease`: full chart render verified — DaemonSet args show `--config.system-log-monitor=/config/kernel-monitor.json,/config/readonly-monitor.json`, ServiceMonitor carries the node relabeling, resources land as configured