### PR TITLE
feat(ai): cut over sglang to llmkube

### DIFF
--- a/kubernetes/apps/ai/litellm/instance/models.yaml
+++ b/kubernetes/apps/ai/litellm/instance/models.yaml
@@ -8,10 +8,9 @@ spec:
   proxyRef: litellm
   params:
     model: openai/qwen-3.6
-    apiBase: http://sglang.ai.svc.cluster.local/v1
-    # sglang is unauthenticated internally, but litellm's openai provider errors on an
-    # unset api_key; any non-empty value satisfies it (dropped when the old configmap's
-    # os.environ/LLAMA_SERVER_API_KEY was migrated — that env var isn't injected here).
+    apiBase: http://qwen36-27b.ai.svc.cluster.local:30000/v1
+    # Native SGLang is unauthenticated internally, but LiteLLM's OpenAI provider
+    # requires a non-empty api_key.
     apiKey: sk-sglang-noauth
     additional:
       timeout: 1800
@@ -19,8 +18,7 @@ spec:
       num_retries: 0
   info:
     mode: chat
-    # Match SGLang's effective 180K context cap after reserving maxOutputTokens.
-    # EXTRA_ARGS' --context-length 180000 overrides the earlier 200000 argument.
+    # Match the configured 180K native SGLang context cap after reserving maxOutputTokens.
     maxInputTokens: 171808
     maxOutputTokens: 8192
 ---
@@ -33,7 +31,7 @@ spec:
   proxyRef: litellm
   params:
     model: openai/qwen-3.6
-    apiBase: http://sglang.ai.svc.cluster.local/v1
+    apiBase: http://qwen36-27b.ai.svc.cluster.local:30000/v1
     apiKey: sk-sglang-noauth
     additional:
       # 900s (was 600): Hermes compression is a ~100K+ prefill on this alias — under GPU

--- a/kubernetes/apps/ai/litellm/ks.yaml
+++ b/kubernetes/apps/ai/litellm/ks.yaml
@@ -14,6 +14,9 @@ spec:
     # Embedding cache backend
     - name: dragonfly-cluster
       namespace: database
+    # Delay the endpoint switch until native SGLang is Available.
+    - name: llmkube-models
+      namespace: ai
   path: ./kubernetes/apps/ai/litellm/instance
   prune: true
   sourceRef:

--- a/kubernetes/apps/ai/llmkube/ks.yaml
+++ b/kubernetes/apps/ai/llmkube/ks.yaml
@@ -36,6 +36,21 @@ spec:
     - name: llmkube
     - name: generic-device-plugin
       namespace: kube-system
+    # This only reduces reconciliation races; the in-pod gate guards teardown.
+    - name: sglang
+      namespace: ai
+  healthChecks:
+    - apiVersion: inference.llmkube.dev/v1alpha1
+      kind: InferenceService
+      name: qwen36-27b
+      namespace: ai
+  timeout: 60m
+  healthCheckExprs:
+    - apiVersion: inference.llmkube.dev/v1alpha1
+      kind: InferenceService
+      inProgress: has(status.phase) && status.phase in ['Pending', 'Creating', 'Progressing', 'WaitingForGPU']
+      failed: has(status.phase) && status.phase == 'Failed'
+      current: has(status.phase) && status.phase == 'Ready' && has(status.conditions) && status.conditions.exists(e, e.type == 'Available' && e.status == 'True')
   path: ./kubernetes/apps/ai/llmkube/models
   prune: true
   sourceRef:

--- a/kubernetes/apps/ai/llmkube/models/kustomization.yaml
+++ b/kubernetes/apps/ai/llmkube/models/kustomization.yaml
@@ -3,6 +3,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./sglang-cutover-rbac.yaml
   - ./qwen36-27b-sglang.yaml
   - ./qwen3-embedding.yaml
   - ./qwen35-2b.yaml

--- a/kubernetes/apps/ai/llmkube/models/qwen36-27b-sglang.yaml
+++ b/kubernetes/apps/ai/llmkube/models/qwen36-27b-sglang.yaml
@@ -63,10 +63,28 @@ metadata:
 spec:
   modelRef: qwen36-27b-awq
   runtime: sglang
-  # Scale up only after retiring standalone SGLang; phase one prepares config
-  # without starting a second 87.5%-VRAM workload or staging model files.
-  replicas: 0
+  replicas: 1
   image: ghcr.io/tanguille/sglang-rdna4:v0.5.15-gfx1201@sha256:3d1561f6a87ce2d61f7c508f6c2f76fd6bbffb094c99d23cb097a89353355bfe
+  # Wait for the legacy Deployment to finish scaling down before starting the
+  # native process; model-init may download while the legacy server still serves.
+  command:
+    - /bin/bash
+    - -ec
+    - |
+      TOKEN_FILE=/var/run/secrets/kubernetes.io/serviceaccount/token
+      CA_FILE=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+      API_URL="https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT_HTTPS}/apis/apps/v1/namespaces/ai/deployments/sglang"
+      while true; do
+        if deployment="$(curl -fsS --cacert "${CA_FILE}" -H "Authorization: Bearer $(cat "${TOKEN_FILE}")" "${API_URL}" 2>/dev/null)"; then
+          if python3 -c 'import json, sys; d=json.load(sys.stdin); m=d["metadata"]; s=d["spec"]; t=d.get("status", {}); raise SystemExit(0 if s.get("replicas") == 0 and t.get("observedGeneration", -1) >= m["generation"] and t.get("replicas", 0) == 0 else 1)' <<<"${deployment}"; then
+            break
+          fi
+        fi
+        sleep 5
+      done
+      sleep 30
+      exec python3 -m sglang.launch_server "$@"
+    - --
   containerPort: 30000
   endpoint:
     # v0.9.8 maps endpoint.port to both Service port and targetPort; use the

--- a/kubernetes/apps/ai/llmkube/models/sglang-cutover-rbac.yaml
+++ b/kubernetes/apps/ai/llmkube/models/sglang-cutover-rbac.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: llmkube-sglang-cutover
+  namespace: ai
+rules:
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    resourceNames:
+      - sglang
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: llmkube-sglang-cutover
+  namespace: ai
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: ai
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: llmkube-sglang-cutover

--- a/kubernetes/apps/ai/sglang/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/sglang/app/helmrelease.yaml
@@ -63,6 +63,8 @@ spec:
 
     controllers:
       app:
+        # First cutover phase; preserve the Service, PVC, and route for rollback.
+        replicas: 0
         # Recreate, not RollingUpdate: singleton holding the node's only squat.ai/dri:1.
         strategy: Recreate
         containers:


### PR DESCRIPTION
## Summary
- scale the standalone SGLang workload to zero while preserving its Service, route, and PVC for rollback
- activate native LLMKube SGLang and update LiteLLM aliases to its service
- gate native ROCm startup on confirmed legacy Deployment teardown, with a 30-second release grace period
- gate LiteLLM reconciliation on LLMKube reporting Qwen as Available

## Cutover behavior
The model-init phase may download while legacy SGLang still serves. Native SGLang does not start until the old Deployment reports zero replicas. LiteLLM keeps its old configuration until the native InferenceService is Available.

## Validation
- YAML parse
- `git diff --check`
- independent review: approved
- `bash .agents/skills/pr-review/scripts/validate-pr.sh` (rendering/shellcheck unavailable locally: `kustomize`/`flate` and `shellcheck` not installed)