### PR TITLE
fix(ai): cover the Stopped phase in the llmkube health gate

### DIFF
--- a/kubernetes/apps/ai/llmkube/ks.yaml
+++ b/kubernetes/apps/ai/llmkube/ks.yaml
@@ -50,7 +50,8 @@ spec:
       kind: InferenceService
       inProgress: has(status.phase) && status.phase in ['Pending', 'Creating', 'Progressing', 'WaitingForGPU']
       failed: has(status.phase) && status.phase == 'Failed'
-      current: has(status.phase) && status.phase == 'Ready' && has(status.conditions) && status.conditions.exists(e, e.type == 'Available' && e.status == 'True')
+      # Stopped is terminal; the CRD says treat it as Pending, which deadlocks this gate.
+      current: has(status.phase) && (status.phase == 'Stopped' || (status.phase == 'Ready' && has(status.conditions) && status.conditions.exists(e, e.type == 'Available' && e.status == 'True')))
   path: ./kubernetes/apps/ai/llmkube/models
   prune: true
   sourceRef:


### PR DESCRIPTION
## What

`healthCheckExprs` on `llmkube-models` covered 6 of the 7 values in the `InferenceService` `status.phase` enum:

| expr | phases |
|---|---|
| `inProgress` | Pending, Creating, Progressing, WaitingForGPU |
| `failed` | Failed |
| `current` | Ready |
| **(none)** | **Stopped** |

`Stopped` matched nothing, so a scale-to-zero service left the Kustomization unable to settle and it burned its full timeout every reconcile — 12 consecutive `HealthCheckFailed` at 5m0.2s each between 11:37Z and 12:56Z on 2026-07-23.

`Stopped` is the CRD's terminal state for a deliberate scale-to-zero ("the user intentionally took the service offline; this is not an error"), so a health gate must treat it as settled. The enum is closed, so all 7 values are now covered — this is not an open-ended whitelist.

## Scope — this is enum completion, not the cause fix

The current `litellm`/`memini` block is **not** caused by this expression, and merging this will not by itself clear it:

- `qwen36-27b`'s replica count is live `kubectl-patch` drift that git never declared, so Flux will never reclaim the field.
- `flux-system/cluster-apps` (the **root** Kustomization), `ai/litellm` and `ai/llmkube-models` are all `suspend: true`, none of it in git. The "dependency not ready" message is frozen pre-suspend state.
- `litellm` and `memini` pods are running — the impact was "new config doesn't reconcile", not "service down".

Those are resolved separately, by hand.

## Known limitation

While `qwen36-27b` is stopped, litellm's `models.yaml` still points at `http://qwen36-27b.ai.svc.cluster.local:30000/v1`. This change makes Flux consider that settled, so it will not surface a stopped backend. That is the correct behaviour for a convergence gate — it is not a liveness check — but worth stating.

## Reviewed and rejected

Dropping the `Available=True` clause from the `Ready` branch. It discriminates nothing on this operator today (`Available=True` holds on both `Stopped` and `Creating`), but removing it changes pre-existing behaviour on thin evidence and is outside this fix.

## Follow-up, not in this PR

`timeout: 60m` in this file is dead config — `kubernetes/flux/cluster/ks.yaml` patches `timeout: 5m` onto every child Kustomization and the patch replaces the child value. Live `llmkube-models.spec.timeout == 5m`. Worth deleting so it stops misleading debugging.

## Verification

`kustomize build kubernetes/apps/ai` renders clean. Flux requires `current`; it cannot be omitted or inferred from `inProgress`/`failed`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment health checks to recognize intentionally stopped inference services as valid, preventing unnecessary rollout or readiness failures.
  * Retained existing readiness validation for available inference services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->