### PR TITLE
fix(ai): retry litellm connection drops instead of losing the run

### DIFF
--- a/kubernetes/apps/ai/litellm/instance/proxy.yaml
+++ b/kubernetes/apps/ai/litellm/instance/proxy.yaml
@@ -63,6 +63,14 @@ spec:
       ttl: 604800 # 7d; tool descriptions are stable, dragonfly runs cache_mode (LRU)
     drop_params: true
     num_retries: 0
+  routerSettings:
+    # Per-error override of the global num_retries: 0. A dropped connection to
+    # SGLang surfaces as InternalServerError ("OpenAIException - Connection
+    # error") and costs a whole scheduled run, because Hermes cron has no retry
+    # queue. Timeouts stay at 0 retries — re-running a ~100K prefill that
+    # already burned 900s would only deepen the GPU contention that caused it.
+    retry_policy:
+      InternalServerErrorRetries: 2
   route:
     hostnames:
       - "litellm.${SECRET_DOMAIN}"


### PR DESCRIPTION
## Problem

`num_retries: 0` at both the proxy and model level, with no fallbacks, means a single dropped connection to SGLang kills the caller outright:

```
litellm.InternalServerError: OpenAIException - Connection error.
Received Model Group=qwen-3.6-fast
Available Model Group Fallbacks=None
```

Hermes cron has no retry queue by design (`cron/executions.py`: *"The ledger records what is known about each attempt; it is not a retry queue"*), so every blip costs a whole scheduled run. Three runs were lost this way today while `qwen36-27b` was restarting.

## Change

A per-error override on the router. `InternalServerError` is the class these connection drops land in, so it retries twice; every other class keeps the existing `num_retries: 0`.

Timeouts deliberately stay at zero retries — re-running a ~100K prefill that already burned its 900s budget would deepen the GPU contention that caused the timeout in the first place.

## Validation

- `RetryPolicy` field names confirmed against the deployed image (v1.93.0) — `InternalServerErrorRetries` is a valid key.
- `kubectl kustomize kubernetes/apps/ai/litellm/instance` renders clean.

Not yet observed end-to-end against a live connection drop; that needs the failure to recur.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved LiteLLM request reliability by retrying qualifying internal server errors up to two times.
  * Existing health checks, routing, and resource settings remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->