### PR TITLE
fix(observability): use the chart's key format to disable RecordingRulesNoData

### DIFF
--- a/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
@@ -76,8 +76,10 @@ spec:
         # Fires on recording rules that are empty by design: count:up0 (count(up == 0))
         # yields no samples whenever every target is up, as do the orphan-pod variants
         # of namespace_workload_pod:kube_pod_owner:relabel.
-        recordingRulesNoData:
-          create: false
+        # Key is the exact alert name and the field is `enabled`, per the chart's own
+        # example; the camelCased `create: false` form silently matched nothing.
+        RecordingRulesNoData:
+          enabled: false
       groups:
         # vmsingle deployment; the chart's vmcluster group duplicates RequestErrorsToAPI etc.
         # Remove this if the stack ever migrates to vmcluster.


### PR DESCRIPTION
Follow-up to #4195, caught while verifying the merge in-cluster.

The alert was still firing after reconcile. The HelmRelease value applied cleanly (`kubectl get hr` shows `recordingRulesNoData: {create: false}`), but the rule remained in the rendered VMRule, because `defaultRules.rules` is keyed by the **exact alert name** with an `enabled` field. The chart says so in its own commented example:

```yaml
rules: {}
  # CPUThrottlingHigh:
  #   enabled: false
```

So `recordingRulesNoData: create: false` matched nothing and was silently ignored. Corrected to `RecordingRulesNoData: enabled: false`.

The neighbouring `etcdMemberCommunicationSlow` entry is deliberately left alone: its key already matches its alert name verbatim, and that alert is absent from the rendered rules, so it is doing its job.

Rationale for disabling is unchanged from #4195: the rule flags recording rules that are empty by design. `count:up0` is `count(up == 0)`, which yields no samples precisely when every scrape target is healthy, as do the orphan-pod variants of `namespace_workload_pod:kube_pod_owner:relabel`.