### PR TITLE
fix(amdgpu): raise R9700 fan setpoint, alert on unexpected reboots

### DIFF
--- a/kubernetes/apps/kube-system/amdgpu-undervolt.yaml
+++ b/kubernetes/apps/kube-system/amdgpu-undervolt.yaml
@@ -28,6 +28,15 @@ spec:
               value: "-82"
             - name: POWER_LIMIT_WATTS
               value: "210"
+            # PMFW regulates the blower on hotspot only and cannot see the memory
+            # sensor, which measures ~11C hotter under load. At the stock 100C
+            # target the controller sits ~17C under its own setpoint and never
+            # ramps, leaving VRAM at 92-96C. Raise both: a lower target so it
+            # ramps at all, a higher acoustic ceiling so it is not capped at 3500.
+            - name: FAN_TARGET_TEMP_C
+              value: "80"
+            - name: ACOUSTIC_TARGET_RPM
+              value: "4500"
           command:
             - /bin/sh
             - -c
@@ -41,11 +50,37 @@ spec:
                 printf '%s %s\n' "$(date '+%Y-%m-%dT%H:%M:%S%z')" "$*"
               }
 
+              # Both fan nodes are auto-mode scalars: the firmware curve stays in
+              # charge, only its setpoint moves. Deliberately NOT fan_curve, which
+              # switches modes and pushes a full OverDriveTable - this SKU has a
+              # driver/firmware interface mismatch (driver 0x2E, PMFW 0x32) and
+              # that is not a variable to add while a reboot cause is unexplained.
+              apply_fan_setting() {
+                node="$1"
+                want="$2"
+                node_name=$(basename "$node")
+
+                if [ ! -w "$node" ]; then
+                  log "skipping $${node_name}: not writable"
+                  return
+                fi
+
+                echo "$want" > "$node"
+                echo c > "$node"
+                got=$(tr -d '\000' < "$node" | awk 'NR==2{print $1; exit}')
+                if [ "$got" = "$want" ]; then
+                  log "set $${node_name} to $${want}"
+                else
+                  log "$${node_name} failed: wanted $${want}, got $${got:-unknown}"
+                fi
+              }
+
               apply_gpu_tuning() {
                 card="$1"
                 card_name=$(basename "$(dirname "$card")")
                 od="$card/pp_od_clk_voltage"
                 perf="$card/power_dpm_force_performance_level"
+                fan_ctrl="$card/gpu_od/fan_ctrl"
 
                 if [ -w "$perf" ] && [ -w "$od" ]; then
                   echo manual > "$perf"
@@ -60,6 +95,9 @@ spec:
                 else
                   log "skipping VDDGFX offset for $${card_name}: pp_od or perf level not writable"
                 fi
+
+                apply_fan_setting "$fan_ctrl/fan_target_temperature" "$FAN_TARGET_TEMP_C"
+                apply_fan_setting "$fan_ctrl/acoustic_target_rpm_threshold" "$ACOUSTIC_TARGET_RPM"
 
                 for cap in "$card"/hwmon/hwmon*/power1_cap; do
                   [ -e "$cap" ] || continue

--- a/kubernetes/apps/kube-system/amdgpu-undervolt.yaml
+++ b/kubernetes/apps/kube-system/amdgpu-undervolt.yaml
@@ -28,11 +28,9 @@ spec:
               value: "-82"
             - name: POWER_LIMIT_WATTS
               value: "210"
-            # PMFW regulates the blower on hotspot only and cannot see the memory
-            # sensor, which measures ~11C hotter under load. At the stock 100C
-            # target the controller sits ~17C under its own setpoint and never
-            # ramps, leaving VRAM at 92-96C. Raise both: a lower target so it
-            # ramps at all, a higher acoustic ceiling so it is not capped at 3500.
+            # PMFW regulates on hotspot only; mem runs ~11C hotter and sat at
+            # 92-96C at the stock 100C target, so the curve never ramped. Auto-mode
+            # scalars, NOT fan_curve (full OverDriveTable, driver 0x2E vs PMFW 0x32).
             - name: FAN_TARGET_TEMP_C
               value: "80"
             - name: ACOUSTIC_TARGET_RPM
@@ -50,11 +48,6 @@ spec:
                 printf '%s %s\n' "$(date '+%Y-%m-%dT%H:%M:%S%z')" "$*"
               }
 
-              # Both fan nodes are auto-mode scalars: the firmware curve stays in
-              # charge, only its setpoint moves. Deliberately NOT fan_curve, which
-              # switches modes and pushes a full OverDriveTable - this SKU has a
-              # driver/firmware interface mismatch (driver 0x2E, PMFW 0x32) and
-              # that is not a variable to add while a reboot cause is unexplained.
               apply_fan_setting() {
                 node="$1"
                 want="$2"

--- a/kubernetes/apps/observability/exporters/node-exporter/app/prometheusrule.yaml
+++ b/kubernetes/apps/observability/exporters/node-exporter/app/prometheusrule.yaml
@@ -21,12 +21,11 @@ spec:
           labels:
             severity: critical
         - alert: NodeRebooted
-          # control-1 has solo-rebooted ~16 times in 90d via an uncaptured guest
-          # kernel panic; the first symptom was always a dead jellyfin stream, not
-          # a page. Fires on planned upgrades too - that is the point, confirm the
-          # reboot was intended. No `for:` - uptime only crosses this once.
+          # control-1 solo-rebooted ~16x in 90d via an uncaptured guest kernel
+          # panic, first symptom a dead jellyfin stream. No `for:` - uptime crosses
+          # this once. Node clock both sides, so NTP skew after boot cannot bias it.
           expr: |-
-            (node_time_seconds{kubernetes_node!=""} - node_boot_time_seconds{kubernetes_node!=""}) < 600
+            node_time_seconds{kubernetes_node!=""} - node_boot_time_seconds < 600
           annotations:
             summary: >-
               {{ $labels.kubernetes_node }} booted less than 10 minutes ago —

--- a/kubernetes/apps/observability/exporters/node-exporter/app/prometheusrule.yaml
+++ b/kubernetes/apps/observability/exporters/node-exporter/app/prometheusrule.yaml
@@ -20,6 +20,19 @@ spec:
               kubelet starvation follows if this keeps falling
           labels:
             severity: critical
+        - alert: NodeRebooted
+          # control-1 has solo-rebooted ~16 times in 90d via an uncaptured guest
+          # kernel panic; the first symptom was always a dead jellyfin stream, not
+          # a page. Fires on planned upgrades too - that is the point, confirm the
+          # reboot was intended. No `for:` - uptime only crosses this once.
+          expr: |-
+            (node_time_seconds{kubernetes_node!=""} - node_boot_time_seconds{kubernetes_node!=""}) < 600
+          annotations:
+            summary: >-
+              {{ $labels.kubernetes_node }} booted less than 10 minutes ago —
+              confirm this reboot was intentional
+          labels:
+            severity: warning
         - alert: NodeGTTMemoryHigh
           # pinned iGPU memory the OOM killer cannot reclaim; normal embedder
           # footprint is 1-2GB, the control-2 wedge had 4.7GB. Scoped to the two

--- a/talos/schematic.yaml
+++ b/talos/schematic.yaml
@@ -2,7 +2,7 @@
 # curl -X POST --data-binary @talos/schematic.yaml \
 #  https://factory.talos.dev/schematics
 # Truenas VM (control-1)
-# dfc849d1bd15c28f7e812d46ac70744b563e49fea8aff2cf784d58eeaf47b92d
+# 6b3af3cd9190614d292a3f607b758c0bfdfd6a74b91c25d19fca504506511b73
 ---
 customization:
   extraKernelArgs:
@@ -16,6 +16,12 @@ customization:
     - amd_pstate=active
     - amdgpu.ppfeaturemask=0xffffffff
     - amdgpu.runpm=0
+    # Arms the PSP RAS trusted application: error-interrupt handling, MCA bank
+    # consumption and EEPROM-backed bad-page retirement. MEM ECC already corrects
+    # without it; this makes errors reportable and bad pages retirable. Adds no
+    # GFX instrumentation - hardware ability[101] is DF+UMC, the GFX bit is absent
+    # on this SKU. Check reported VRAM on first boot before sglang reclaims it.
+    - amdgpu.ras_enable=1
     - pcie_aspm.policy=performance
     - mitigations=off
     - security=none

--- a/talos/schematic.yaml
+++ b/talos/schematic.yaml
@@ -16,11 +16,8 @@ customization:
     - amd_pstate=active
     - amdgpu.ppfeaturemask=0xffffffff
     - amdgpu.runpm=0
-    # Arms the PSP RAS trusted application: error-interrupt handling, MCA bank
-    # consumption and EEPROM-backed bad-page retirement. MEM ECC already corrects
-    # without it; this makes errors reportable and bad pages retirable. Adds no
-    # GFX instrumentation - hardware ability[101] is DF+UMC, the GFX bit is absent
-    # on this SKU. Check reported VRAM on first boot before sglang reclaims it.
+    # PSP RAS reporting: arms error interrupts + MCA consumption, which NPD's
+    # CperHardwareError* alerts already consume. DF+UMC only, no GFX on this SKU.
     - amdgpu.ras_enable=1
     - pcie_aspm.policy=performance
     - mitigations=off

--- a/talos/talconfig.yaml
+++ b/talos/talconfig.yaml
@@ -22,7 +22,7 @@ nodes:
   - hostname: "control-1"
     ipAddress: "192.168.0.11"
     installDisk: "/dev/vda"
-    talosImageURL: factory.talos.dev/installer/dfc849d1bd15c28f7e812d46ac70744b563e49fea8aff2cf784d58eeaf47b92d
+    talosImageURL: factory.talos.dev/installer/6b3af3cd9190614d292a3f607b758c0bfdfd6a74b91c25d19fca504506511b73
     controlPlane: true
     patches:
       - "@./patches/control-1/amd-gpu.yaml"


### PR DESCRIPTION
Fallout from investigating control-1's spontaneous reboots. Two changes apply live, one is inert until the next node upgrade.

## 1. Fan setpoint — the substantive change

The R9700's firmware fan loop **regulates on hotspot/junction only and cannot see the memory sensor** (sensor selection isn't exposed on RDNA3+). Under sustained load junction measures ~11 °C *below* mem, so with the stock 100 °C target the controller sits ~17 °C beneath its own setpoint and never ramps — while VRAM runs 92–96 °C and the blower idles near the 3500 rpm acoustic cap, having never exceeded 82% of `fan1_max`.

Both knobs are auto-mode scalars, so AMD's curve stays in charge. Deliberately **not** `fan_curve`, which switches modes and pushes a full `OverDriveTable`: this SKU has a driver/firmware interface mismatch (driver declares 0x2E, PMFW reports 0x32) and that's not a variable worth adding while a reboot cause is open.

**This is not a safety fix.** Mem peaked 8 °C under the vendor's own `temp3_crit` of 108 °C, `THROTTLER_TEMP_MEM_BIT` has never set, mclk never left its top state, and ECC counters read zero. It spends unused cooler headroom, nothing more.

## 2. NodeRebooted alert

~16 solo reboots in 90 days and the first symptom was always a dead Jellyfin stream, never a page. Fires on planned upgrades too — that's the point; the question it asks is whether the reboot was meant to happen.

## 3. GECC on control-1 — inert, and weaker than it first looked

Kernel args go in the factory schematic because UKI cmdline forbids `install.extraKernelArgs`. New schematic is registered and its contents are byte-identical to the old one apart from `amdgpu.ras_enable=1`.

**Caveat worth reading before merging this commit:** the main benefit I originally cited — arming bad-page retirement — turns out to be dead code on Navi48. `umc_v8_14_ras_hw_ops` has only `.query_ras_error_count`, no `.query_ras_error_address`, so `amdgpu_ras_add_bad_pages()` is unreachable. The `ue/ce` counters already accumulate without GECC. It's close to a no-op here. It's included because it was already staged and costs nothing to carry, but it doesn't justify a reboot on its own — drop this commit if you'd rather not.

Nothing reconciles talconfig, so this applies only when someone runs `task talos:upgrade-node IP=192.168.0.11`. On that boot, check `node_drm_memory_vram_size_bytes` (currently 34208743424) **before** SGLang reclaims it — VRAM is 99.6% allocated and has no margin.

## Validation

- `kustomize build` clean for both `kube-system` and `observability`
- Rendered DaemonSet script passes `sh -n` after simulating Flux `$$` → `$` envsubst
- Readback parser dry-run against a fake sysfs node returns the right field
- Confirmed no collision between the new lowercase shell vars and the 22 uppercase `cluster-settings` substitution keys
- `talhelper genconfig` renders control-1 to the new schematic; control-2/3 unchanged

## Tested live

`fan_target_temperature` write+commit was verified on the card — it's at 80 now, so the DaemonSet change makes the current state durable rather than introducing it.

`acoustic_target_rpm_threshold` is **untested**: the write was blocked by a permission prompt. The helper verifies and logs each write, so a rejected value shows up in the DaemonSet log rather than failing silently.

## Not included

`VOLTAGE_OFFSET_MV` stays at -82. Changing the fan and the undervolt together would confound the reboot bisect, and the fan change is the one that addresses thermals. The undervolt remains an open candidate for the reboots and is free to falsify separately.

## Still open

Temperature is **not** the reboot cause — high confidence. In 6.18 the only amdgpu path that reacts to temperature reads hotspot and calls `orderly_poweroff()`, never a panic, and the mem sensor is wired to no interrupt. The stronger lead is an unbisected 6.18 amdgpu regression that hard-hangs RDNA3/RDNA4 with no kernel logs; Talos v1.13.7 ships 6.18.39 and the whole v1.13 line is 6.18.x, which spans every reboot on record.
