### PR TITLE
fix(cluster): right-size hugepages to the one workload that uses them

### DIFF
--- a/kubernetes/apps/database/cloudnative-pg/cluster/cluster.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/cluster.yaml
@@ -82,12 +82,7 @@ spec:
       max_connections: "150"
       shared_buffers: 1GB
       effective_cache_size: 4GB
-      # "off", not "try": shared_memory_size is 1111MB so postgres needs 556 pages,
-      # the hugepages-2Mi limit granted 512, and try fell back to 4K silently for
-      # the life of the cluster (HugePages_Rsvd 0 on every node). Dropping the
-      # limit without this would remove the pod-cgroup cap and let postgres finally
-      # take 556 pages, starving xmrig. Hugepages buy ~25MiB of page tables here
-      # and the published gains start above ~80 connections; we run 41.
+      # off, not the try default: without a cap postgres would grab hugepages meant for xmrig once the request below is dropped.
       huge_pages: "off"
       # io_method: "io_uring" # Blocked by default K8s/containerd seccomp profile (see cloudnative-pg/cloudnative-pg#9948). worker = safe default.
       io_method: "worker"

--- a/kubernetes/apps/database/cloudnative-pg/cluster/cluster.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/cluster.yaml
@@ -82,7 +82,13 @@ spec:
       max_connections: "150"
       shared_buffers: 1GB
       effective_cache_size: 4GB
-      huge_pages: "try"
+      # "off", not "try": shared_memory_size is 1111MB so postgres needs 556 pages,
+      # the hugepages-2Mi limit granted 512, and try fell back to 4K silently for
+      # the life of the cluster (HugePages_Rsvd 0 on every node). Dropping the
+      # limit without this would remove the pod-cgroup cap and let postgres finally
+      # take 556 pages, starving xmrig. Hugepages buy ~25MiB of page tables here
+      # and the published gains start above ~80 connections; we run 41.
+      huge_pages: "off"
       # io_method: "io_uring" # Blocked by default K8s/containerd seccomp profile (see cloudnative-pg/cloudnative-pg#9948). worker = safe default.
       io_method: "worker"
       work_mem: 16MB
@@ -148,7 +154,6 @@ spec:
     limits:
       cpu: 4
       memory: 3Gi
-      hugepages-2Mi: 1Gi
   monitoring:
     enablePodMonitor: true
   plugins:

--- a/kubernetes/apps/web3/monero/xmrig/helmrelease.yaml
+++ b/kubernetes/apps/web3/monero/xmrig/helmrelease.yaml
@@ -48,11 +48,15 @@ spec:
               requests:
                 cpu: 1
                 memory: 32Mi
-                hugepages-2Mi: 3Gi
+                # Measured need is 1175 pages: 1040 dataset + 128 RandomX cache
+                # (retained to rebuild on seed change) + 6 scratchpads at 6 threads.
+                # 1184 pages leaves room for 8. Do not trim below the cache: xmrig
+                # falls back to _mm_malloc for it, which exceeds the 128Mi limit.
+                hugepages-2Mi: 2368Mi
               limits:
                 cpu: 6
                 memory: 128Mi
-                hugepages-2Mi: 3Gi
+                hugepages-2Mi: 2368Mi
     persistence:
       tmp:
         type: emptyDir

--- a/kubernetes/apps/web3/monero/xmrig/helmrelease.yaml
+++ b/kubernetes/apps/web3/monero/xmrig/helmrelease.yaml
@@ -48,10 +48,7 @@ spec:
               requests:
                 cpu: 1
                 memory: 32Mi
-                # Measured need is 1175 pages: 1040 dataset + 128 RandomX cache
-                # (retained to rebuild on seed change) + 6 scratchpads at 6 threads.
-                # 1184 pages leaves room for 8. Do not trim below the cache: xmrig
-                # falls back to _mm_malloc for it, which exceeds the 128Mi limit.
+                # 1184 pages measured (1040 dataset + 128 cache + scratchpads); below the cache xmrig falls back to _mm_malloc and OOMs.
                 hugepages-2Mi: 2368Mi
               limits:
                 cpu: 6

--- a/talos/patches/global/machine-sysctls.yaml
+++ b/talos/patches/global/machine-sysctls.yaml
@@ -16,4 +16,10 @@ machine:
     net.ipv4.neigh.default.gc_thresh3: "16384" # Prevent ARP cache overflows
     net.ipv4.tcp_slow_start_after_idle: "0" # Preserve congestion window after idle
     user.max_user_namespaces: "11255" # User Namespaces
-    vm.nr_hugepages: "2048"
+    # Sized to xmrig alone (the only real consumer), measured 2026-07-23 with one
+    # miner pinned up: "allocated 2336 MB (2080+256) huge pages 100% 1168/1168"
+    # plus 6 scratchpad pages = 1175 of 2048 used, node HugePages_Free 2048 -> 873.
+    # 1184 leaves margin for 8 threads. CNPG asked for 512 pages but postgres needs
+    # 556, so huge_pages=try silently fell back to 4K and reserved 0 - that request
+    # is dropped in the same change, along with huge_pages: "off" to keep it there.
+    vm.nr_hugepages: "1184"

--- a/talos/patches/global/machine-sysctls.yaml
+++ b/talos/patches/global/machine-sysctls.yaml
@@ -16,10 +16,4 @@ machine:
     net.ipv4.neigh.default.gc_thresh3: "16384" # Prevent ARP cache overflows
     net.ipv4.tcp_slow_start_after_idle: "0" # Preserve congestion window after idle
     user.max_user_namespaces: "11255" # User Namespaces
-    # Sized to xmrig alone (the only real consumer), measured 2026-07-23 with one
-    # miner pinned up: "allocated 2336 MB (2080+256) huge pages 100% 1168/1168"
-    # plus 6 scratchpad pages = 1175 of 2048 used, node HugePages_Free 2048 -> 873.
-    # 1184 leaves margin for 8 threads. CNPG asked for 512 pages but postgres needs
-    # 556, so huge_pages=try silently fell back to 4K and reserved 0 - that request
-    # is dropped in the same change, along with huge_pages: "off" to keep it there.
-    vm.nr_hugepages: "1184"
+    vm.nr_hugepages: "1184" # Sized to xmrig alone; CNPG's hugepages request is dropped in the same change


### PR DESCRIPTION
## The finding

Measured on 2026-07-23, all three nodes:

```
HugePages_Total: 2048    HugePages_Free: 2048    HugePages_Rsvd: 0
```

**4 Gi/node — 12 Gi cluster-wide — was carved out of the kernel and nothing consumed a single page.** On nodes that were sitting at 98–99% memory and could not schedule a 274 Mi vmagent during the control-1 outage.

## CNPG never used them

```
shared_memory_size               = 1111 MB
shared_memory_size_in_huge_pages = 556        ← needs 556 pages
hugepages-2Mi limit              = 1Gi = 512  ← 44 pages short
huge_pages                       = try        → silent fallback to 4K
```

Shared memory is `shared_buffers` **plus** wal_buffers, 150 connection slots and pg_stat_statements — so 1 GB of shared_buffers needs more than 1 Gi of hugepages. With `try`, postgres fell back and logged nothing. It has been on 4K pages for the life of the cluster with zero incidents.

Setting `huge_pages: "off"` is **not optional alongside dropping the request**. Verified inside the pod: `hugetlb.2MB.max` is unlimited at container level (kubelet writes no container-level cap; enforcement is at the pod cgroup). Removing the request alone would lift that cap and let postgres finally take its 556 pages — invisibly to the scheduler — and starve xmrig.

Not worth granting properly either: it buys ~25 MiB of page tables per node, and the published throughput gains start above ~80 connections. This cluster runs 41 backends behind pgbouncer.

## xmrig is the only real consumer — measured, not inferred

Pinned one miner up via `paused-replicas=1`:

```
randomx allocated 2336 MB (2080+256) huge pages 100% 1168/1168 +JIT
cpu     READY threads 6/6 (6) huge pages 100% 6/6 memory 12288 KB
```

1168 (2080 dataset + 256 cache) + 6 scratchpads = **1174 pages**. Node `HugePages_Free` went 2048 → 873, i.e. 1175 with alignment.

The 256 MB is the RandomX cache **retained** after dataset construction, to rebuild on seed change every ~2048 blocks. Trimming below it does not degrade hashrate — xmrig falls back to `_mm_malloc` for that allocation, which exceeds its 128Mi memory limit and CrashLoops.

## Change

| | before | after |
|---|---|---|
| `vm.nr_hugepages` | 2048 (4 Gi) | **1184** (2368 MiB) |
| xmrig `hugepages-2Mi` | 3 Gi | **2368Mi** |
| CNPG `hugepages-2Mi` | 1 Gi | **removed** |
| CNPG `huge_pages` | `try` | **`off`** |

**Reclaims 1.69 Gi/node = 5.1 GiB cluster-wide.** xmrig keeps 100% hugepage backing on all three nodes at full `maxReplicaCount: 3`, so there is no hashrate change. postgres is unaffected because it was never using them.

## Rollout note

Shrinking `nr_hugepages` always succeeds immediately. Growing it on a node at 98% memory can partially fail (needs contiguous 2 MiB blocks), so if this is ever reverted, do it on a drained or freshly-booted node.

## Unrelated finding

xmrig logs `msr kernel module is not available / FAILED TO APPLY MSR MOD, HASHRATE WILL BE LOW`. The miner is running below potential for a reason that has nothing to do with hugepages. Not addressed here.
