### PR TITLE
perf(amdgpu): raise GPU power cap to 250W for prefill throughput

### DIFF
--- a/kubernetes/apps/kube-system/amdgpu-undervolt.yaml
+++ b/kubernetes/apps/kube-system/amdgpu-undervolt.yaml
@@ -26,8 +26,14 @@ spec:
           env:
             - name: VOLTAGE_OFFSET_MV
               value: "-82"
+            # Measured sweep, uncontended, TG read from sglang's own counter:
+            #   210W -> 1027 PP / 23.09 TG   250W -> 1184 PP / 23.24 TG
+            #   290W -> 1150 PP / 27.80 TG   330W -> 1301 PP / 23.29 TG (drew 313)
+            # Decode is bandwidth-bound and flat at ~23 across the whole range, so
+            # watts only buy prefill. 250 takes +15% PP for 2.8% worse PP/W; 330
+            # takes +27% for 15% worse. 210 remains the best tok/W on both metrics.
             - name: POWER_LIMIT_WATTS
-              value: "210"
+              value: "250"
             # Measured sweep at 209W, 60s avg per point: 82C->3274rpm/mem 80C,
             # 78->3396/83, 75->3549/70, 72->3960/80, 70->4201/77. Fan tracks the
             # target cleanly but mem barely moves across the band, so this buys


### PR DESCRIPTION
Raises `POWER_LIMIT_WATTS` 210 → 250. Measured, uncontended (`queue-req: 0` on every row), TG read from sglang's own gen-throughput counter rather than my wall-clock.

| cap | PP tok/s | TG tok/s | draw | mem | junction | PP/W | TG/W |
|---|---|---|---|---|---|---|---|
| 210 W | 1027.1 | 23.09 | 209 W | 88 °C | 79 °C | **4.914** | **0.1105** |
| 250 W | 1184.4 | 23.24 | 248 W | 88 °C | 79 °C | 4.776 | 0.0937 |
| 290 W | 1149.7 | 27.80 | 289 W | 88 °C | 83 °C | 3.978 | 0.0962 |
| 330 W | 1301.3 | 23.29 | 313 W | 90 °C | 87 °C | 4.158 | 0.0744 |

## Why 250

**Decode does not scale with power at all** — TG is flat at ~23 tok/s across a 57% power increase. That's the memory-bandwidth wall: decode is limited by streaming 27B of weights out of GDDR6 per token, and core watts don't change that. Watts buy prefill only.

250 W takes **+15% prefill for 2.8% worse PP/W** and no measured temperature change. 330 W takes +27% for 15% worse PP/W, 8 °C more junction, and doesn't even reach its cap — it drew 313 W, hitting a clock or thermal limit first.

**210 W remains the most efficient point on both metrics** and is also the firmware floor (`power1_cap_min`). This change deliberately trades a little efficiency for prefill headroom on long-context work. If usage is decode-dominated (chat, agent turns), 210 W is strictly better and this should be reverted.

## Caveats

- **Single sample per point**, 50 s settle. The 290 W row is internally inconsistent — worst PP *and* best TG — which points at that sample catching an odd GPU state rather than a real dip. Don't read small differences as signal.
- **Expect temperatures above the 88 °C in the table.** That sample was taken while the card warmed from 210 W, so it likely understates steady state. Junction should drift toward the 82 °C fan target, the fan ramps to hold it, and mem lands a few degrees higher — roughly 91–93 °C. Still 15+ °C below the 108 °C vendor `temp3_crit`, so the cost is fan noise, not risk.

## Not changed

`VOLTAGE_OFFSET_MV` stays at -82. The undervolt is still an open suspect in control-1's unexplained reboots, and changing two GPU variables at once would confound that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Increased the AMD GPU power limit from 210W to 250W.
  * Updated performance measurement notes to reflect the revised power and throughput tradeoffs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->