### PR TITLE
fix(ai): correct embedder-recycle JSON parsing and generation check

### DIFF
--- a/kubernetes/apps/ai/llmkube/recycle/scripts/embedder-recycle.sh
+++ b/kubernetes/apps/ai/llmkube/recycle/scripts/embedder-recycle.sh
@@ -7,7 +7,8 @@ token="$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)"
 last_timestamp=
 
 json_field() {
-  printf '%s' "$1" | sed -n "s/.*\"$2\":\([^,}]*\).*/\1/p" | sed -n '1p'
+  # apiserver pretty-prints JSON for curl's User-Agent, so skip the space after the colon
+  printf '%s' "$1" | sed -n "s/.*\"$2\": *\([^,}]*\).*/\1/p" | sed -n '1p'
 }
 
 at_least_one() {
@@ -27,7 +28,9 @@ wait_ready() {
     updated="$(json_field "$status" updatedReplicas || true)"
     available="$(json_field "$status" availableReplicas || true)"
     ready="$(json_field "$status" readyReplicas || true)"
-    if [ "$observed" = "$generation" ] && at_least_one "$updated" && at_least_one "$available" && at_least_one "$ready"; then
+    # llmkube reconciles the Deployment right after our patch, bumping generation past
+    # the value we patched, so require observed >= ours rather than exact equality.
+    if at_least_one "$observed" && [ "$observed" -ge "$generation" ] && at_least_one "$updated" && at_least_one "$available" && at_least_one "$ready"; then
       return 0
     fi
     sleep 5


### PR DESCRIPTION
The nightly `embedder-recycle` CronJob has been failing on every run: it silently exits 1 after patching the first embedder (`qwen3-embedding`) and never recycles `vmcp-embedding`.

Two bugs in `scripts/embedder-recycle.sh`, both found by tracing the job with `sh -x` against the live apiserver:

- **JSON parsing** — the apiserver pretty-prints its JSON responses for curl's User-Agent, so `"generation": 5747` was parsed *with* the leading space and rejected by the `*[!0-9]*` numeric guard, hitting the silent `exit 1`. Fixed by skipping the space after the colon in `json_field`.
- **Generation check** — `wait_ready` compared `observedGeneration` to the exact generation returned by our PATCH, but llmkube reconciles the Deployment immediately after, bumping the generation past ours so equality never held (60s timeout → `set -e` → exit 1). Changed to `observed >= ours`, which is sound since generation is monotonic and our `restartedAt` annotation persists across llmkube's reconcile.

Verified end-to-end against the cluster: the fixed script exits 0 and both embedders roll (confirmed `vmcp-embedding` got a fresh pod).