### PR TITLE
fix(kube-system): correct node-problem-detector alert condition and reason names

### DIFF
--- a/kubernetes/apps/kube-system/node-problem-detector/app/prometheusrule.yaml
+++ b/kubernetes/apps/kube-system/node-problem-detector/app/prometheusrule.yaml
@@ -11,7 +11,7 @@ spec:
         # kube-state-metrics exports NPD-written Node conditions automatically.
         - alert: NodeProblemCondition
           expr: |-
-            kube_node_status_condition{condition=~"KernelDeadlock|ReadonlyFilesystem|XfsHasShutdown",status="true"} == 1
+            kube_node_status_condition{condition=~"KernelDeadlock|ReadonlyFilesystem|XfsShutdown|CperHardwareErrorFatal",status="true"} == 1
           for: 1m
           annotations:
             summary: >-
@@ -24,7 +24,7 @@ spec:
         # OOMKilling excluded — already covered by the OomKilled/OomStorm rules in victoria-metrics.
         - alert: NodeKernelProblemEvents
           expr: |-
-            sum by (node, reason) (increase(problem_counter{reason=~"TaskHung|KernelOops|IOError|Ext4Error|MemoryReadError|UnregisterNetDevice|CperHardwareErrorFatal"}[10m])) > 0
+            sum by (node, reason) (increase(problem_counter{reason=~"TaskHung|KernelOops|IOError|Ext4Error|MemoryReadError|UnregisterNetDevice|CperHardwareErrorRecoverable"}[10m])) > 0
           annotations:
             summary: >-
               {{ $value }} {{ $labels.reason }} kernel events on {{ $labels.node }} in the last 10 minutes


### PR DESCRIPTION
Follow-up to #4102, found during post-deploy verification against the live cluster.

- The permanent condition NPD writes is `XfsShutdown` — `XfsHasShutdown` is the *reason* string, so the condition alert matched a series that can never exist. Confirmed in the running pod's `/config/kernel-monitor.json` and on the live Node conditions (all 3 nodes now show `XfsShutdown: False`).
- `CperHardwareErrorFatal` is likewise a permanent *condition* (not a transient counter reason): moved it into the condition alert and put `CperHardwareErrorRecoverable` (a real transient reason) in the event alert instead.

Verified working end-to-end on the live deployment: synthetic `task khungtest:1 blocked for more than 120 seconds.` injected into control-3's `/dev/kmsg` produced a `TaskHung` node event within seconds, `problem_gauge`/`problem_counter` are scraped with the `node` relabeling, and `kube_node_status_condition{condition="XfsShutdown"}` series exist for all nodes.