### PR TITLE
revert(talos): disable amdgpu GECC, it costs 2GiB of VRAM for nothing

### DIFF
--- a/talos/schematic.yaml
+++ b/talos/schematic.yaml
@@ -2,7 +2,7 @@
 # curl -X POST --data-binary @talos/schematic.yaml \
 #  https://factory.talos.dev/schematics
 # Truenas VM (control-1)
-# 6b3af3cd9190614d292a3f607b758c0bfdfd6a74b91c25d19fca504506511b73
+# c68c8884333629a78b939df2c920651ecddd733c41ca9bd0a872ec53dc060d8e
 ---
 customization:
   extraKernelArgs:
@@ -16,9 +16,10 @@ customization:
     - amd_pstate=active
     - amdgpu.ppfeaturemask=0xffffffff
     - amdgpu.runpm=0
-    # PSP RAS reporting: arms error interrupts + MCA consumption, which NPD's
-    # CperHardwareError* alerts already consume. DF+UMC only, no GFX on this SKU.
-    - amdgpu.ras_enable=1
+    # Explicit 0, not absent: GECC persists in PSP firmware state once armed, so
+    # dropping the flag leaves it on. It costs exactly 2GiB of VRAM (6.25% carve-out)
+    # and sglang runs at 99.6% allocation. MEM ECC corrects regardless of this.
+    - amdgpu.ras_enable=0
     - pcie_aspm.policy=performance
     - mitigations=off
     - security=none

--- a/talos/talconfig.yaml
+++ b/talos/talconfig.yaml
@@ -22,7 +22,7 @@ nodes:
   - hostname: "control-1"
     ipAddress: "192.168.0.11"
     installDisk: "/dev/vda"
-    talosImageURL: factory.talos.dev/installer/6b3af3cd9190614d292a3f607b758c0bfdfd6a74b91c25d19fca504506511b73
+    talosImageURL: factory.talos.dev/installer/c68c8884333629a78b939df2c920651ecddd733c41ca9bd0a872ec53dc060d8e
     controlPlane: true
     patches:
       - "@./patches/control-1/amd-gpu.yaml"


### PR DESCRIPTION
Reverts the GECC enablement from #4125. **Already applied to control-1 and verified** — this commit brings git back in line with the node.

## What GECC actually cost

| | before | with GECC |
|---|---|---|
| VRAM total | 34,208,743,424 B (32624 M) | 32,061,259,776 B (30576 M) |
| | | **−2.00 GiB exactly (6.25%)** |

That's the classic 1/16 ECC carve-out. sglang was running at **99.6%** of the old total, so the 27B model no longer fits.

## What it bought — nothing measurable

```
RAS INFO: ras initialized successfully, hardware ability[101] ras_mask[101]
```

Unchanged from before. `101` is DF + UMC; the GFX bit (`0x4`) is still absent, so no `gfx_err_count` node appeared and the GFX core remains as uninstrumented as it was. That was the entire reason for enabling it — to instrument the block suspected in the unexplained reboots. It cannot be instrumented on this SKU.

The `umc_err_count` counters already populated without GECC (`ue: 0 ce: 0 de: 0` throughout).

## This does not disable ECC

Worth being explicit, since the intent was "enable ECC": `amdgpu: MEM ECC is active.` is reported **both with and without** the flag. The memory controller corrects errors regardless. GECC is only the PSP reporting/recovery layer stacked on top — and on this ASIC even its bad-page retirement path is dead code (`umc_v8_14_ras_hw_ops` has no `.query_ras_error_address`).

Final state on the node:

```
amdgpu: MEM ECC is active.
amdgpu: 32624M of VRAM memory ready
amdgpu: GECC is disabled
```

## Why `=0` and not just removing the flag

Dropping the flag left GECC **enabled** — it persists in PSP firmware state once armed, and the driver says so directly: *"To disable GECC, please reboot the system and load the amdgpu driver with the parameter amdgpu_ras_enable=0"*. So the schematic carries an explicit `amdgpu.ras_enable=0`, which is also self-documenting against a future accidental re-enable.

Both directions stage on one boot and apply on the next.

## Operational note worth keeping

Two things bit during this, both worth remembering:

1. **A schematic-only change does not move the Talos version**, so `talosctl upgrade` no-ops in ~0.5 s unless the image ID actually differs — and a plain reboot will not pick up a new cmdline, because the cmdline lives in the UKI that only an install rewrites. tuppr hit this too: it cordoned control-1 at 22:04, no-op'd, and left the node cordoned with jellyfin down.
2. **`searxng` has a PDB with `minAvailable: 1` on a single replica**, so `ALLOWED DISRUPTIONS` is 0 and it can never be evicted. Any drain of the node it lands on will hang until the 5-minute timeout and then fail the upgrade. Worked around with `--drain=false`; the PDB itself is worth fixing separately.

## Schematic IDs

- `dfc849d1…` — original, no RAS flag
- `6b3af3cd…` — `ras_enable=1` (#4125, reverted here)
- `c68c8884…` — `ras_enable=0`, current


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated AMDGPU settings to disable RAS reporting and adjust VRAM allocation behavior.
  * Updated the control-plane node’s Talos installer image to a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->