### PR TITLE
fix(amdgpu): undercut junction with fan target so the curve actually ramps

### DIFF
--- a/kubernetes/apps/kube-system/amdgpu-undervolt.yaml
+++ b/kubernetes/apps/kube-system/amdgpu-undervolt.yaml
@@ -28,11 +28,13 @@ spec:
               value: "-82"
             - name: POWER_LIMIT_WATTS
               value: "210"
-            # PMFW regulates on hotspot only; mem runs ~11C hotter and sat at
-            # 92-96C at the stock 100C target, so the curve never ramped. Auto-mode
-            # scalars, NOT fan_curve (full OverDriveTable, driver 0x2E vs PMFW 0x32).
+            # PMFW regulates on hotspot only; mem runs ~11C hotter. 80 measured as
+            # a no-op (mem 88.00 -> 87.52C): junction already sits 78-81C, so there
+            # was no error signal. The target has to undercut junction to make the
+            # curve ramp at all. Auto-mode scalars, NOT fan_curve (full
+            # OverDriveTable, driver 0x2E vs PMFW 0x32 mismatch on this SKU).
             - name: FAN_TARGET_TEMP_C
-              value: "80"
+              value: "70"
             - name: ACOUSTIC_TARGET_RPM
               value: "4500"
           command:


### PR DESCRIPTION
Follow-up to #4125. That PR's fan change **did not work** — this corrects the value.

## Measured result of #4125

| | before (4h) | after (35min) |
|---|---|---|
| mem | 88.00 °C | 87.52 °C |
| junction | 80.59 °C | 77.92 °C |
| fan | 3088 rpm | 3155 rpm |
| power | 192.9 W | 209 W |

Memory down 0.5 °C, fan up 2%. The predicted −4 to −8 °C did not appear. Both sysfs writes landed cleanly, including the previously-untested acoustic one:

```
20:31:22  set fan_target_temperature to 80
20:31:22  set acoustic_target_rpm_threshold to 4500
```

## Why it was a no-op

The PMFW fan loop regulates on **junction**. Junction already sits at 78–81 °C under sustained inference, so a target of 80 °C produces essentially no error signal — the controller is at its setpoint and has no reason to ramp.

The acoustic ceiling was equally inert for the same reason: the fan has never exceeded ~3500 rpm across the whole day (range 2819–3491), so 4500 was never the binding constraint. The claim in #4125 that the fan was "pressed against" the 3500 cap was wrong — it was a spot reading, not the distribution.

## This change

`FAN_TARGET_TEMP_C: 80 → 70`, so the target undercuts where junction settles and the controller has something to correct. This is also what finally makes the 4500 rpm ceiling load-bearing.

`OD_RANGE` permits 25–105, so 70 is legal. No other knob changes.

## Expectations, deliberately conservative

- **Audible.** If this works it means the blower spins up toward 4500 rpm, which is 82% of `fan1_max`.
- **Unproven.** Nothing here is measured yet. Mem swings 78–94 °C on memory-access mix alone at constant 209 W, which already produced one false positive in #4125 when a low sample got reported as success.
- Verification should be an hour at matched power, compared like-for-like — not a spot reading.

## Still not a safety fix

Mem peaked 8 °C under the vendor's own 108 °C `temp3_crit`, `THROTTLER_TEMP_MEM_BIT` has never set, and mclk has never left its top state. This spends unused cooler headroom; it does not avert anything. Temperature is also not the cause of control-1's reboots — in 6.18 the only amdgpu path that reacts to temperature reads hotspot and calls `orderly_poweroff()`, never a panic.
