### PR TITLE
fix(amdgpu): back off fan target, add blower-stall alert

### DIFF
--- a/kubernetes/apps/kube-system/amdgpu-undervolt.yaml
+++ b/kubernetes/apps/kube-system/amdgpu-undervolt.yaml
@@ -28,13 +28,15 @@ spec:
               value: "-82"
             - name: POWER_LIMIT_WATTS
               value: "210"
-            # PMFW regulates on hotspot only; mem runs ~11C hotter. 80 measured as
-            # a no-op (mem 88.00 -> 87.52C): junction already sits 78-81C, so there
-            # was no error signal. The target has to undercut junction to make the
-            # curve ramp at all. Auto-mode scalars, NOT fan_curve (full
-            # OverDriveTable, driver 0x2E vs PMFW 0x32 mismatch on this SKU).
+            # Measured sweep at 209W, 60s avg per point: 82C->3274rpm/mem 80C,
+            # 78->3396/83, 75->3549/70, 72->3960/80, 70->4201/77. Fan tracks the
+            # target cleanly but mem barely moves across the band, so this buys
+            # noise, not cooling - 70 was +36% rpm over the 3088rpm stock average
+            # for ~3C. 82 keeps the controller engaged at +6%. Card has never been
+            # within 6C of its own 108C mem crit. Auto-mode scalars, NOT fan_curve
+            # (full OverDriveTable, driver 0x2E vs PMFW 0x32 mismatch on this SKU).
             - name: FAN_TARGET_TEMP_C
-              value: "70"
+              value: "82"
             - name: ACOUSTIC_TARGET_RPM
               value: "4500"
           command:

--- a/kubernetes/apps/observability/exporters/drm-exporter/app/kustomization.yaml
+++ b/kubernetes/apps/observability/exporters/drm-exporter/app/kustomization.yaml
@@ -5,3 +5,4 @@ kind: Kustomization
 resources:
   - helmrelease.yaml
   - ocirepository.yaml
+  - prometheusrule.yaml

--- a/kubernetes/apps/observability/exporters/drm-exporter/app/prometheusrule.yaml
+++ b/kubernetes/apps/observability/exporters/drm-exporter/app/prometheusrule.yaml
@@ -1,0 +1,30 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: drm-exporter-rules
+spec:
+  groups:
+    - name: drm-exporter.rules
+      rules:
+        - alert: GpuFanStalled
+          # ROCm #6101 and #6078 are filed against this exact SKU (ASUS Turbo
+          # R9700): blower stationary under load, GPU to 109C, thermally
+          # throttling. Root cause is the SMU interface mismatch this card also
+          # reports (driver 0x2e vs fw 0x32) leaving fan registers inaccessible.
+          # No upstream fix, reported still present on kernel 7.0. The fan is the
+          # only thermal margin this card has, so this is the one GPU condition
+          # worth paging on. Floor is 30% PWM (~1650rpm); under 1000 while pulling
+          # >100W is the stall, not a low idle.
+          expr: |-
+            max by (kubernetes_node) (drm_fan_speed_rpm) < 1000
+            and
+            max by (kubernetes_node) (drm_power_watts) > 100
+          for: 5m
+          annotations:
+            summary: >-
+              {{ $labels.kubernetes_node }} GPU fan has stalled under load —
+              card has no thermal margin without it, power off the GPU workload
+          labels:
+            severity: critical


### PR DESCRIPTION
Closes out the R9700 thermal work. Net result: **the fan tuning was not worth it, and the real risk is something else entirely.**

## 1. Fan target 70 → 82

Measured sweep, constant 209 W, 80 s settle + 60 s average per point:

| target | fan | junction | mem |
|---|---|---|---|
| 82 °C | 3274 rpm | 72 °C | 80 °C |
| 78 °C | 3396 rpm | 74 °C | 83 °C |
| 75 °C | 3549 rpm | 70 °C | 80 °C |
| 72 °C | 3960 rpm | 70 °C | 80 °C |
| 70 °C | 4201 rpm | 68 °C | 77 °C |

Fan tracks the target cleanly — that mechanism is real. But memory barely moves across the whole band. 70 cost **+36% rpm** over the 3088 rpm stock average to buy roughly 3 °C.

The earlier "−8 to −10 °C" claim compared against a 4-hour baseline at different load and cooler ambient rather than a matched control. It does not survive the sweep. Two caveats on the sweep itself, both pushing the same way: 80 s may not be full VRAM settling, and it ran monotonically high→low target so each point inherits the previous cooler state — so it likely *understates* the low-target benefit. The truth is somewhere between 3 and 10 °C, and pinning it needs a multi-hour matched A/B that isn't worth running for a card this far from its limits.

82 keeps the controller engaged at +6% rpm. Card has never come within 6 °C of its 108 °C mem crit, never throttled, mclk never left its top state.

## 2. GpuFanStalled alert — the actually important half

**ROCm [#6101](https://github.com/ROCm/ROCm/issues/6101) and [#6078](https://github.com/ROCm/ROCm/issues/6078) are filed against this exact SKU** — ASUS Turbo Radeon AI PRO R9700 32 GB. Both report the blower **physically stationary under load** while the GPU hit **109 °C** and thermally throttled.

Root cause is the SMU driver/firmware interface mismatch **this card also reports** — driver `0x2e` vs firmware `0x32` — leaving fan-control registers inaccessible. `rocm-smi --setfan` returns "Not supported", sysfs `pwm1` is read-only. No upstream fix, and #6101 says it persists on kernel 7.0.

This matters more than any cooling change: the fan is the only thermal margin the card has, and a stall is **silent**. Memory overtemp on this ASIC throttles with zero dmesg output — a grep for throttle-related `dev_warn/err/info` across the SMU14 sources returns nothing. Nothing would tell you.

`max by (kubernetes_node) (drm_fan_speed_rpm) < 1000 and max by (kubernetes_node) (drm_power_watts) > 100`, `for: 5m`, severity critical. The `max by` handles the second 0 W power series the exporter emits. Fan floor is 30% PWM (~1650 rpm), so sub-1000 under load is a stall, not a low idle. Verified against live data — currently returns empty, as it should.

## Validation

- `kustomize build` clean for both app dirs; `GpuFanStalled` renders in `drm-exporter-rules`, `FAN_TARGET_TEMP_C` renders as `82`
- New `prometheusrule.yaml` registered in the drm-exporter kustomization, matching node-exporter's layout
- Alert expression run against live VictoriaMetrics — returns empty (no stall)

## Context: no hardware change is warranted

A research pass on warranty-safe cooling mods concluded the card is normal and nothing physical moves the needle much. An instrumented review of a comparable R9700 blower measured memory reaching 90 °C at 3200–3400 rpm and 57.9 dB(A) — this card runs slightly cooler and quieter at comparable rpm. No owner anywhere reports an R9700 failing from heat; only throttling.

Chassis work only lowers *intake* air, worth ~0.5–0.7 dB per °C, so a realistic 5–8 °C intake improvement is 2.5–5.5 dB — against the 6.7 dB the fan-target change cost. Undoing that change is the single largest available lever, which is what this PR does.

Repadding is explicitly **not** recommended: ASUS's warranty document tells you not to remove the thermal module, and while Belgian statutory rights run against the retailer for 2 years regardless, months 25–36 are ASUS policy alone and opening the card forfeits them.
