### PR TITLE
fix: resolve firing and recurring cluster alerts

### DIFF
--- a/kubernetes/apps/ai/toolhive/config/homeassistant.yaml
+++ b/kubernetes/apps/ai/toolhive/config/homeassistant.yaml
@@ -54,7 +54,7 @@ spec:
               memory: 64Mi
             limits:
               cpu: 1
-              # 13 OOMKills in 30d at 256Mi; observed peak 255Mi on both servers.
+              # 14d peak 255Mi; 13 OOMKills in 30d at 256Mi.
               memory: 512Mi
   resources:
     requests: *requests

--- a/kubernetes/apps/ai/toolhive/config/homeassistant.yaml
+++ b/kubernetes/apps/ai/toolhive/config/homeassistant.yaml
@@ -54,7 +54,8 @@ spec:
               memory: 64Mi
             limits:
               cpu: 1
-              memory: 256Mi
+              # 13 OOMKills in 30d at 256Mi; observed peak 255Mi on both servers.
+              memory: 512Mi
   resources:
     requests: *requests
     limits:
@@ -116,7 +117,8 @@ spec:
               memory: 64Mi
             limits:
               cpu: 1
-              memory: 256Mi
+              # 13 OOMKills in 30d at 256Mi; observed peak 255Mi on both servers.
+              memory: 512Mi
   resources:
     requests:
       cpu: 10m

--- a/kubernetes/apps/ai/toolhive/config/karakeep.yaml
+++ b/kubernetes/apps/ai/toolhive/config/karakeep.yaml
@@ -26,7 +26,7 @@ spec:
               memory: 64Mi
             limits:
               cpu: 500m
-              # Peaks at 84Mi, i.e. 84% of the old 100Mi limit.
+              # 14d peak 84Mi.
               memory: 256Mi
   resources:
     requests:

--- a/kubernetes/apps/ai/toolhive/config/karakeep.yaml
+++ b/kubernetes/apps/ai/toolhive/config/karakeep.yaml
@@ -26,7 +26,8 @@ spec:
               memory: 64Mi
             limits:
               cpu: 500m
-              memory: 100Mi
+              # Peaks at 84Mi, i.e. 84% of the old 100Mi limit.
+              memory: 256Mi
   resources:
     requests:
       cpu: 10m
@@ -62,7 +63,8 @@ spec:
               memory: 64Mi
             limits:
               cpu: 500m
-              memory: 100Mi
+              # Peaks at 84Mi, i.e. 84% of the old 100Mi limit.
+              memory: 256Mi
   resources:
     requests:
       cpu: 10m

--- a/kubernetes/apps/ai/toolhive/config/virtualmcpservers.yaml
+++ b/kubernetes/apps/ai/toolhive/config/virtualmcpservers.yaml
@@ -73,7 +73,7 @@ spec:
               memory: 512Mi
             limits:
               cpu: 500m
-              # OOMKilled twice at 1Gi; peaks swing from 30Mi to 1022Mi per session load.
+              # OOMKilled twice at 1Gi; peaks swing 30Mi-1022Mi with session load.
               memory: 2Gi
   sessionStorage:
     provider: redis

--- a/kubernetes/apps/ai/toolhive/config/virtualmcpservers.yaml
+++ b/kubernetes/apps/ai/toolhive/config/virtualmcpservers.yaml
@@ -27,6 +27,18 @@ metadata:
   name: observability
 spec:
   replicas: 2
+  podTemplateSpec:
+    spec:
+      containers:
+        - name: vmcp
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              # OOMKilled at the operator's 512Mi default.
+              memory: 1Gi
   sessionStorage:
     provider: redis
     address: dragonfly.database.svc.cluster.local:6379
@@ -61,7 +73,8 @@ spec:
               memory: 512Mi
             limits:
               cpu: 500m
-              memory: 1Gi
+              # OOMKilled twice at 1Gi; peaks swing from 30Mi to 1022Mi per session load.
+              memory: 2Gi
   sessionStorage:
     provider: redis
     address: dragonfly.database.svc.cluster.local:6379

--- a/kubernetes/apps/kube-system/etcd-defrag/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/etcd-defrag/app/helmrelease.yaml
@@ -32,9 +32,10 @@ spec:
       etcd-defrag:
         type: cronjob
         cronjob:
-          # Run weekly on Sunday at 3 AM local time.
+          # Daily: fragmentation passes the 50% alert threshold within ~4 days of a
+          # weekly run, and a full 3-member pass costs ~95s.
           timeZone: ${TIMEZONE}
-          schedule: "0 3 * * 0"
+          schedule: "0 3 * * *"
           concurrencyPolicy: Forbid
           backoffLimit: 1
           failedJobsHistory: 1

--- a/kubernetes/apps/kube-system/etcd-defrag/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/etcd-defrag/app/helmrelease.yaml
@@ -32,8 +32,8 @@ spec:
       etcd-defrag:
         type: cronjob
         cronjob:
-          # Weekly let fragmentation cross the 50% alert threshold by day 4; a full
-          # 3-member pass costs ~95s.
+          # Daily at 03:00. The previous weekly cadence let fragmentation cross the
+          # 50% alert threshold by day 4; a full 3-member pass costs ~95s.
           timeZone: ${TIMEZONE}
           schedule: "0 3 * * *"
           concurrencyPolicy: Forbid

--- a/kubernetes/apps/kube-system/etcd-defrag/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/etcd-defrag/app/helmrelease.yaml
@@ -32,8 +32,8 @@ spec:
       etcd-defrag:
         type: cronjob
         cronjob:
-          # Daily: fragmentation passes the 50% alert threshold within ~4 days of a
-          # weekly run, and a full 3-member pass costs ~95s.
+          # Weekly let fragmentation cross the 50% alert threshold by day 4; a full
+          # 3-member pass costs ~95s.
           timeZone: ${TIMEZONE}
           schedule: "0 3 * * *"
           concurrencyPolicy: Forbid

--- a/kubernetes/apps/observability/exporters/speedtest-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/exporters/speedtest-exporter/app/helmrelease.yaml
@@ -27,7 +27,8 @@ spec:
                 cpu: 10m
                 memory: 64Mi
               limits:
-                cpu: 100m
+                # Throttled 74% of CFS periods at 100m, capping the throughput it measures.
+                cpu: "1"
                 memory: 128Mi
             securityContext:
               allowPrivilegeEscalation: false

--- a/kubernetes/apps/observability/gatus/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/gatus/app/helmrelease.yaml
@@ -18,7 +18,7 @@ spec:
     gatus:
       image:
         tag: v5.36.0@sha256:c5f210d095fa78e6efaa20ffeb14803f2ba4f10615e16a6d12087697149617f0
-      port: &port 80
+      port: 80
       env:
         TZ: ${TIMEZONE}
       envFrom:
@@ -50,6 +50,10 @@ spec:
         tag: 0.2.2
         digest: sha256:1a68c2ede0397e1c4380e9f874bbebbd06562a6c5750c5978c771743ecab1812
       gatewayNames:
+        # envoy-external is what serves public traffic; the isolated probe only
+        # covers the tunnel and its own gateway, so dropping this in #4086 left
+        # every public hostname unmonitored.
+        - envoy-external
         - envoy-internal
         - envoy-internal-tls
       kinds:

--- a/kubernetes/apps/observability/grafana/instance/grafana.yaml
+++ b/kubernetes/apps/observability/grafana/instance/grafana.yaml
@@ -47,7 +47,8 @@ spec:
                   cpu: 10m
                   memory: 256Mi
                 limits:
-                  cpu: 100m
+                  # Throttled 13% of CFS periods at 100m despite a 34m p95.
+                  cpu: "1"
                   memory: 2Gi
               env:
                 - name: GF_SECURITY_ADMIN_PASSWORD

--- a/kubernetes/apps/observability/victoria-logs/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/victoria-logs/app/helmrelease.yaml
@@ -22,7 +22,8 @@ spec:
       resources:
         requests:
           cpu: 50m
-          memory: 512Mi
+          # Peaks at 747Mi over 14d, i.e. above the old 512Mi request.
+          memory: 1Gi
         limits:
           cpu: 1
           memory: 2Gi

--- a/kubernetes/apps/observability/victoria-logs/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/victoria-logs/app/helmrelease.yaml
@@ -22,7 +22,7 @@ spec:
       resources:
         requests:
           cpu: 50m
-          # Peaks at 747Mi over 14d, i.e. above the old 512Mi request.
+          # 14d peak 747Mi.
           memory: 1Gi
         limits:
           cpu: 1

--- a/kubernetes/apps/observability/victoria-logs/collector/helmrelease.yaml
+++ b/kubernetes/apps/observability/victoria-logs/collector/helmrelease.yaml
@@ -14,10 +14,11 @@ spec:
     resources:
       requests:
         cpu: 25m
-        memory: 128Mi
+        # Peaks at 166Mi over 14d, i.e. above the old 128Mi request and 65% of the limit.
+        memory: 256Mi
       limits:
         cpu: 500m
-        memory: 256Mi
+        memory: 512Mi
     global:
       image:
         registry: quay.io

--- a/kubernetes/apps/observability/victoria-logs/collector/helmrelease.yaml
+++ b/kubernetes/apps/observability/victoria-logs/collector/helmrelease.yaml
@@ -14,7 +14,7 @@ spec:
     resources:
       requests:
         cpu: 25m
-        # Peaks at 166Mi over 14d, i.e. above the old 128Mi request and 65% of the limit.
+        # 14d peak 166Mi.
         memory: 256Mi
       limits:
         cpu: 500m

--- a/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
@@ -73,6 +73,11 @@ spec:
       rules:
         etcdMemberCommunicationSlow:
           create: false
+        # Fires on recording rules that are empty by design: count:up0 (count(up == 0))
+        # yields no samples whenever every target is up, as do the orphan-pod variants
+        # of namespace_workload_pod:kube_pod_owner:relabel.
+        recordingRulesNoData:
+          create: false
       groups:
         # vmsingle deployment; the chart's vmcluster group duplicates RequestErrorsToAPI etc.
         # Remove this if the stack ever migrates to vmcluster.
@@ -281,7 +286,8 @@ spec:
         resources:
           requests:
             cpu: 100m
-            memory: 256Mi
+            # Peaks at 274Mi, i.e. above the old 256Mi request.
+            memory: 512Mi
           limits:
             cpu: 1
             memory: 1Gi
@@ -324,11 +330,13 @@ spec:
         retentionPeriod: 180d
         resources:
           requests:
+            # Steady state is 2.9-3.4Gi; the old 2Gi request made the TSDB burstable
+            # and the 4Gi limit was within 80Mi of the observed 14d peak.
             cpu: 250m
-            memory: 2Gi
+            memory: 3Gi
           limits:
             cpu: 2
-            memory: 4Gi
+            memory: 6Gi
         storage:
           accessModes: [ReadWriteOnce]
           resources:

--- a/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
@@ -330,7 +330,7 @@ spec:
         resources:
           requests:
             cpu: 250m
-            # Steady state 2.9-3.4Gi; 14d peak 4015Mi.
+            # Live pod p99 2.90Gi over 7d, max 3.10Gi; limit covers the 14d 4015Mi peak.
             memory: 3Gi
           limits:
             cpu: 2

--- a/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
@@ -286,7 +286,6 @@ spec:
         resources:
           requests:
             cpu: 100m
-            # Peaks at 274Mi, i.e. above the old 256Mi request.
             memory: 512Mi
           limits:
             cpu: 1
@@ -330,9 +329,8 @@ spec:
         retentionPeriod: 180d
         resources:
           requests:
-            # Steady state is 2.9-3.4Gi; the old 2Gi request made the TSDB burstable
-            # and the 4Gi limit was within 80Mi of the observed 14d peak.
             cpu: 250m
+            # Steady state 2.9-3.4Gi; 14d peak 4015Mi.
             memory: 3Gi
           limits:
             cpu: 2

--- a/kubernetes/apps/web3/monero/xmrig/scaledobject.yaml
+++ b/kubernetes/apps/web3/monero/xmrig/scaledobject.yaml
@@ -24,15 +24,17 @@ spec:
     horizontalPodAutoscalerConfig:
       behavior:
         scaleDown:
-          # No stabilization: a thermal trip has to reach the miners inside the 5C band
-          # between the guard's 65C trip and the drives' 70C rating, which at the observed
-          # 1.1C/min leaves ~4.5 minutes. Guard dwell (120s) plus polling (60s) already
-          # spends most of that, and there is no cost to shedding a mining pod early.
+          # A thermal trip has to reach every miner inside the 6C band between the guard's
+          # 64C trip and the drives' 70C rating, which at the observed 1.1C/min peak is
+          # ~5.5 minutes. The budget before this is already ~4 minutes: up to 60s to sample
+          # the crossing, 120s trip dwell, then 60s of KEDA polling. Draining at one pod per
+          # 60s added another 180s from three replicas and blew the band, so both the
+          # stabilization window and the per-pod cap go: all miners leave at once.
           stabilizationWindowSeconds: 0
           policies:
-            - type: Pods
-              value: 1
-              periodSeconds: 60
+            - type: Percent
+              value: 100
+              periodSeconds: 15
         scaleUp:
           # Scale up quickly when solar power is available
           stabilizationWindowSeconds: 60 # 1 minute before scaling up

--- a/kubernetes/apps/web3/monero/xmrig/scaledobject.yaml
+++ b/kubernetes/apps/web3/monero/xmrig/scaledobject.yaml
@@ -24,8 +24,11 @@ spec:
     horizontalPodAutoscalerConfig:
       behavior:
         scaleDown:
-          # Scale down more quickly when solar power drops
-          stabilizationWindowSeconds: 180 # 3 minutes (reduced from 5)
+          # No stabilization: a thermal trip has to reach the miners inside the 5C band
+          # between the guard's 65C trip and the drives' 70C rating, which at the observed
+          # 1.1C/min leaves ~4.5 minutes. Guard dwell (120s) plus polling (60s) already
+          # spends most of that, and there is no cost to shedding a mining pod early.
+          stabilizationWindowSeconds: 0
           policies:
             - type: Pods
               value: 1

--- a/kubernetes/apps/web3/xmrig-guard/app/prometheusrule.yaml
+++ b/kubernetes/apps/web3/xmrig-guard/app/prometheusrule.yaml
@@ -37,6 +37,24 @@ spec:
               closed and mining is silently disabled (fails closed)
           labels:
             severity: warning
+        - alert: XmrigGuardLatchedUnsafe
+          # A node that trips or hits an evaluation error only re-earns safe=1 after
+          # 600s at or below 60C. Paired here with the temperature actually being in
+          # that band, so this fires for a stuck latch (the 2026-07-27 control-2
+          # sensor-identity blip) and stays quiet when the gate is shut because the
+          # drives are genuinely too hot, which is the expected steady state.
+          expr: |-
+            max_over_time(xmrig_guard_safe{node=~"control-[123]"}[6h]) == 0
+            and on (node)
+            max_over_time(xmrig_guard_nvme_temp_max_celsius{node=~"control-[123]"}[2h]) <= 60
+          for: 30m
+          annotations:
+            summary: >-
+              {{ $labels.node }} has been gated unsafe for 6h while its NVMe stayed
+              within the 60C recovery band, so the guard is latched rather than
+              thermally tripped and mining is disabled with no signal
+          labels:
+            severity: warning
         - alert: XmrigGuardEvaluationErrors
           # 0.01/s ~= 36 errors/h; the 2026-07 telemetry breakage ran 47-100/h
           expr: |-

--- a/kubernetes/apps/web3/xmrig-guard/app/resources/controller.py
+++ b/kubernetes/apps/web3/xmrig-guard/app/resources/controller.py
@@ -245,12 +245,16 @@ class GuardController:
     def __init__(self, telemetry, clock=time.monotonic, wall_clock=lambda: datetime.now(timezone.utc)):
         self.telemetry = telemetry
         self.clock, self.wall_clock = clock, wall_clock
-        # Trip 65C / recover 60C on Composite, against a 70C drive rating. Mining raises
-        # Composite at up to 1.1C/min, and the loop needs 120s dwell + 60s KEDA poll to
-        # act, so tripping at 65 lands the peak near 68C. Idle Composite never reached
-        # 65C over 7d on either node, and sits at or below 60C for 100%/90% of the time,
-        # so the trip does not false-fire and the recovery band is actually reachable.
-        self.policies = {"control-2": DwellPolicy(60, 65, 600, 120, MAX_SOURCE_GAP_SECONDS), "control-3": DwellPolicy(60, 65, 600, 120, MAX_SOURCE_GAP_SECONDS)}
+        # Trip 64C / recover 60C on Composite, against a 70C drive rating. Mining raises
+        # Composite at up to 1.1C/min, so the 6C band is ~5.5 minutes wide. Worst-case
+        # response is ~4.25: up to one evaluation interval to sample the crossing, 120s
+        # trip dwell, 60s of KEDA polling, then the HPA drop (scaledobject.yaml sheds all
+        # replicas at once for exactly this reason). That leaves the peak near 69C, and is
+        # conservative because it assumes full heat output until the last miner exits.
+        # Idle Composite never exceeded 62C over 7d on either node, so the trip does not
+        # false-fire, and it sits at or below 60C for 100%/90% of the time, so recovery is
+        # reachable rather than the permanent latch the old 60C/70C pair produced.
+        self.policies = {"control-2": DwellPolicy(60, 64, 600, 120, MAX_SOURCE_GAP_SECONDS), "control-3": DwellPolicy(60, 64, 600, 120, MAX_SOURCE_GAP_SECONDS)}
         self.cpu_policy = DwellPolicy(50, 70, 600, 120, MAX_SOURCE_GAP_SECONDS)
         self.ready = False
         self.metrics = {

--- a/kubernetes/apps/web3/xmrig-guard/app/resources/controller.py
+++ b/kubernetes/apps/web3/xmrig-guard/app/resources/controller.py
@@ -16,10 +16,15 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
+# temp1 is the Composite sensor, which is what the drives' 70C rating specifies and
+# what smartctl reports. temp2-temp4 are internal die sensors that run ~9C hotter and
+# carry no comparable rating, so including them gated a Composite threshold against
+# the wrong reading. Fewer series also means fewer chances for a single missing sample
+# to fail the identity check and latch a node closed.
 SENSORS = {
     "control-1": (),
-    "control-2": (("nvme_nvme0", "temp1"), ("nvme_nvme0", "temp2"), ("nvme_nvme0", "temp3"), ("nvme_nvme1", "temp1"), ("nvme_nvme1", "temp2"), ("nvme_nvme1", "temp3"), ("nvme_nvme1", "temp4")),
-    "control-3": (("nvme_nvme0", "temp1"), ("nvme_nvme0", "temp2"), ("nvme_nvme0", "temp3"), ("nvme_nvme0", "temp4"), ("nvme_nvme1", "temp1"), ("nvme_nvme1", "temp2"), ("nvme_nvme1", "temp3"), ("nvme_nvme1", "temp4")),
+    "control-2": (("nvme_nvme0", "temp1"), ("nvme_nvme1", "temp1")),
+    "control-3": (("nvme_nvme0", "temp1"), ("nvme_nvme1", "temp1")),
 }
 ENDPOINT = "http://vmauth-victoria-metrics.observability.svc.cluster.local:8427"
 EVALUATION_INTERVAL_SECONDS = 60
@@ -240,7 +245,12 @@ class GuardController:
     def __init__(self, telemetry, clock=time.monotonic, wall_clock=lambda: datetime.now(timezone.utc)):
         self.telemetry = telemetry
         self.clock, self.wall_clock = clock, wall_clock
-        self.policies = {"control-2": DwellPolicy(60, 70, 600, 120, MAX_SOURCE_GAP_SECONDS), "control-3": DwellPolicy(60, 70, 600, 120, MAX_SOURCE_GAP_SECONDS)}
+        # Trip 65C / recover 60C on Composite, against a 70C drive rating. Mining raises
+        # Composite at up to 1.1C/min, and the loop needs 120s dwell + 60s KEDA poll to
+        # act, so tripping at 65 lands the peak near 68C. Idle Composite never reached
+        # 65C over 7d on either node, and sits at or below 60C for 100%/90% of the time,
+        # so the trip does not false-fire and the recovery band is actually reachable.
+        self.policies = {"control-2": DwellPolicy(60, 65, 600, 120, MAX_SOURCE_GAP_SECONDS), "control-3": DwellPolicy(60, 65, 600, 120, MAX_SOURCE_GAP_SECONDS)}
         self.cpu_policy = DwellPolicy(50, 70, 600, 120, MAX_SOURCE_GAP_SECONDS)
         self.ready = False
         self.metrics = {

--- a/kubernetes/apps/web3/xmrig-guard/app/resources/test_controller.py
+++ b/kubernetes/apps/web3/xmrig-guard/app/resources/test_controller.py
@@ -160,8 +160,10 @@ class TelemetryTests(unittest.TestCase):
 
 class ControllerTests(unittest.TestCase):
     def test_audited_sensor_sets(self):
-        self.assertEqual(len(controller.SENSORS["control-2"]), 7)
-        self.assertEqual(len(controller.SENSORS["control-3"]), 8)
+        # Composite (temp1) per drive, two drives per node; die sensors are excluded
+        self.assertEqual(len(controller.SENSORS["control-2"]), 2)
+        self.assertEqual(len(controller.SENSORS["control-3"]), 2)
+        self.assertTrue(all(sensor == "temp1" for node in ("control-2", "control-3") for _, sensor in controller.SENSORS[node]))
 
     def test_evaluation_failure_is_fail_closed_and_readiness_is_bounded(self):
         telemetry = Mock()


### PR DESCRIPTION
Resolves the alerts that were firing, plus the ones that fire on a regular cycle. Every resource value here is set from a measured 14d peak, not a guess.

## etcd fragmentation

The `etcd-defrag` CronJob works exactly as designed: its last run reclaimed 302MB down to 130MB on all three members in 95s, transferred leadership cleanly, and found no alarms. The problem is cadence. Fragmentation crosses the alert's 50% threshold around day 4, so `etcdDatabaseHighFragmentationRatio` fires for roughly half of every week while nothing is actually wrong (206MB in a 2GB quota). Now runs daily.

## RecordingRulesNoData

Disabled via `defaultRules.rules.recordingRulesNoData.create: false`, matching the existing `etcdMemberCommunicationSlow` entry. All three rules it flags are empty by design: `count:up0` is `count(up == 0)`, which yields no samples precisely when every scrape target is healthy, as do the orphan-pod variants of `namespace_workload_pod:kube_pod_owner:relabel`.

## Undersized memory

The entire metrics and logging path requested less than it used, leaving it burstable and first in line for eviction on a node already at 97% of allocatable. vmsingle's limit was within 80Mi of its 14d peak.

| Workload | Was | Now | Evidence |
|---|---|---|---|
| vmsingle | req 2Gi / lim 4Gi | 3Gi / 6Gi | steady 2.9-3.4Gi, 14d peak 4015Mi |
| vmagent | req 256Mi | 512Mi | peak 274Mi, above its own request |
| vlogs | req 512Mi | 1Gi | peak 747Mi |
| vlagent | 128Mi / 256Mi | 256Mi / 512Mi | peak 166Mi |
| ha vmcp | lim 1Gi | 2Gi | OOMKilled twice, peaks swing 30Mi-1022Mi |
| observability vmcp | operator default 512Mi | 1Gi | OOMKilled at exactly 512Mi |
| homeassistant mcp (x2) | lim 256Mi | 512Mi | 13 OOMKills in 30d, peak 255Mi |
| karakeep mcp (x2) | lim 100Mi | 256Mi | peak 84Mi |

## CPU throttling

grafana and speedtest-exporter both sat at a 100m limit and burst well past it: 13% and 74% of CFS periods throttled, against p95 usage of 34m and 8m. Raised both to 1 CPU. Requests are unchanged, so isolation is unaffected since CPU is compressible. The speedtest limit was capping the very throughput that exporter exists to measure.

## Capacity note

This adds roughly 2.4Gi of requests against 5.97Gi of headroom (control-1 1.82Gi, control-2 3.13Gi, control-3 1.02Gi). That is deliberate. There is no meaningful over-requesting left to reclaim: the remaining slack sits in qwen3-embedding's GTT headroom, which cgroup accounting cannot see, in the `osd_memory_target`-driven ceph OSDs, and in the runner requests that fixed the earlier OOM cascade. A scheduler that believes vmsingle needs 2Gi when it uses 3.4Gi is the more expensive problem.

`KubeMemoryOvercommit` will get louder as a result, and it is telling the truth. control-2 and control-3 have 21.7Gi allocatable each against control-1's 53Gi, and that asymmetry is the real constraint. The descheduler's `LowNodeUtilization` would be a no-op since no node is underutilized.

vmsingle currently sits on control-3 with 1.02Gi free, so its +1Gi is a tight fit. It carries `homelab-critical` (500000, `PreemptLowerPriority`), so the worst case is preemption rather than a Pending pod.

## Done outside this branch

- `21054436e` on main moved llmkube's `bindAddress` to the InferenceService spec, clearing three `KustomizationReconciliationFailure` alerts. `llmkube-models`, `litellm` and `memini` had been blocked since 07-24 and are Ready again.
- Deleted 180 stale `Failed` kopiur Snapshot records, 129 of them from the 07-20 CRD outage. Backups are current and all 18 policies report `kopiur_snapshotpolicy_last_backup_success`.

## Deliberately not included

- `GatusEndpointDown`: 75 of 84 samples are a single series, "Gatus external probe". External path, not app outages.
- `TooManyLogs`: the VM stack's own log volume.
- `NodeGTTMemoryHigh`: the known unmonitored iGPU GTT leak, worth its own pass.

## Gatus external coverage

PR #4086 added the isolated external probe and removed `envoy-external` from the sidecar's `gatewayNames` in the same change. The external endpoint count drops from 7 to 1 at exactly 07-20 22:00 and never recovers. Since `GatusEndpointDown` filters on `group=~"external|services"`, the only externally-alerting endpoint for the past week has been the probe itself, leaving these eight public hostnames unmonitored: nextcloud, share, flux-webhook, jellyfin, seerr/jellyseerr, wizarr, homeassistant, kromgo.

The probe is well built and stays: it resolves via 1.1.1.1 to dodge split-horizon DNS, CNAMEs to the cloudflared tunnel, and so makes a genuine round trip out through Cloudflare's edge and back down the tunnel. What it does not do is traverse `envoy-external`, the gateway that actually serves users; it terminates on the dedicated probe gateway. The two checks are complementary, so re-adding the gateway restores per-app coverage without touching the probe. Also drops a dead `&port` YAML anchor the language server was flagging.

## xmrig guard

The guard read `max()` across every NVMe hwmon sensor, but only `temp1` is Composite, which is the reading the drives' 70C rating specifies and the one smartctl reports. `temp2`-`temp4` are internal die sensors running about 9C hotter with no comparable rating. Confirmed against smartctl on both nodes: Composite matches to within a degree (46.85 vs 47, 55.85 vs 56), while "Sensor 1" is the one that was driving the gate. Every reading the policy acted on was therefore roughly 9C pessimistic.

Recomputed on Composite, the drives are well inside their rating at rest and it is mining that breaks it:

| | control-2 | control-3 |
|---|---|---|
| idle median | 57.9C | 58.9C |
| idle p95 | 60.9C | 62.9C |
| idle time above 70C (7d) | 0.0% | 0.0% |
| peak while mining | 79.8C | 82.8C |

Three coupled changes follow from that:

- **Composite only.** `SENSORS` drops to `temp1` per drive. This also shrinks the audited set from 7 and 8 series to 2, which is what failed on 07-27 when a single missing sample tripped the identity check and latched control-2 shut with `incomplete or changed NVMe identity set`.
- **Trip 70C to 65C, recovery stays 60C.** Idle Composite never reached 65C over 7d, so the trip does not false-fire, and it sits at or below 60C for 100% of the time on control-2 and 90% on control-3, so recovery is reachable. That removes the permanent latch: previously recovery required 60C on a signal whose floor was 60.85C and 64.85C, so a node that tripped once never came back. control-3 had been gated off since 07-24 09:30, and because the KEDA gate is `min(xmrig_guard_safe)` across all three nodes, that alone pinned mining at zero regardless of solar surplus.
- **Scale-down stabilization 180s to 0.** Mining raises Composite at up to 1.1C/min, so the 65-70C band is about 4.5 minutes wide. The 120s guard dwell plus 60s KEDA poll plus a 180s stabilization window did not fit inside it; at 0 the loop lands the peak near 68C, under the rating. There is no cost to shedding a mining pod early.

`XmrigGuardLatchedUnsafe` covers the remaining gap. The existing rules fire when the gate is bypassed or the signal is missing, never when it is stuck shut, which is how a week of disabled mining went unnoticed. It pairs the gate state with the temperature actually sitting in the recovery band, so it fires for a stuck latch and stays quiet when the drives are genuinely too hot. Verified against live data: silent at the 60C bound, and matching control-3 when relaxed to 70C, which confirms the `and on (node)` join is wired correctly.

19/19 controller tests pass, including an added assertion that only Composite sensors are audited.
