### PR TITLE
revert(database): drop the PgBouncer use-vc dnsConfig

### DIFF
--- a/kubernetes/apps/database/cloudnative-pg/cluster/pooler-ro.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/pooler-ro.yaml
@@ -14,9 +14,6 @@ spec:
   # kills request-less pods first) and spread across nodes.
   template:
     spec:
-      dnsConfig:
-        options:
-          - name: use-vc
       containers:
         - name: pgbouncer
           resources:

--- a/kubernetes/apps/database/cloudnative-pg/cluster/pooler-session.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/pooler-session.yaml
@@ -14,9 +14,6 @@ spec:
   # kills request-less pods first) and spread across nodes.
   template:
     spec:
-      dnsConfig:
-        options:
-          - name: use-vc
       containers:
         - name: pgbouncer
           resources:

--- a/kubernetes/apps/database/cloudnative-pg/cluster/pooler.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/pooler.yaml
@@ -17,9 +17,6 @@ spec:
   # traffic on the survivor and can exhaust its PgBouncer wait queue.
   template:
     spec:
-      dnsConfig:
-        options:
-          - name: use-vc
       containers:
         - name: pgbouncer
           resources:


### PR DESCRIPTION
Reverts e4e3645fd (#4135). Split out of #4147 so the urgent policy fix can merge without a pooler rollout.

## Why it never worked

#4135 forced PgBouncer DNS over TCP. PgBouncer never uses TCP for DNS here. Observed across three pooler pods on two nodes, sampled every 2s for 50s:

```
udp53=1  tcp53=0     # socket inode unchanged throughout
```

pgbouncer 1.25.1 resolves through libcares 1.34.5.

The mechanism is **not** established, and the earlier "c-ares not glibc, so it never takes effect" explanation is wrong: c-ares 1.34.5 does parse `use-vc` (`ares_sysconfig_files.c: process_option()`) and applies it without an optmask gate, and pgbouncer never passes `ARES_OPT_FLAGS` to override it. The socket observation is the evidence; I can't source the why.

## Why removing it is not cosmetic

`use-vc` is a pod-level `dnsConfig` — it applies to every process in the pod, not just pgbouncer. The pooler's pid 1 is the Go `/controller/manager`, and Go's `net` dnsconfig parser honours `use-vc`/`usevc`/`tcp`, as does glibc NSS.

Under the CoreDNS reply drops fixed in #4147, TCP is the strictly worse transport: a denied `SYN,ACK` wedges the caller through the full TCP SYN retry ladder, where a dropped UDP reply just retries in 1-2s. So this removes an aggravating factor.

## Blocked on — do not merge yet

This changes `template.spec`, so CNPG rolls all 7 pooler pods (rw ×3, ro ×2, session ×2). Two gates:

1. **#4147 must merge first and be verified.** Its check is that the poolers recover *without* deletion. A rollout here would reset the pinned backends and destroy that signal — you'd never know whether the policy fix worked.
2. **control-3 memory headroom.** Deployments are `maxSurge=1, maxUnavailable=0`. `pgbouncer-rw` requests 128Mi; control-3 currently has **~52Mi** free (99% of allocatable requested). Only `pgbouncer-rw` carries `whenUnsatisfiable: DoNotSchedule`, so once the topology hits 2/1/0 the `maxSkew: 1` constraint forces the next surge pod onto control-3 specifically, where it cannot schedule — stalling the roll indefinitely. That is the same deadlock that cost 20 minutes on 07-21, and headroom is worse now than it was then.

#4144 frees 2Gi/node by cutting `vm.nr_hugepages` 2048→1024; landing that first clears gate 2. Alternatively batch this with some future pooler change that has to roll anyway.

`pgbouncer-ro` and `pgbouncer-session` use `ScheduleAnyway` and carry no deadlock risk.