### PR TITLE
fix(database): force PgBouncer DNS over TCP

### DIFF
--- a/kubernetes/apps/database/cloudnative-pg/cluster/pooler-ro.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/pooler-ro.yaml
@@ -14,6 +14,9 @@ spec:
   # kills request-less pods first) and spread across nodes.
   template:
     spec:
+      dnsConfig:
+        options:
+          - name: use-vc
       containers:
         - name: pgbouncer
           resources:

--- a/kubernetes/apps/database/cloudnative-pg/cluster/pooler-session.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/pooler-session.yaml
@@ -14,6 +14,9 @@ spec:
   # kills request-less pods first) and spread across nodes.
   template:
     spec:
+      dnsConfig:
+        options:
+          - name: use-vc
       containers:
         - name: pgbouncer
           resources:

--- a/kubernetes/apps/database/cloudnative-pg/cluster/pooler.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/pooler.yaml
@@ -17,6 +17,9 @@ spec:
   # traffic on the survivor and can exhaust its PgBouncer wait queue.
   template:
     spec:
+      dnsConfig:
+        options:
+          - name: use-vc
       containers:
         - name: pgbouncer
           resources:


### PR DESCRIPTION
## Summary

- force DNS over TCP in the RW, RO, and session PgBouncer pods
- bypass the c-ares UDP resolver failure that leaves CNPG backend pools unable to resolve `postgres16-rw`
- prevent downstream services such as Memini from surfacing misleading authentication errors when their database is unavailable

## Validation

- `git diff --check`
- `mise exec -- flate test all` — 278 passed
- focused independent review — GO, no findings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DNS resolution reliability for database connection pooling services by enabling TCP-based DNS queries.
  * Updated read-only, session-mode, and standard pooling configurations consistently to reduce potential DNS-related connectivity issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->