### PR TITLE
fix(network): allow CoreDNS replies through the database ingress allowlist

### DIFF
--- a/kubernetes/apps/kube-system/network-policies/app/database-ingress.yaml
+++ b/kubernetes/apps/kube-system/network-policies/app/database-ingress.yaml
@@ -27,6 +27,11 @@ spec:
             io.kubernetes.pod.namespace: security
         - matchLabels:
             io.kubernetes.pod.namespace: database
+        # DNS replies are rev-NAT'd into ingress, so default-deny blocks them.
+        # No toPorts: the reply's dest port is the client's ephemeral, not 53.
+        - matchLabels:
+            io.kubernetes.pod.namespace: kube-system
+            k8s-app: kube-dns
     # cnpg serves validating/mutating webhooks the apiserver must reach.
     - fromEntities:
         - kube-apiserver


### PR DESCRIPTION
## Root cause

`database-ingress-allowlist` (#4072) sets `endpointSelector: {}`, making ingress default-deny for every pod in `database`. The allowlist omits `kube-system`, so Cilium drops rev-NAT'd CoreDNS replies. Captured live on control-3, endpoint 1100 = `pgbouncer-rw-7ff5f7bdb4-rfwgp`:

```
drop (Policy denied) bpf_lxc.c:2472, identity 19145->9091:
  10.43.0.10:53 -> 10.42.2.107:38066 tcp SYN, ACK
```

`cilium-dbg identity get 19145` → `k8s-app=kube-dns`, `namespace=kube-system`.

A reply from a **pod IP** matches the outbound conntrack entry and bypasses policy evaluation. Only the **rev-NAT'd ClusterIP** reply is re-evaluated as a new ingress flow carrying the CoreDNS identity. That is why direct-to-pod DNS succeeds in ~1ms while the ClusterIP times out on both UDP and TCP.

Cilium cannot match a source port ([#19965](https://github.com/cilium/cilium/issues/19965)) — the reply's destination is the client's ephemeral port — so `toPorts: [53]` would match the wrong field and silently do nothing. Full-port ingress from the kube-dns identity is the floor.

## Why only some pods

Service backend pinning. `rfwgp` is pinned to BackendID 994 = `10.42.2.109`, the CoreDNS pod on its **own node**; conntrack shows `TxFlagsSeen=0x02 RxFlagsSeen=0x00 Packets=0` — the reply dies at ingress before it can ever update conntrack. Poolers pinned to a remote backend are unaffected, which is why deleting the pod has always *looked* like a fix.

Measured:

| pooler | node | CoreDNS on node | DNS failures / 5m |
|---|---|---|---|
| 9jvml | control-2 | no | 0 |
| nl8x9 | control-1 | yes | 61 |
| rfwgp | control-3 | yes ×2 | 38 |

## Blast radius

`crowdsec-lapi` CrashLoopBackOff on `cscli machines add`; radarr/sonarr/prowlarr/bazarr taking `server_login_retry` through `pgbouncer-rw`; the CNPG primary and operator intermittently losing DNS.

## Scope

Cluster-scoped policy object only. **Zero pods restarted**, instantly reversible. The #4135 (`use-vc`) revert was originally bundled here and has been split into #4149 — it mutates `template.spec` and would roll all 7 pooler pods, which would both inherit rollout risk into an urgent fix and destroy this PR's verification (see below).

## Reviewed and rejected

An earlier revision also added `host`, `remote-node`, `health` to `fromEntities` to protect kubelet probes on a future worker node. Dropped — `AllowLocalhost: always` is Cilium's runtime default under k8s and already inserts an unconditional host-identity ingress allow into every endpoint's policy map, verified on a namespace with no CNP granting it. Kubelet only probes pods on its own node, so probes always arrive as the local host identity. `health` targets node health endpoints, never app pods.

## Follow-ups, not in this PR

- `fromEntities: [kube-apiserver]` resolves to identity 7 = `{reserved:kube-apiserver, reserved:remote-node}` on this collapsed control plane, so it already grants every host-namespace process on every *other* node ANY-port ingress to every `database` pod. Scoping to `toPorts: 9443` (cnpg webhook) would tighten it; counters support it (identity 7 → postgres = 0 bytes).
- **Hubble is disabled** (`hubble.enabled: false`). #4072's own body specified verification via `hubble observe --namespace database --verdict DROPPED` — a command that has never been runnable in this cluster. Agent-only Hubble (no relay, no UI) is the cheap fix and would have surfaced this drop immediately.

## Verification

`kustomize build` renders clean. `kube-system/network-policies` is not suspended and reports `Applied revision: main@bc287c014`, so this applies on merge.

Post-merge: policy drops for identity 19145 stop, and the poolers recover **without deletion**. That last point is the signal — do not merge #4149 until it is confirmed, since a pooler roll would reset the pinned backends and make the result unreadable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated database network access rules to allow DNS traffic from the cluster’s DNS service.
  * Improved DNS resolution reliability for applications connecting to the database.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->