### PR TITLE
fix(etcd-defrag): lower defrag threshold from 100MB to 50MB free space

### DIFF
--- a/kubernetes/apps/kube-system/etcd-defrag/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/etcd-defrag/app/helmrelease.yaml
@@ -50,8 +50,8 @@ spec:
               - --cacert=/certs/ca.crt
               - --cert=/certs/server.crt
               - --key=/certs/server.key
-              # Defrag when DB quota usage > 50% OR free space > 100MB
-              - --defrag-rule=dbQuotaUsage > 0.5 || dbSizeFree > 100*1024*1024
+              # Defrag when DB quota usage > 50% OR free space > 50MB
+              - --defrag-rule=dbQuotaUsage > 0.5 || dbSizeFree > 50*1024*1024
               # Move the leader before defragmenting it.
               - --move-leader
               # --cluster defragments all three control-plane etcd members.


### PR DESCRIPTION
Reduces the etcd defrag free-space threshold from 100MB to 50MB so defrag runs earlier when DB page count grows but stays under the 50% quota usage trigger. This helps reclaim space more proactively on the control plane etcd instances.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the etcd defragmentation schedule to run when less free database space remains, improving storage maintenance behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->