### PR TITLE
test(ai): add SGLang decode benchmark harness

### DIFF
--- a/.github/workflows/build-sglang-rdna4-throughput.yaml
+++ b/.github/workflows/build-sglang-rdna4-throughput.yaml
@@ -1,0 +1,80 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: Build sglang-rdna4 throughput candidate
+run-name: Build sglang-rdna4 throughput candidate ${{ inputs.run_token }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      run_token:
+        description: Benchmark build identifier
+        required: true
+        type: string
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  IMAGE: ghcr.io/tanguille/sglang-rdna4
+  TAG: v0.5.15-gfx1201-decode-ab-086-087-${{ inputs.run_token }}
+  FORK_REF: a7e69a2cf9e13fcbf366a18aefbfb7798da4edcb
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Validate run token
+        env:
+          RUN_TOKEN: ${{ inputs.run_token }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${RUN_TOKEN}" || ! "${RUN_TOKEN}" =~ ^[a-z0-9-]{1,94}$ ]]; then
+            echo "run_token must contain only lowercase letters, digits, and dashes, with a maximum of 94 characters" >&2
+            exit 1
+          fi
+
+      - name: Move docker storage to /mnt
+        run: |
+          sudo systemctl stop docker.service docker.socket
+          sudo mkdir -p /mnt/docker
+          # Merge, don't clobber: preserve any other daemon settings the runner image ships.
+          echo "$(sudo jq '. + {"data-root":"/mnt/docker"}' /etc/docker/daemon.json 2>/dev/null || echo '{"data-root":"/mnt/docker"}')" \
+            | sudo tee /etc/docker/daemon.json
+          sudo systemctl start docker.service
+          docker info --format 'docker data root: {{.DockerRootDir}}'
+          df -h /mnt
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Log in to GHCR
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        id: build
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: docker/sglang-rdna4
+          push: true
+          tags: ${{ env.IMAGE }}:${{ env.TAG }}
+          build-args: |
+            FORK_REF=${{ env.FORK_REF }}
+          provenance: false
+          sbom: false
+
+      - name: Summary
+        run: echo "${IMAGE}:${TAG}@${{ steps.build.outputs.digest }}" >> "${GITHUB_STEP_SUMMARY}"

--- a/docs/superpowers/plans/2026-07-22-sglang-single-stream-throughput.md
+++ b/docs/superpowers/plans/2026-07-22-sglang-single-stream-throughput.md
@@ -1,0 +1,569 @@
+# SGLang Single-Stream Decode Throughput Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build and measure an RDNA4 SGLang candidate containing patches 086 and 087 against the current image on the same R9700, without any unapproved restart or production image change.
+
+**Architecture:** A manual-only GitHub Actions workflow builds the candidate under a dedicated experiment tag and reports its authoritative digest. A valid but normally unreferenced Flux manifest defines a `Recreate` benchmark Deployment, Service, and experiment-only Triton-cache PVCs. During an explicitly approved maintenance window, a GitOps commit sets the production `InferenceService` to `replicas: 0` and enables the control benchmark; later GitOps changes recreate it with the candidate. SGLang v0.5.15's native benchmark CLI supplies deterministic fixed-length requests and JSONL metrics. A final GitOps change prunes the benchmark resources and restores production.
+
+**Tech Stack:** Docker Buildx/GHCR, GitHub Actions, FluxCD/Kustomize, Kubernetes, SGLang v0.5.15 `sglang.benchmark.serving`, Bash, JSONL.
+
+---
+
+## File Structure
+
+- Create: `.github/workflows/build-sglang-rdna4-throughput.yaml` — manual-only candidate build with a distinct experiment tag and digest-authoritative output.
+- Create: `kubernetes/apps/ai/llmkube/models/qwen36-27b-decode-ab.yaml` — dormant benchmark Deployment, Service, and two experiment-only Triton PVCs; not referenced by Kustomize outside an approved window.
+- Create: `kubernetes/apps/ai/llmkube/models/run-qwen36-decode-ab.sh` — fixed control/candidate matrix and JSONL validation using SGLang's native CLI.
+- Create: `kubernetes/apps/ai/llmkube/models/test-qwen36-decode-ab.sh` — local Bash/Python static contract test for the runner, runbook, plan, and safety invariants.
+- Create: `kubernetes/apps/ai/llmkube/models/qwen36-27b-decode-ab.md` — exact maintenance, benchmark, result-capture, rollback, and cleanup runbook.
+- Modify temporarily during the approved window: `kubernetes/apps/ai/llmkube/ks.yaml`, `kubernetes/apps/ai/llmkube/models/kustomization.yaml`, and `kubernetes/apps/ai/llmkube/models/qwen36-27b-sglang.yaml`.
+- Modify after measurement: `docs/llm-hosting/sglang-benchmarks.md` — append the exact control/candidate evidence.
+
+### Task 1: Add the manual candidate-image workflow
+
+**Files:**
+- Create: `.github/workflows/build-sglang-rdna4-throughput.yaml`
+
+- [ ] **Step 1: Create the complete manual-only workflow**
+
+```yaml
+---
+name: Build sglang-rdna4 throughput candidate
+run-name: Build sglang-rdna4 throughput candidate ${{ inputs.run_token }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      run_token:
+        description: Benchmark build identifier
+        required: true
+        type: string
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  IMAGE: ghcr.io/tanguille/sglang-rdna4
+  TAG: v0.5.15-gfx1201-decode-ab-086-087-${{ inputs.run_token }}
+  FORK_REF: a7e69a2cf9e13fcbf366a18aefbfb7798da4edcb
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Validate run token
+        env:
+          RUN_TOKEN: ${{ inputs.run_token }}
+        run: |
+          set -euo pipefail
+          [[ "${RUN_TOKEN}" =~ ^[a-z0-9-]{1,94}$ ]]
+
+      - name: Move docker storage to /mnt
+        run: |
+          sudo systemctl stop docker.service docker.socket
+          sudo mkdir -p /mnt/docker
+          echo "$(sudo jq '. + {"data-root":"/mnt/docker"}' /etc/docker/daemon.json 2>/dev/null || echo '{"data-root":"/mnt/docker"}')" \
+            | sudo tee /etc/docker/daemon.json
+          sudo systemctl start docker.service
+          docker info --format 'docker data root: {{.DockerRootDir}}'
+          df -h /mnt
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Log in to GHCR
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push candidate
+        id: build
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: docker/sglang-rdna4
+          push: true
+          tags: ${{ env.IMAGE }}:${{ env.TAG }}
+          build-args: |
+            FORK_REF=${{ env.FORK_REF }}
+          provenance: false
+          sbom: false
+
+      - name: Summary
+        run: echo "Pushed \`${IMAGE}:${TAG}@${{ steps.build.outputs.digest }}\`" >> "${GITHUB_STEP_SUMMARY}"
+```
+
+Do not add a `push` trigger. Fork commit `a7e69a2c...` contains patch 087 and its history includes patch 086. The stable `v0.5.15-gfx1201` tag must not be rebuilt. The existing `Dockerfile:53-57` already exposes `ARG FORK_REF`; do not alter its production default.
+
+- [ ] **Step 2: Validate the workflow and its trigger boundary**
+
+Run:
+
+```bash
+bash .agents/skills/pr-review/scripts/validate-pr.sh
+git diff --check
+python3 - <<'PY'
+from pathlib import Path
+
+workflow = Path(".github/workflows/build-sglang-rdna4-throughput.yaml").read_text()
+assert "workflow_dispatch:" in workflow
+assert "\n  push:" not in workflow
+PY
+```
+
+Expected: all commands exit 0; the candidate workflow contains `workflow_dispatch` and no `push:` event.
+
+- [ ] **Step 3: Commit only after the user requests a checkpoint commit**
+
+```bash
+git add .github/workflows/build-sglang-rdna4-throughput.yaml
+git commit -m "ci(ai): add SGLang throughput candidate build"
+```
+
+### Task 2: Add the dormant GitOps benchmark workload
+
+**Files:**
+- Create: `kubernetes/apps/ai/llmkube/models/qwen36-27b-decode-ab.yaml`
+
+- [ ] **Step 1: Create the complete dormant workload manifest**
+
+```yaml
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: qwen36-27b-decode-ab-control-triton
+  namespace: ai
+spec:
+  accessModes: [ReadWriteOnce]
+  storageClassName: openebs-hostpath
+  resources:
+    requests:
+      storage: 10Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: qwen36-27b-decode-ab-candidate-triton
+  namespace: ai
+spec:
+  accessModes: [ReadWriteOnce]
+  storageClassName: openebs-hostpath
+  resources:
+    requests:
+      storage: 10Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: qwen36-27b-decode-ab
+  namespace: ai
+spec:
+  selector:
+    app.kubernetes.io/name: qwen36-27b-decode-ab
+  ports:
+    - name: http
+      port: 8000
+      targetPort: http
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: qwen36-27b-decode-ab
+  namespace: ai
+spec:
+  replicas: 0
+  revisionHistoryLimit: 0
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: qwen36-27b-decode-ab
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: qwen36-27b-decode-ab
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: control-1
+      securityContext:
+        runAsUser: 0
+        runAsGroup: 0
+        supplementalGroups: [44, 226]
+        seccompProfile:
+          type: Unconfined
+      containers:
+        - name: sglang
+          image: ghcr.io/tanguille/sglang-rdna4:v0.5.15-gfx1201@sha256:3d1561f6a87ce2d61f7c508f6c2f76fd6bbffb094c99d23cb097a89353355bfe
+          command: [python3, -m, sglang.launch_server]
+          args:
+            - --model-path
+            - /models/1bdc22cc0419b237/model.safetensors
+            - --host
+            - 0.0.0.0
+            - --port
+            - "8000"
+            - --enable-metrics
+            - --served-model-name
+            - qwen-3.6
+            - --tp-size
+            - "1"
+            - --context-length
+            - "180000"
+            - --mem-fraction-static
+            - "0.875"
+            - --chunked-prefill-size
+            - "8192"
+            - --max-running-requests
+            - "32"
+            - --quantization
+            - awq
+            - --kv-cache-dtype
+            - fp8_e4m3
+            - --reasoning-parser
+            - qwen3
+            - --dtype
+            - bfloat16
+            - --num-continuous-decode-steps
+            - "16"
+            - --watchdog-timeout
+            - "600"
+            - --attention-backend
+            - triton
+            - --pre-warm-nccl
+            - --trust-remote-code
+            - --chat-template
+            - /opt/rdna4-inference/scripts/qwen3.6_devrole_chat_template.jinja
+            - --tool-call-parser
+            - qwen3_coder
+            - --disable-custom-all-reduce
+            - --disable-overlap-schedule
+            - --cuda-graph-backend-decode=disabled
+            - --cuda-graph-backend-prefill=disabled
+            - --max-mamba-cache-size
+            - "60"
+            - --mamba-ssm-dtype
+            - bfloat16
+            - --max-queued-requests
+            - "32"
+            - --weight-loader-drop-cache-after-load
+            - --enable-hierarchical-cache
+            - --hicache-io-backend
+            - direct
+            - --hicache-ratio
+            - "1.5"
+            - --model-loader-extra-config
+            - '{"num_threads":2}'
+            - --schedule-conservativeness
+            - "0.1"
+            - --enable-mixed-chunk
+            - --hicache-write-policy
+            - write_through_selective
+          env:
+            - {name: HIP_VISIBLE_DEVICES, value: "0"}
+            - {name: ROCR_VISIBLE_DEVICES, value: "0"}
+            - {name: GPU_DEVICE_ORDINAL, value: "0"}
+            - {name: CUDA_VISIBLE_DEVICES, value: "0"}
+            - {name: HF_HUB_OFFLINE, value: "1"}
+            - {name: TRANSFORMERS_OFFLINE, value: "1"}
+            - {name: TRITON_CACHE_DIR, value: /cache/sglang/triton}
+          ports:
+            - name: http
+              containerPort: 8000
+          resources:
+            requests:
+              cpu: "2"
+              memory: 24Gi
+              squat.ai/dri: "1"
+            limits:
+              memory: 24Gi
+              squat.ai/dri: "1"
+          startupProbe:
+            httpGet: {path: /health, port: http}
+            initialDelaySeconds: 60
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 120
+          livenessProbe:
+            exec:
+              command: ["true"]
+            periodSeconds: 3600
+          readinessProbe:
+            tcpSocket: {port: http}
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 6
+          volumeMounts:
+            - {name: model-cache, mountPath: /models, readOnly: true}
+            - {name: triton-cache, mountPath: /cache}
+            - {name: dshm, mountPath: /dev/shm}
+      volumes:
+        - name: model-cache
+          persistentVolumeClaim:
+            claimName: qwen36-27b-model-cache
+            readOnly: true
+        - name: triton-cache
+          persistentVolumeClaim:
+            claimName: qwen36-27b-decode-ab-control-triton
+        - name: dshm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 8Gi
+```
+
+Do not add MTP/EAGLE/speculative flags. Shallow vLLM MTP measurements used a different checkpoint at approximately 420 input tokens; SGLang verification falls to 0.2 tok/s near 188K, so speculation would invalidate and endanger this deep-context kernel A/B. Never mount or clear `qwen36-27b-triton-cache`; it belongs to production.
+
+- [ ] **Step 2: Validate without activating the workload**
+
+Run:
+
+```bash
+mise exec -- kubectl apply --dry-run=client -f kubernetes/apps/ai/llmkube/models/qwen36-27b-decode-ab.yaml
+mise exec -- kustomize build kubernetes/apps/ai/llmkube/models >/tmp/opencode/llmkube-models.yaml
+bash .agents/skills/pr-review/scripts/validate-pr.sh
+git diff --check
+python3 - <<'PY'
+from pathlib import Path
+
+rendered = Path("/tmp/opencode/llmkube-models.yaml").read_text()
+assert "name: qwen36-27b-decode-ab" not in rendered
+PY
+```
+
+Expected: all commands exit 0. The Kustomize output must not contain `qwen36-27b-decode-ab`, proving the dormant manifest is not live.
+
+- [ ] **Step 3: Commit only after the user requests a checkpoint commit**
+
+```bash
+git add kubernetes/apps/ai/llmkube/models/qwen36-27b-decode-ab.yaml
+git commit -m "test(ai): add dormant SGLang decode benchmark"
+```
+
+### Task 3: Add the maintenance and benchmark runbook
+
+**Files:**
+- Create: `kubernetes/apps/ai/llmkube/models/run-qwen36-decode-ab.sh`
+- Create: `kubernetes/apps/ai/llmkube/models/qwen36-27b-decode-ab.md`
+
+- [ ] **Step 1: Document read-only preflight checks**
+
+Require a fresh explicit approval before any push, Flux reconciliation, resource activation, restart, or deletion. The runbook must run its complete read-only preflight in a strict `set -euo pipefail` subshell. It captures production Pod and InferenceService JSON and uses literal `jq -e` assertions for the committed control image, exact generated ordered args, readable cached model, Pod Ready=True, InferenceService Ready/Available, and no Failed/Degraded=True. Only a zero exit permits continuing; any drift aborts before downtime.
+
+The exact runnable subshell block is maintained in
+`kubernetes/apps/ai/llmkube/models/qwen36-27b-decode-ab.md`.
+
+Abort if any assertion fails; only a zero exit permits continuing. No stop proceeds until drift, unhealthy state, or unsafe GPU work is corrected and re-reviewed.
+
+- [ ] **Step 2: Document candidate build and immutable digest capture**
+
+After the workflow is merged and separate push permission is granted, generate a unique UTC `run_token` (lowercase letters/digits/dashes, at most 94 characters) and dispatch the workflow with its required `run-name` and unique run name:
+
+```bash
+set -euo pipefail
+RUN_TOKEN="$(date -u +%Y%m%d-%H%M%S)-$$"
+RUN_NAME="Build sglang-rdna4 throughput candidate $RUN_TOKEN"
+mise exec -- gh workflow run build-sglang-rdna4-throughput.yaml --ref main -f run_token="$RUN_TOKEN"
+RUN_ID=''
+for _ in {1..30}; do
+  MATCHES="$(mise exec -- gh run list --workflow build-sglang-rdna4-throughput.yaml --branch main --event workflow_dispatch --limit 20 --json databaseId,displayTitle | mise exec -- jq -c --arg name "$RUN_NAME" '[.[] | select(.displayTitle == $name)]')"
+  MATCH_COUNT="$(mise exec -- jq -r 'length' <<<"$MATCHES")"
+  case "$MATCH_COUNT" in
+    0) sleep 2 ;;
+    1) RUN_ID="$(mise exec -- jq -r 'if length == 1 then .[0].databaseId else error("expected exactly one workflow match") end' <<<"$MATCHES")"; break ;;
+    *) printf 'error: ambiguous workflow run title (%s matches)\n' "$MATCH_COUNT" >&2; exit 1 ;;
+  esac
+done
+if [[ -z "$RUN_ID" ]]; then
+  printf 'error: workflow run was not found before poll timeout\n' >&2
+  exit 1
+fi
+mise exec -- gh run watch "${RUN_ID}" --exit-status
+CANDIDATE_TAG="v0.5.15-gfx1201-decode-ab-086-087-$RUN_TOKEN"
+CANDIDATE_DIGEST="$(mise exec -- crane digest "ghcr.io/tanguille/sglang-rdna4:$CANDIDATE_TAG")"
+[[ "$CANDIDATE_DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]
+CANDIDATE_IMAGE="ghcr.io/tanguille/sglang-rdna4:$CANDIDATE_TAG@$CANDIDATE_DIGEST"
+```
+
+Record the digest. The digest is authoritative; use the exact `CANDIDATE_IMAGE` in the candidate GitOps change and script invocation. Do not dispatch the stable workflow or update the production image.
+
+- [ ] **Step 3: Document the GitOps maintenance transition to control**
+
+In one reviewed maintenance change:
+
+1. Add `replicas: 0` to the production `InferenceService` spec in `qwen36-27b-sglang.yaml`.
+2. Add `qwen36-27b-decode-ab.yaml` to `models/kustomization.yaml`.
+3. Change the `llmkube-models` Kustomization health check in `kubernetes/apps/ai/llmkube/ks.yaml` from the production InferenceService to the control benchmark Deployment in the same GitOps change.
+4. Change the benchmark Deployment to `replicas: 1` with the control image and control Triton PVC.
+5. Validate, commit, then request explicit push and optional `flux reconcile` approval.
+
+The temporary `healthChecks` entry must be exactly:
+
+```yaml
+healthChecks:
+  - apiVersion: apps/v1
+    kind: Deployment
+    name: qwen36-27b-decode-ab
+    namespace: ai
+```
+
+Keep the existing `healthCheckExprs` entry for `inference.llmkube.dev/v1alpha1` `InferenceService` unchanged. This transition keeps `llmkube-models` and its dependent Kustomizations healthy while production is intentionally `Stopped`.
+
+Wait for production to report `Stopped`, the production pod to disappear, and the benchmark Deployment to become Available. Never use `kubectl scale`, because the operator and Flux own replica state.
+
+- [ ] **Step 4: Add the fixed native benchmark script**
+
+The implementation must provide this interface and safety behavior:
+
+`control` accepts exactly one argument and uses the fixed control image;
+`candidate` accepts exactly two arguments and requires the full dynamic
+`tag@sha256:digest` matching the per-dispatch tag and lowercase digest. Require
+`RUN_LABEL` in `[a-z0-9-]{1,128}` before any cluster call. Before
+benchmarking, fetch all matching pods as JSON and require exactly one
+non-terminating Running/Ready pod with one `sglang` container, exact image,
+command, full ordered benchmark-manifest args, and the arm-specific Triton
+PVC. Install an EXIT trap after argument setup; on success or failure it must
+preserve the original status and best-effort capture current/previous logs, Pod
+YAML/status, describe events, and read-only VRAM evidence. Keep the fixed
+matrix and strict JSONL checks unchanged. Use the compatible `--backend sglang`.
+Each context runs three independent
+one-prompt processes using `--dataset-name random-ids`, `--tokenize-prompt`, the local
+tokenizer, `--random-range-ratio 1`, and seed 42. Validate exact `input_lens`,
+`output_lens`, and errors for every object, then preserve all three raw objects
+and calculate median metrics. The benchmark manifest uses `--tp-size`, not
+unsupported `--tp`.
+
+`179000 + 256` remains below the 180000 context limit. SGLang v0.5.15 ignores EOS by default, so every successful result must contain three 256-token outputs. `jq -e` makes any reported error or short output fail the script.
+
+Validate the argument guard and shell syntax:
+
+```bash
+test "$(bash kubernetes/apps/ai/llmkube/models/run-qwen36-decode-ab.sh 2>&1; printf '%s' "$?")" = "error: invalid arguments
+usage: kubernetes/apps/ai/llmkube/models/run-qwen36-decode-ab.sh control | kubernetes/apps/ai/llmkube/models/run-qwen36-decode-ab.sh candidate tag@sha256:digest
+2"
+mise exec -- shellcheck kubernetes/apps/ai/llmkube/models/run-qwen36-decode-ab.sh
+```
+
+Expected: both commands exit 0.
+
+- [ ] **Step 5: Run the control matrix**
+
+After the benchmark Deployment is Available:
+
+```bash
+RUN_LABEL="${RUN_TOKEN}-control-cold" bash kubernetes/apps/ai/llmkube/models/run-qwen36-decode-ab.sh control
+```
+
+After a fresh approval, change only a Pod-template annotation through reviewed
+GitOps, retain the control image and same control PVC, wait for the replacement
+Pod Ready, and run the warm matrix with
+`RUN_LABEL="${RUN_TOKEN}-control-warm"`. Cold evidence covers startup and an
+empty Triton cache; warm evidence covers the populated same-PVC cache.
+
+- [ ] **Step 6: Document the GitOps transition from control to candidate**
+
+First set the benchmark Deployment to `replicas: 0`, push with approval, and wait for the control pod to disappear. The candidate PVC must be new/empty. In the next reviewed change, set the exact `CANDIDATE_IMAGE`, switch the mount to `qwen36-27b-decode-ab-candidate-triton`, and restore benchmark replicas to 1. This two-step transition prevents a single-GPU rollout deadlock even though the Deployment uses `Recreate`.
+
+Wait for a cold candidate boot, then run:
+
+```bash
+RUN_LABEL="${RUN_TOKEN}-candidate-cold" bash kubernetes/apps/ai/llmkube/models/run-qwen36-decode-ab.sh candidate "${CANDIDATE_IMAGE}"
+```
+
+After a fresh approval, retain the candidate image and same candidate PVC while
+changing only a Pod-template annotation through reviewed GitOps; wait for the
+replacement Pod Ready, then run
+`RUN_LABEL="${RUN_TOKEN}-candidate-warm"` with the same exact image. Never
+clear PVCs in place. All results are run-tokened and each context has three
+independent processes in both cold and warm matrices.
+
+The script guarantees identical flags, seed, lengths, and request counts for both arms. The first boot validates cold Triton compilation; repeated requests in the same pod exercise the warm cache. Do not clear either experiment PVC in place.
+
+- [ ] **Step 7: Document objective comparison gates**
+
+Compare control and candidate TPOT-derived decode tok/s, TTFT, E2E, errors, startup duration, SGLang memory/KV-capacity logs, and `rocm-smi --showmeminfo vram` when that read-only tool exists in the image. The candidate is eligible for a separate promotion decision only if it:
+
+- improves median decode tok/s at 128K or 179K;
+- regresses 2K decode by no more than 5%;
+- completes every request with no OOM, crash, kernel error, or invalid output;
+- retains safe VRAM/KV headroom; and
+- repeats consistently across three fixed-seed requests.
+
+Do not run a KV-split override sweep in the primary A/B. If the default result is promising but inconclusive, plan a separate candidate-only sweep for 32/48/64/96 at 128K and 179K.
+
+- [ ] **Step 8: Document GitOps cleanup and production restoration**
+
+In one reviewed cleanup change, remove `qwen36-27b-decode-ab.yaml` from `models/kustomization.yaml`, restore the original explicit `InferenceService/qwen36-27b` health check in `kubernetes/apps/ai/llmkube/ks.yaml`, and restore production to `replicas: 1` (or remove the temporary replicas field). Obtain explicit permission before the push, Flux reconcile, and pruning of the two experiment PVCs. The restored `healthChecks` entry must be exactly:
+
+```yaml
+healthChecks:
+  - apiVersion: inference.llmkube.dev/v1alpha1
+    kind: InferenceService
+    name: qwen36-27b
+    namespace: ai
+```
+
+Retain the existing `InferenceService` `healthCheckExprs` unchanged. Wait until:
+
+```bash
+mise exec -- kubectl wait --for=jsonpath='{.status.phase}'=Ready inferenceservice/qwen36-27b -n ai --timeout=35m
+mise exec -- kubectl get pods -n ai -l inference.llmkube.dev/service=qwen36-27b
+```
+
+Production must be Ready on its original image before closing the maintenance window. Benchmark results never authorize changing the production image digest.
+
+- [ ] **Step 9: Validate and commit the runbook only when requested**
+
+```bash
+mise exec -- shellcheck kubernetes/apps/ai/llmkube/models/run-qwen36-decode-ab.sh
+bash kubernetes/apps/ai/llmkube/models/test-qwen36-decode-ab.sh
+git diff --check
+```
+
+Then, if requested:
+
+```bash
+git add kubernetes/apps/ai/llmkube/models/qwen36-27b-decode-ab.md kubernetes/apps/ai/llmkube/models/run-qwen36-decode-ab.sh kubernetes/apps/ai/llmkube/models/test-qwen36-decode-ab.sh
+git commit -m "docs(ai): add SGLang decode A/B runbook"
+```
+
+### Task 4: Record measured evidence
+
+**Files:**
+- Modify: `docs/llm-hosting/sglang-benchmarks.md`
+
+- [ ] **Step 1: Append results only after both matrices and restoration finish**
+
+Add a dated section containing control/candidate image digests, fork refs, model revision, cache state, exact input/output lengths, request count, median TPOT-derived decode tok/s, TTFT, E2E, startup duration, memory evidence, and all errors. Do not prefill values or describe an unrun experiment as measured.
+
+- [ ] **Step 2: State the bounded conclusion**
+
+Record whether the claim was established, limited, or refuted. Separate raw decode findings from production latency and aggregate throughput. If gates fail, retain the production image and document the candidate as rejected.
+
+- [ ] **Step 3: Validate and commit only when requested**
+
+```bash
+git diff --check
+```
+
+Then, if requested:
+
+```bash
+git add docs/llm-hosting/sglang-benchmarks.md
+git commit -m "docs(ai): record SGLang decode A/B results"
+```
+
+## Verification Evidence Path
+
+The claim is that patches 086 and 087 improve exact-model raw single-stream decode at deep context. Production traffic cannot establish that claim because prompt composition, cache hits, and concurrent load differ. Sequential control/candidate Deployments on the same GPU, fixed model revision, fixed launch flags, separate cold Triton caches, deterministic native benchmark inputs, and JSONL per-request details provide direct evidence. The maintenance and restoration checks bound operational risk; promotion remains a separate explicitly approved change.

--- a/docs/superpowers/specs/2026-07-22-sglang-single-stream-throughput-design.md
+++ b/docs/superpowers/specs/2026-07-22-sglang-single-stream-throughput-design.md
@@ -1,11 +1,11 @@
 # SGLang Single-Stream Decode Throughput Experiment
 
-**Status:** Draft for review
+**Status:** Approved, amended for a controlled maintenance window
 **Date:** 2026-07-22
 
 ## Goal
 
-Improve raw single-stream decode throughput for Qwen3.6-27B AWQ on the AMD R9700 (gfx1201), while preserving long-context stability and avoiding any production restart or in-place deployment change during the experiment.
+Improve raw single-stream decode throughput for Qwen3.6-27B AWQ on the AMD R9700 (gfx1201), while preserving long-context stability. Preparation must not affect production; the same-GPU A/B runs only in an explicitly approved maintenance window and production is restored afterward.
 
 ## Current Evidence
 
@@ -33,15 +33,24 @@ Profile the remaining AWQ/GDN GEMV path and develop another targeted optimizatio
 
 ## Experiment Design
 
-Run an offline or isolated A/B comparison:
+Run a sequential A/B comparison during an approved maintenance window because the cluster has one R9700:
 
 - **Control:** current production image and launch configuration.
-- **Candidate:** image rebuilt with patches 086 and 087, with the runtime KV-split sweep available if needed.
+- **Candidate:** a per-dispatch image rebuilt with patches 086 and 087, identified only by its unique run-token tag at its captured immutable `tag@sha256:digest`.
+- Stop the native InferenceService through its GitOps-managed `spec.replicas: 0` state before enabling the benchmark Deployment.
+- In the same GitOps transition, temporarily health-check `apps/v1` Deployment `qwen36-27b-decode-ab` instead of `InferenceService/qwen36-27b`, while retaining the existing InferenceService `healthCheckExprs`; restore the original health check before cleanup is complete.
+- Run control and candidate as sequential revisions of a Flux-managed `Recreate` Deployment on the same GPU; never run them concurrently.
+- Before either arm, fail closed unless the benchmark Pod is the single non-terminating Running/Ready Pod with the expected image, exact command and ordered args, and arm-specific Triton PVC; preserve logs, Pod status/description, and VRAM evidence on every exit.
+- Mount the existing model-cache PVC read-only and use experiment-only Triton-cache PVCs.
 - Same Qwen3.6-27B AWQ checkpoint, TP=1, FP8 KV, and model settings.
 - Single-stream concurrency only.
 - Context points: 2K, 32K, 128K, and approximately 180K tokens.
-- Measure both cold and warm Triton-cache conditions.
-- Use repeated runs at each point and report median plus tail behavior.
+- Measure both cold and warm Triton-cache conditions using the same PVC within
+  each arm; cold starts with a newly created PVC and warm follows an approved
+  same-image Pod-template restart.
+- Run three independent one-prompt processes at each context in both cache
+  states, with fixed seed/input/output validation, and report median plus tail
+  behavior while preserving each raw result.
 
 Record:
 
@@ -65,9 +74,13 @@ If the candidate fails these gates, retain the current image and document the me
 
 ## Safety and Scope
 
-- Do not restart, reconcile, or mutate the production SGLang workload as part of this experiment.
-- Do not change the production HelmRelease, image digest, or PVC contents.
-- Use a separate image reference and isolated pod/workload for testing.
+- Building the candidate and validating manifests must not restart, reconcile, or mutate production.
+- The benchmark interface accepts one argument for control and an arm plus full candidate `tag@sha256:digest`; validate all arm-specific state before issuing benchmark requests.
+- Live execution requires explicit approval for the maintenance window, GitOps stop, benchmark resources, cleanup, and production restore.
+- Do not change the production image digest or mutate the model-cache and production Triton-cache PVC contents.
+- Use a separate image reference, isolated Pods, and experiment-only Triton caches.
+- The temporary benchmark health check keeps `llmkube-models` and dependent Kustomizations healthy while production is intentionally `Stopped`; restore the original `InferenceService/qwen36-27b` health check before closing the window.
+- Restore `spec.replicas: 1` through GitOps after cleanup and verify production readiness before closing the window.
 - Promotion, if justified by the gates, is a separate change requiring explicit approval.
 
 ## Expected Outcome

--- a/docs/superpowers/specs/2026-07-22-sglang-single-stream-throughput-design.md
+++ b/docs/superpowers/specs/2026-07-22-sglang-single-stream-throughput-design.md
@@ -1,0 +1,75 @@
+# SGLang Single-Stream Decode Throughput Experiment
+
+**Status:** Draft for review
+**Date:** 2026-07-22
+
+## Goal
+
+Improve raw single-stream decode throughput for Qwen3.6-27B AWQ on the AMD R9700 (gfx1201), while preserving long-context stability and avoiding any production restart or in-place deployment change during the experiment.
+
+## Current Evidence
+
+The current v0.5.15 image already contains the established dense-AWQ GEMV optimizations. Production measurements show substantially improved request latency after the rebuild, but no decode-throughput improvement:
+
+- Six-hour mean TTFT: 93.5s → 18.1s.
+- Six-hour mean E2E latency: 261.9s → 64.3s.
+- Six-hour median decode: 16.61 → 13.26 tok/s.
+
+Historical controlled results indicate approximately 16 tok/s single-stream decode on the current configuration. FP8 KV is retained because prior testing was faster than bf16 KV. HiCache and prefix reuse are capacity/latency features, not expected raw decode multipliers.
+
+## Options Considered
+
+### 1. Isolated kernel rebuild with patches 086 and 087 — recommended
+
+Patch 086 changes AMD flash-decode KV-split behavior; patch 087 improves bf16 PV accumulation. Fork reports suggest the largest potential benefit at very long context, but those results were on a different model and are not evidence for Qwen3.6-27B. This option requires a separately built image and test pod, but does not require changing production.
+
+### 2. Runtime KV-split sweep
+
+Benchmark `SGLANG_KV_SPLITS_OVERRIDE` values 32, 48, 64, and 96 using the existing image. This is a lower-risk baseline and can identify whether occupancy is the limiting factor, but it may require a test pod and is unlikely to match a kernel-level improvement.
+
+### 3. Further kernel profiling
+
+Profile the remaining AWQ/GDN GEMV path and develop another targeted optimization. This has the highest effort and uncertainty, so it is deferred until options 1 and 2 establish whether flash-decode occupancy is the bottleneck.
+
+## Experiment Design
+
+Run an offline or isolated A/B comparison:
+
+- **Control:** current production image and launch configuration.
+- **Candidate:** image rebuilt with patches 086 and 087, with the runtime KV-split sweep available if needed.
+- Same Qwen3.6-27B AWQ checkpoint, TP=1, FP8 KV, and model settings.
+- Single-stream concurrency only.
+- Context points: 2K, 32K, 128K, and approximately 180K tokens.
+- Measure both cold and warm Triton-cache conditions.
+- Use repeated runs at each point and report median plus tail behavior.
+
+Record:
+
+1. Decode tok/s, with context length and generated-token count.
+2. TTFT and end-to-end latency.
+3. VRAM usage and memory headroom.
+4. Correctness/output validity.
+5. OOMs, crashes, kernel errors, and cache compilation failures.
+
+## Promotion Gates
+
+The candidate is not eligible for production consideration unless it:
+
+- Improves decode tok/s at the target long-context range on the exact production model.
+- Does not regress short-context decode materially.
+- Completes all test points without OOM, crash, or correctness failure.
+- Does not consume unsafe VRAM headroom.
+- Has reproducible results across repeated runs and both cache states.
+
+If the candidate fails these gates, retain the current image and document the measured result. Do not infer benefit from results on another model.
+
+## Safety and Scope
+
+- Do not restart, reconcile, or mutate the production SGLang workload as part of this experiment.
+- Do not change the production HelmRelease, image digest, or PVC contents.
+- Use a separate image reference and isolated pod/workload for testing.
+- Promotion, if justified by the gates, is a separate change requiring explicit approval.
+
+## Expected Outcome
+
+The experiment should determine whether the remaining decode limit is primarily flash-decode occupancy or model-specific AWQ/GDN compute. It is not intended to optimize aggregate concurrency, prefix-cache hit rate, or prefill throughput.

--- a/kubernetes/apps/ai/llmkube/models/qwen36-27b-decode-ab.md
+++ b/kubernetes/apps/ai/llmkube/models/qwen36-27b-decode-ab.md
@@ -1,0 +1,215 @@
+# Qwen3.6 decode A/B runbook
+
+## Purpose and safety
+
+This compares control and candidate SGLang RDNA4 images at fixed single-stream
+context lengths. It causes approved downtime on the only R9700. Every push,
+Flux reconcile, resource activation, restart, or deletion requires fresh
+explicit approval. No production image change is authorized.
+
+The cluster is GitOps-owned: do not use direct `kubectl scale` or `kubectl
+apply`. All live changes below mean reviewed repository changes followed by
+separately approved push and Flux reconciliation.
+
+## Prerequisites and preflight
+
+Confirm the worktree contains only reviewed task changes and that the following
+read-only checks are safe. These checks capture the production Pod and
+InferenceService JSON, then fail closed on any image, generated-argument, or
+health drift:
+
+```bash
+( set -euo pipefail
+  PROD_PODS_JSON="$(mise exec -- kubectl get pods -n ai -l inference.llmkube.dev/service=qwen36-27b -o json)"
+  PROD_POD="$(mise exec -- jq -er '
+    [.items[] | select(.metadata.deletionTimestamp == null)]
+    | if length != 1 then error("expected exactly one non-terminating production pod")
+      elif .[0].status.phase != "Running" then error("production pod is not Running")
+      elif (any(.[0].status.conditions[]?; .type == "Ready" and .status == "True") | not) then error("production pod is not Ready")
+      else .[0].metadata.name end
+  ' <<<"$PROD_PODS_JSON")"
+  PROD_POD_JSON="$(mise exec -- kubectl get pod "$PROD_POD" -n ai -o json)"
+  IS_JSON="$(mise exec -- kubectl get inferenceservice qwen36-27b -n ai -o json)"
+  EXPECTED_IMAGE='ghcr.io/tanguille/sglang-rdna4:v0.5.15-gfx1201@sha256:3d1561f6a87ce2d61f7c508f6c2f76fd6bbffb094c99d23cb097a89353355bfe'
+  EXPECTED_ARGS='["--model-path","/models/1bdc22cc0419b237/model.safetensors","--host","::","--port","30000","--enable-metrics","--context-length","180000","--mem-fraction-static","0.875","--max-running-requests","32","--chunked-prefill-size","8192","--tp-size","1","--quantization","awq","--kv-cache-dtype","fp8_e4m3","--reasoning-parser","qwen3","--dtype","bfloat16","--num-continuous-decode-steps","16","--watchdog-timeout","600","--attention-backend","triton","--pre-warm-nccl","--trust-remote-code","--chat-template","/opt/rdna4-inference/scripts/qwen3.6_devrole_chat_template.jinja","--tool-call-parser","qwen3_coder","--disable-custom-all-reduce","--disable-overlap-schedule","--cuda-graph-backend-decode=disabled","--cuda-graph-backend-prefill=disabled","--max-mamba-cache-size","60","--served-model-name","qwen-3.6","--mamba-ssm-dtype","bfloat16","--max-queued-requests","32","--weight-loader-drop-cache-after-load","--enable-hierarchical-cache","--hicache-io-backend","direct","--hicache-ratio","1.5","--model-loader-extra-config","{\"num_threads\":2}","--schedule-conservativeness","0.1","--enable-mixed-chunk","--hicache-write-policy","write_through_selective","--host","0.0.0.0"]'
+
+  mise exec -- jq -e --arg expected "$EXPECTED_IMAGE" \
+    '.spec.containers | length == 1 and .[0].image == $expected' <<<"$PROD_POD_JSON" >/dev/null
+  mise exec -- jq -e --argjson expected "$EXPECTED_ARGS" \
+    '.spec.containers | length == 1 and .[0].args == $expected' <<<"$PROD_POD_JSON" >/dev/null
+  mise exec -- jq -e \
+    'any(.status.conditions[]?; .type == "Ready" and .status == "True")' <<<"$PROD_POD_JSON" >/dev/null
+  mise exec -- jq -e \
+    '.status.phase == "Ready"
+     and any(.status.conditions[]?; .type == "Available" and .status == "True")
+     and all(.status.conditions[]?; ((.type == "Failed" or .type == "Degraded") and .status == "True") | not)' \
+    <<<"$IS_JSON" >/dev/null
+  mise exec -- kubectl exec -n ai "$PROD_POD" -- test -r /models/1bdc22cc0419b237/model.safetensors
+  for pvc in qwen36-27b-decode-ab-control-triton qwen36-27b-decode-ab-candidate-triton; do
+    PVC_NAME="$(mise exec -- kubectl get pvc -n ai "$pvc" --ignore-not-found -o name)"
+    if [[ -n "$PVC_NAME" ]]; then
+      printf 'error: experiment PVC already exists: %s\n' "$pvc" >&2
+      exit 1
+    fi
+  done
+)
+```
+
+The production preflight requires exactly one non-terminating pod in phase Running with Ready=True before extracting its name.
+
+Every assertion aborts the maintenance procedure on missing or unexpected
+production pod/model, image or exact argument drift, a Pod without Ready=True,
+an InferenceService that is not Ready/Available, Failed or Degraded=True, or
+unsafe GPU/memory state. No stop proceeds until the drift or unhealthy state is
+corrected and re-reviewed. Record the read-only evidence before requesting
+approval. Only a zero exit from this complete subshell permits continuing to the
+maintenance transition.
+
+## Build the candidate
+
+After the workflow is merged and a push is approved, generate a unique UTC
+token and dispatch the manual workflow with its required run name and input:
+
+```bash
+set -euo pipefail
+RUN_TOKEN="$(date -u +%Y%m%d-%H%M%S)-$$"
+RUN_NAME="Build sglang-rdna4 throughput candidate $RUN_TOKEN"
+mise exec -- gh workflow run build-sglang-rdna4-throughput.yaml --ref main -f run_token="$RUN_TOKEN"
+RUN_ID=''
+for _ in {1..30}; do
+  MATCHES="$(mise exec -- gh run list --workflow build-sglang-rdna4-throughput.yaml --branch main --event workflow_dispatch --limit 20 --json databaseId,displayTitle | mise exec -- jq -c --arg name "$RUN_NAME" '[.[] | select(.displayTitle == $name)]')"
+  MATCH_COUNT="$(mise exec -- jq -r 'length' <<<"$MATCHES")"
+  case "$MATCH_COUNT" in
+    0) sleep 2 ;;
+    1) RUN_ID="$(mise exec -- jq -r 'if length == 1 then .[0].databaseId else error("expected exactly one workflow match") end' <<<"$MATCHES")"; break ;;
+    *) printf 'error: ambiguous workflow run title (%s matches)\n' "$MATCH_COUNT" >&2; exit 1 ;;
+  esac
+done
+if [[ -z "$RUN_ID" ]]; then
+  printf 'error: workflow run was not found before poll timeout\n' >&2
+  exit 1
+fi
+mise exec -- gh run watch "$RUN_ID" --exit-status
+CANDIDATE_TAG="v0.5.15-gfx1201-decode-ab-086-087-$RUN_TOKEN"
+CANDIDATE_DIGEST="$(mise exec -- crane digest "ghcr.io/tanguille/sglang-rdna4:$CANDIDATE_TAG")"
+[[ "$CANDIDATE_DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]
+CANDIDATE_IMAGE="ghcr.io/tanguille/sglang-rdna4:$CANDIDATE_TAG@$CANDIDATE_DIGEST"
+printf '%s\n' "$CANDIDATE_IMAGE"
+```
+
+The exact unique display title is polled on `main`; an unqualified latest run
+is never accepted. The bounded poll must find the exact `RUN_ID`, and the
+captured digest is authoritative. Use the resulting `CANDIDATE_IMAGE` in the
+candidate GitOps change and script invocation; never use a tag without its
+captured digest.
+
+## Maintenance transition and control
+
+Use reviewed GitOps changes, in order:
+
+1. Set production `InferenceService` `replicas: 0`.
+2. Add `qwen36-27b-decode-ab.yaml` to `models/kustomization.yaml`.
+3. Set benchmark Deployment `replicas: 1`, using the control image and control
+   Triton claim.
+4. Temporarily change `kubernetes/apps/ai/llmkube/ks.yaml` explicit
+   `healthChecks` to:
+
+   ```yaml
+   healthChecks:
+     - apiVersion: apps/v1
+       kind: Deployment
+       name: qwen36-27b-decode-ab
+       namespace: ai
+   ```
+
+   Retain the existing `InferenceService` `healthCheckExprs` unchanged. This
+   prevents llmkube-models, litellm, and memini Flux blockage while production
+   is intentionally stopped.
+
+Validate before commit; request push/reconcile approval; wait for production
+Stopped and its pod gone, and benchmark Available. The fresh control PVC must
+be created by this transition. Then run the cold control matrix with the
+workflow token:
+
+```bash
+RUN_LABEL="${RUN_TOKEN}-control-cold" bash kubernetes/apps/ai/llmkube/models/run-qwen36-decode-ab.sh control
+```
+
+Results, summaries, server logs, and best-effort VRAM evidence are under the
+run-tokened `/tmp/opencode/sglang-decode-ab/${RUN_TOKEN}-control-cold/control/`.
+
+For the warm control matrix, obtain fresh approval for a reviewed GitOps
+Recreate restart by changing only a Pod-template annotation while retaining
+the control image and the same control PVC. Wait for the replacement Pod to be
+Running/Ready, then run:
+
+```bash
+RUN_LABEL="${RUN_TOKEN}-control-warm" bash kubernetes/apps/ai/llmkube/models/run-qwen36-decode-ab.sh control
+```
+
+The cold run proves startup and empty Triton-cache behavior; the warm run
+measures the populated same-PVC cache. Never clear a PVC in place.
+
+## Candidate transition and run
+
+Use reviewed GitOps changes to set benchmark replicas to `0`; obtain approved
+push/reconcile and wait for the pod to disappear. The candidate PVC must be
+empty/new. In the next reviewed change, set the benchmark image to the exact
+captured `$CANDIDATE_IMAGE`, switch to the candidate Triton claim, and set
+replicas to `1`. Wait for cold boot, then run with that exact image:
+
+```bash
+RUN_LABEL="${RUN_TOKEN}-candidate-cold" bash kubernetes/apps/ai/llmkube/models/run-qwen36-decode-ab.sh candidate "$CANDIDATE_IMAGE"
+```
+
+For the warm candidate matrix, obtain fresh approval for the same reviewed
+GitOps Pod-template annotation restart while retaining the candidate image and
+the same candidate PVC. Wait for the replacement Pod to be Running/Ready, then
+run:
+
+```bash
+RUN_LABEL="${RUN_TOKEN}-candidate-warm" bash kubernetes/apps/ai/llmkube/models/run-qwen36-decode-ab.sh candidate "$CANDIDATE_IMAGE"
+```
+
+No KV split override belongs in the primary A/B. Do not add speculative, MTP,
+or EAGLE flags. The script accepts exactly one argument for control and the arm
+plus full `tag@sha256:digest` for candidate; it validates the image, pod,
+container, command, ordered args, and arm-specific Triton PVC before running.
+It always preserves the benchmark exit status while best-effort capturing
+current/previous logs, Pod YAML/status, describe output, and VRAM evidence.
+Each context uses three independent one-prompt processes with seed 42, and
+each run label keeps raw JSONL and summaries from overwriting other matrices.
+The runner uses offline `--dataset-name random-ids` with `--tokenize-prompt`, the local
+tokenizer, `--random-range-ratio 1`, and validates exact `input_lens` as well
+as output lengths and errors.
+
+## Comparison gates
+
+Compare TPOT-derived decode TPS, TTFT, E2E latency, output throughput, startup
+duration/logs, SGLang memory/KV-capacity logs, and
+`rocm-smi --showmeminfo vram` evidence. Candidate must improve median decode
+TPS at 128K or 179K, have no more than a 5% 2K regression, and have no errors,
+OOM, crash, kernel, or invalid-output failures. Require safe memory/KV
+headroom and consistent three fixed-seed outputs.
+
+Results do not authorize promotion; document them later in
+`docs/llm-hosting/sglang-benchmarks.md`.
+
+## Cleanup and rollback
+
+Through reviewed GitOps, remove the benchmark reference, restore production
+replicas to `1` (or remove the temporary field), and restore the original
+explicit health check exactly:
+
+```yaml
+healthChecks:
+  - apiVersion: inference.llmkube.dev/v1alpha1
+    kind: InferenceService
+    name: qwen36-27b
+    namespace: ai
+```
+
+Keep `healthCheckExprs` unchanged. Obtain explicit push/reconcile/PVC prune
+approval. Verify production is Ready on the original image before closing the
+window. Never delete or restart resources directly; if unsafe, use reviewed
+GitOps to transition back to control and then restore production.

--- a/kubernetes/apps/ai/llmkube/models/qwen36-27b-decode-ab.yaml
+++ b/kubernetes/apps/ai/llmkube/models/qwen36-27b-decode-ab.yaml
@@ -1,0 +1,205 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: qwen36-27b-decode-ab-control-triton
+  namespace: ai
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: openebs-hostpath
+  resources:
+    requests:
+      storage: 10Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: qwen36-27b-decode-ab-candidate-triton
+  namespace: ai
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: openebs-hostpath
+  resources:
+    requests:
+      storage: 10Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: qwen36-27b-decode-ab
+  namespace: ai
+spec:
+  selector:
+    app.kubernetes.io/name: qwen36-27b-decode-ab
+  ports:
+    - name: http
+      port: 8000
+      targetPort: http
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: qwen36-27b-decode-ab
+  namespace: ai
+  labels:
+    app.kubernetes.io/name: qwen36-27b-decode-ab
+spec:
+  replicas: 0
+  revisionHistoryLimit: 0
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: qwen36-27b-decode-ab
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: qwen36-27b-decode-ab
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: control-1
+      securityContext:
+        runAsUser: 0
+        runAsGroup: 0
+        supplementalGroups:
+          - 44
+          - 226
+        seccompProfile:
+          type: Unconfined
+      containers:
+        - name: sglang
+          image: ghcr.io/tanguille/sglang-rdna4:v0.5.15-gfx1201@sha256:3d1561f6a87ce2d61f7c508f6c2f76fd6bbffb094c99d23cb097a89353355bfe
+          command:
+            - python3
+            - -m
+            - sglang.launch_server
+          args:
+            - --model-path
+            - /models/1bdc22cc0419b237/model.safetensors
+            - --host
+            - 0.0.0.0
+            - --port
+            - "8000"
+            - --enable-metrics
+            - --served-model-name
+            - qwen-3.6
+            - --tp-size
+            - "1"
+            - --context-length
+            - "180000"
+            - --mem-fraction-static
+            - "0.875"
+            - --chunked-prefill-size
+            - "8192"
+            - --max-running-requests
+            - "32"
+            - --quantization
+            - awq
+            - --kv-cache-dtype
+            - fp8_e4m3
+            - --reasoning-parser
+            - qwen3
+            - --dtype
+            - bfloat16
+            - --num-continuous-decode-steps
+            - "16"
+            - --watchdog-timeout
+            - "600"
+            - --attention-backend
+            - triton
+            - --pre-warm-nccl
+            - --trust-remote-code
+            - --chat-template
+            - /opt/rdna4-inference/scripts/qwen3.6_devrole_chat_template.jinja
+            - --tool-call-parser
+            - qwen3_coder
+            - --disable-custom-all-reduce
+            - --disable-overlap-schedule
+            - --cuda-graph-backend-decode=disabled
+            - --cuda-graph-backend-prefill=disabled
+            - --max-mamba-cache-size
+            - "60"
+            - --mamba-ssm-dtype
+            - bfloat16
+            - --max-queued-requests
+            - "32"
+            - --weight-loader-drop-cache-after-load
+            - --enable-hierarchical-cache
+            - --hicache-io-backend
+            - direct
+            - --hicache-ratio
+            - "1.5"
+            - --model-loader-extra-config
+            - '{"num_threads":2}'
+            - --schedule-conservativeness
+            - "0.1"
+            - --enable-mixed-chunk
+            - --hicache-write-policy
+            - write_through_selective
+          env:
+            - name: HIP_VISIBLE_DEVICES
+              value: "0"
+            - name: ROCR_VISIBLE_DEVICES
+              value: "0"
+            - name: GPU_DEVICE_ORDINAL
+              value: "0"
+            - name: CUDA_VISIBLE_DEVICES
+              value: "0"
+            - name: HF_HUB_OFFLINE
+              value: "1"
+            - name: TRANSFORMERS_OFFLINE
+              value: "1"
+            - name: TRITON_CACHE_DIR
+              value: /cache/sglang/triton
+          ports:
+            - name: http
+              containerPort: 8000
+          resources:
+            requests:
+              cpu: "2"
+              memory: 24Gi
+              squat.ai/dri: "1"
+            limits:
+              memory: 24Gi
+              squat.ai/dri: "1"
+          startupProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 60
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 120
+          livenessProbe:
+            exec:
+              command:
+                - "true"
+            periodSeconds: 3600
+          readinessProbe:
+            tcpSocket:
+              port: http
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 6
+          volumeMounts:
+            - name: model-cache
+              mountPath: /models
+              readOnly: true
+            - name: triton-cache
+              mountPath: /cache
+            - name: dshm
+              mountPath: /dev/shm
+      volumes:
+        - name: model-cache
+          persistentVolumeClaim:
+            claimName: qwen36-27b-model-cache
+            readOnly: true
+        - name: triton-cache
+          persistentVolumeClaim:
+            claimName: qwen36-27b-decode-ab-control-triton
+        - name: dshm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 8Gi

--- a/kubernetes/apps/ai/llmkube/models/run-qwen36-decode-ab.sh
+++ b/kubernetes/apps/ai/llmkube/models/run-qwen36-decode-ab.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CONTROL_IMAGE='ghcr.io/tanguille/sglang-rdna4:v0.5.15-gfx1201@sha256:3d1561f6a87ce2d61f7c508f6c2f76fd6bbffb094c99d23cb097a89353355bfe'
+CANDIDATE_IMAGE_RE='^ghcr\.io/tanguille/sglang-rdna4:v0\.5\.15-gfx1201-decode-ab-086-087-[a-z0-9-]{1,94}@sha256:[0-9a-f]{64}$'
+EXPECTED_ARGS='["--model-path","/models/1bdc22cc0419b237/model.safetensors","--host","0.0.0.0","--port","8000","--enable-metrics","--served-model-name","qwen-3.6","--tp-size","1","--context-length","180000","--mem-fraction-static","0.875","--chunked-prefill-size","8192","--max-running-requests","32","--quantization","awq","--kv-cache-dtype","fp8_e4m3","--reasoning-parser","qwen3","--dtype","bfloat16","--num-continuous-decode-steps","16","--watchdog-timeout","600","--attention-backend","triton","--pre-warm-nccl","--trust-remote-code","--chat-template","/opt/rdna4-inference/scripts/qwen3.6_devrole_chat_template.jinja","--tool-call-parser","qwen3_coder","--disable-custom-all-reduce","--disable-overlap-schedule","--cuda-graph-backend-decode=disabled","--cuda-graph-backend-prefill=disabled","--max-mamba-cache-size","60","--mamba-ssm-dtype","bfloat16","--max-queued-requests","32","--weight-loader-drop-cache-after-load","--enable-hierarchical-cache","--hicache-io-backend","direct","--hicache-ratio","1.5","--model-loader-extra-config","{\"num_threads\":2}","--schedule-conservativeness","0.1","--enable-mixed-chunk","--hicache-write-policy","write_through_selective"]'
+
+usage() {
+  printf 'usage: %s control | %s candidate tag@sha256:digest\n' "$0" "$0" >&2
+}
+
+if [[ $# -eq 1 && $1 == control ]]; then
+  ARM=control
+  EXPECTED_IMAGE=$CONTROL_IMAGE
+elif [[ $# -eq 2 && $1 == candidate ]]; then
+  ARM=candidate
+  EXPECTED_IMAGE=$2
+  if [[ ! $EXPECTED_IMAGE =~ $CANDIDATE_IMAGE_RE ]]; then
+    printf 'error: invalid candidate image\n' >&2
+    usage
+    exit 2
+  fi
+else
+  printf 'error: invalid arguments\n' >&2
+  usage
+  exit 2
+fi
+
+if [[ -z ${RUN_LABEL:-} || ! $RUN_LABEL =~ ^[a-z0-9-]{1,128}$ ]]; then
+  printf 'error: RUN_LABEL must match [a-z0-9-]{1,128}\n' >&2
+  exit 2
+fi
+
+EXPECTED_CLAIM="qwen36-27b-decode-ab-${ARM}-triton"
+RESULT_PARENT="/tmp/opencode/sglang-decode-ab/$RUN_LABEL"
+RESULT_DIR="$RESULT_PARENT/$ARM"
+POD=''
+PODS_JSON=''
+
+capture_evidence() {
+  local status=$?
+  set +e
+  if [[ -n $PODS_JSON ]]; then
+    printf '%s\n' "$PODS_JSON" >"$RESULT_DIR/pod-selection.json"
+  fi
+  if [[ -n $POD ]]; then
+    mise exec -- kubectl logs -n ai "$POD" -c sglang >"$RESULT_DIR/server.log" 2>&1
+    mise exec -- kubectl logs -n ai "$POD" -c sglang --previous >"$RESULT_DIR/server-previous.log" 2>&1
+    mise exec -- kubectl get pod -n ai "$POD" -o yaml >"$RESULT_DIR/pod.yaml" 2>&1
+    mise exec -- kubectl get pod -n ai "$POD" -o json | mise exec -- jq '.status' >"$RESULT_DIR/pod-status.json" 2>&1
+    mise exec -- kubectl describe pod -n ai "$POD" >"$RESULT_DIR/pod-describe.txt" 2>&1
+    mise exec -- kubectl exec -n ai "$POD" -c sglang -- sh -c \
+      'if command -v rocm-smi >/dev/null 2>&1; then rocm-smi --showmeminfo vram; else printf "%s\n" "rocm-smi unavailable"; fi' \
+      >"$RESULT_DIR/rocm-smi-vram.txt" 2>&1
+  fi
+  exit "$status"
+}
+trap capture_evidence EXIT
+
+mkdir -p "$RESULT_PARENT"
+if ! mkdir "$RESULT_DIR"; then
+  printf 'error: result directory already exists: %s\n' "$RESULT_DIR" >&2
+  exit 1
+fi
+PODS_JSON="$(mise exec -- kubectl get pods -n ai -l app.kubernetes.io/name=qwen36-27b-decode-ab -o json)"
+POD="$(mise exec -- jq -er '[.items[] | select(.metadata.deletionTimestamp == null)] | if length == 1 then .[0].metadata.name else empty end' <<<"$PODS_JSON")"
+mise exec -- jq -e --arg pod "$POD" --arg expected_image "$EXPECTED_IMAGE" --arg expected_claim "$EXPECTED_CLAIM" --argjson expected_args "$EXPECTED_ARGS" '
+  [.items[] | select(.metadata.name == $pod)] as $selected
+  | if ($selected | length) != 1 then error("selected benchmark pod disappeared") else $selected[0] end
+  | if .status.phase != "Running" then error("benchmark pod is not Running") else . end
+  | if (any(.status.conditions[]?; .type == "Ready" and .status == "True") | not) then error("benchmark pod is not Ready") else . end
+  | if (.spec.containers | length) != 1 or .spec.containers[0].name != "sglang" then error("expected exactly one sglang container") else . end
+  | if .spec.containers[0].image != $expected_image then error("unexpected benchmark image") else . end
+  | if .spec.containers[0].command != ["python3", "-m", "sglang.launch_server"] then error("unexpected benchmark command") else . end
+  | if .spec.containers[0].args != $expected_args then error("unexpected benchmark args") else . end
+  | if ([.spec.volumes[]? | select(.name == "triton-cache") | .persistentVolumeClaim.claimName] != [$expected_claim]) then error("unexpected Triton PVC") else . end
+' <<<"$PODS_JSON" >/dev/null
+
+while IFS=: read -r LABEL INPUT_LEN; do
+  RAW_FILES=()
+  for REPEAT in 1 2 3; do
+    REMOTE_RESULT="/tmp/$RUN_LABEL-$ARM-$LABEL-r$REPEAT.jsonl"
+    LOCAL_RESULT="$RESULT_DIR/$LABEL.repeat-$REPEAT.jsonl"
+    RAW_FILES+=("$LOCAL_RESULT")
+
+    mise exec -- kubectl exec -n ai "$POD" -c sglang -- rm -f "$REMOTE_RESULT"
+    mise exec -- kubectl exec -n ai "$POD" -c sglang -- \
+      python3 -m sglang.benchmark.serving \
+      --backend sglang \
+      --base-url http://127.0.0.1:8000 \
+      --model qwen-3.6 \
+      --dataset-name random-ids \
+      --tokenize-prompt \
+      --tokenizer /models/1bdc22cc0419b237 \
+      --num-prompts 1 \
+      --random-input-len "$INPUT_LEN" \
+      --random-output-len 256 \
+      --random-range-ratio 1 \
+      --max-concurrency 1 \
+      --request-rate inf \
+      --seed 42 \
+      --temperature 0 \
+      --top-p 1 \
+      --cache-report \
+      --output-details \
+      --output-file "$REMOTE_RESULT"
+    mise exec -- kubectl cp "ai/$POD:$REMOTE_RESULT" "$LOCAL_RESULT"
+    mise exec -- jq -e -s --argjson input_len "$INPUT_LEN" '
+      if length != 1 then error("expected one benchmark result") else .[0] end
+      | if .input_lens != [$input_len] then error("unexpected input length") else . end
+      | if .output_lens != [256] then error("unexpected output length") else . end
+      | if any(.errors[]; . != null and . != "") then error("benchmark request failed") else . end
+    ' "$LOCAL_RESULT" >/dev/null
+  done
+
+  mise exec -- jq -e -s '
+    if length != 3 then error("expected three benchmark repeats") else . end
+    | {
+        median_decode_tps: (1000 / (sort_by(.median_tpot_ms)[1].median_tpot_ms)),
+        median_tpot_ms: sort_by(.median_tpot_ms)[1].median_tpot_ms,
+        median_ttft_ms: sort_by(.median_ttft_ms)[1].median_ttft_ms,
+        median_e2e_latency_ms: sort_by(.median_e2e_latency_ms)[1].median_e2e_latency_ms,
+        output_throughput: sort_by(.output_throughput)[1].output_throughput,
+        input_lens: map(.input_lens),
+        output_lens: map(.output_lens),
+        errors: map(.errors),
+        raw_results: .
+      }
+  ' "${RAW_FILES[@]}" > "$RESULT_DIR/$LABEL.summary.json"
+done <<'CASES'
+2k:2048
+32k:32000
+128k:128000
+179k:179000
+CASES
+
+printf 'results: %s\n' "$RESULT_DIR"

--- a/kubernetes/apps/ai/llmkube/models/test-qwen36-decode-ab.sh
+++ b/kubernetes/apps/ai/llmkube/models/test-qwen36-decode-ab.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+WORKTREE=$(CDPATH= cd -- "$SCRIPT_DIR/../../../../../" && pwd)
+python3 - "$WORKTREE" <<'PY'
+from pathlib import Path
+import re
+import sys
+
+root = Path(sys.argv[1])
+script = (root / "kubernetes/apps/ai/llmkube/models/run-qwen36-decode-ab.sh").read_text()
+runbook = (root / "kubernetes/apps/ai/llmkube/models/qwen36-27b-decode-ab.md").read_text()
+plan = (root / "docs/superpowers/plans/2026-07-22-sglang-single-stream-throughput.md").read_text()
+spec = (root / "docs/superpowers/specs/2026-07-22-sglang-single-stream-throughput-design.md").read_text()
+workflow = (root / ".github/workflows/build-sglang-rdna4-throughput.yaml").read_text()
+manifest = (root / "kubernetes/apps/ai/llmkube/models/qwen36-27b-decode-ab.yaml").read_text()
+failures = []
+
+def require(condition, name):
+    if not condition:
+        failures.append(name)
+
+require("jq -e" in script and re.search(r"jq\s+-e[r]", script), "raw jq pod-name extraction")
+require("--dataset-name random-ids" in script, "random-ids dataset")
+require("--backend sglang" in script and "--backend sglang-oai" not in script, "compatible sglang backend")
+require("--tokenize-prompt" in script, "tokenize-prompt")
+require("--tokenizer" in script and "/models/1bdc22cc0419b237" in script, "local tokenizer")
+require("--random-range-ratio 1" in script, "random range ratio 1")
+require(not re.search(r"--dataset-name\s+random(?:\s|[\"'])", script), "no random dataset")
+require("--random-range-ratio 0" not in script, "no ratio zero")
+require("input_lens" in script and "INPUT_LEN" in script, "input length validation")
+require("--num-prompts 1" in script, "one prompt per process")
+require(len(re.findall(r"repeat|REPEAT", script)) >= 2, "three independent repeats")
+require("RUN_LABEL" in script and "RUN_LABEL" in runbook, "run-tokened results")
+require(bool(re.search(r"RUN_LABEL =~ \^\[a-z0-9-\]\{1,128\}\$", script)), "exact 128-character run label regex")
+require("mkdir \"$RESULT_DIR\"" in script and "mkdir -p \"$RESULT_DIR\"" not in script, "result directory reuse rejection")
+require("pod-selection.json" in script and "PODS_JSON" in script, "selection evidence before validation")
+require("non-terminating" in runbook and "phase Running" in runbook and "Ready=True" in runbook, "strict production pod preflight")
+require(all(term in runbook for term in ("control-cold", "control-warm", "candidate-cold", "candidate-warm")), "cold and warm runbook labels")
+require("same PVC" in runbook or "same-PVC" in runbook, "same PVC warm restart")
+require("RUN_TOKEN" in plan and "run-name" in plan and "CANDIDATE_TAG" in plan, "dynamic workflow plan")
+require("--tp-size" in plan and not re.search(r"--tp(?:\s|[\"'=])", plan), "supported tp-size plan sample")
+require("run_token:" in workflow and "run-name: Build sglang-rdna4 throughput candidate ${{ inputs.run_token }}" in workflow, "actual workflow run token and name")
+require("TAG: v0.5.15-gfx1201-decode-ab-086-087-${{ inputs.run_token }}" in workflow and "\n  push:" not in workflow, "actual workflow dynamic tag and no push")
+require("--tp-size" in manifest and "HF_HUB_OFFLINE" in manifest and "TRANSFORMERS_OFFLINE" in manifest, "actual manifest offline settings")
+require("claimName: qwen36-27b-model-cache" in manifest and re.search(r"mountPath: /models\s+readOnly: true", manifest), "actual model PVC read-only")
+require("qwen36-27b-triton-cache" not in manifest and "replicas: 0" in manifest and "type: Recreate" in manifest, "actual dormant isolated benchmark")
+require("error: invalid arguments" in plan, "plan argument guard error output")
+for text, name in ((plan, "plan"), (runbook, "runbook"), (spec, "spec")):
+    require("--dataset-name random-ids" in text or name == "spec", f"{name} random-ids sync")
+    require("--random-range-ratio 1" in text or name == "spec", f"{name} ratio sync")
+    require("input_lens" in text or name == "spec", f"{name} input validation sync")
+require("independent" in plan and "warm" in plan and "cold" in plan, "plan repetition/cache flow")
+require("--tp " not in plan, "no unsupported tp sample")
+
+if failures:
+    print("RED: contract failures:")
+    for failure in failures:
+        print(f"- {failure}")
+    raise SystemExit(1)
+print("GREEN: Task 3 static contract satisfied")
+PY
+
+REUSE_LABEL="contract-reuse-$BASHPID"
+REUSE_DIR="/tmp/opencode/sglang-decode-ab/$REUSE_LABEL/control"
+MARKER="/tmp/opencode/sglang-decode-ab/$REUSE_LABEL/mise-called"
+FAKE_BIN="/tmp/opencode/sglang-decode-ab/$REUSE_LABEL/bin"
+mkdir -p "$REUSE_DIR" "$FAKE_BIN"
+cat >"$FAKE_BIN/mise" <<'FAKE_MISE'
+#!/usr/bin/env bash
+set -euo pipefail
+touch "$MARKER"
+exit 77
+FAKE_MISE
+chmod +x "$FAKE_BIN/mise"
+export MARKER
+set +e
+RUN_LABEL="$REUSE_LABEL" PATH="$FAKE_BIN:$PATH" bash "$SCRIPT_DIR/run-qwen36-decode-ab.sh" control >/dev/null 2>&1
+reuse_status=$?
+set -e
+mise_observed=false
+if [[ -e "$MARKER" ]]; then
+  mise_observed=true
+fi
+rm -rf "/tmp/opencode/sglang-decode-ab/$REUSE_LABEL"
+if [[ $reuse_status -ne 1 || $mise_observed == true ]]; then
+  printf 'RED: result reuse was not rejected before mise (status=%s)\n' "$reuse_status" >&2
+  exit 1
+fi
+printf 'GREEN: result reuse rejected before mise\n'


### PR DESCRIPTION
## Summary
- add a manual, run-tokened image build for RDNA4 decode patches 086/087
- add a dormant Flux benchmark workload with isolated Triton caches
- add an offline exact-token benchmark runner and controlled maintenance runbook

## Validation
- `bash kubernetes/apps/ai/llmkube/models/test-qwen36-decode-ab.sh`
- `bash -n` for both benchmark scripts
- `git diff --check origin/main...HEAD`
- whole-diff review: approved
- repository validator completed with warnings because flate/kustomize/shellcheck are unavailable locally, plus pre-existing global warnings

## Safety
- benchmark manifest is not referenced by Kustomize and defaults to zero replicas
- production image, replicas, PVCs, and cluster state are unchanged
- build dispatch, merge, Flux reconciliation, restart, benchmark activation, and cleanup remain separately approval-gated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a controlled RDNA4 throughput benchmark workflow that builds and publishes uniquely identified candidate images.
  * Added Kubernetes resources and scripts for running repeatable Qwen3.6 single-stream decode A/B benchmarks.
  * Added safeguards for image verification, workload readiness, evidence collection, and benchmark result aggregation.

* **Documentation**
  * Added detailed runbooks and experiment specifications covering preflight checks, controlled rollouts, promotion criteria, cleanup, and rollback procedures.

* **Tests**
  * Added static contract checks to validate benchmark configuration and prevent unsafe cache or workload reuse.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->