### PR TITLE
fix(toolhive): give the unified optimizer a writable /tmp for FTS5

### DIFF
--- a/kubernetes/apps/ai/toolhive/config/virtualmcpservers.yaml
+++ b/kubernetes/apps/ai/toolhive/config/virtualmcpservers.yaml
@@ -168,9 +168,23 @@ spec:
   replicas: 1
   podTemplateSpec:
     spec:
+      # The operator sets readOnlyRootFilesystem, so the optimizer's FTS5 index has
+      # nowhere to spill: queries whose sorter exceeds memory fail with "disk I/O
+      # error (6410)", which the MCP layer returns as zero matches rather than an
+      # error. An agent reads that as "this tool does not exist".
+      volumes:
+        - name: tmp
+          emptyDir: {}
       containers:
         - name: vmcp
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
           env:
+            # sqlite's unix VFS tries /var/tmp before /tmp; both are read-only here,
+            # so point it at the mount explicitly instead of relying on the search order.
+            - name: TMPDIR
+              value: /tmp
             - name: OPENAI_API_KEY
               value: ${LITELLM_API_KEY}
           resources:


### PR DESCRIPTION
## Problem

`find_tool` on the unified vmcp optimizer intermittently returned **zero matches** for tools that exist. An agent reads that as "this tool is not available", and one Hermes cron run spent 92 minutes hand-writing shell probes before delivering a health report claiming the ToolHive backends were gone. They were not: `unified` was Ready the whole time and aggregating 172 tools from 8/8 backends.

The real error is swallowed:

```
find_tool failed: tool search failed: FTS5 query failed: disk I/O error (6410)
```

Reproducible and query-dependent:

| query | result |
|---|---|
| `query prometheus metrics` | ok, 97.9% token savings |
| `get home assistant entity state` | `disk I/O error (6410)` |
| `list flux kustomizations` | ok, 99.2% token savings |

## Cause

The operator sets `readOnlyRootFilesystem: true`, and the pod mounts no writable volume at all (only the config projection and the SA token). Small FTS5 queries resolve in memory; ones whose sorter spills need a temp file, sqlite tries to open one, and gets EIO. Larger backends like Home Assistant cross that line, which is why the failure looks random until you vary the query.

## Fix

An `emptyDir` at `/tmp`, plus an explicit `TMPDIR` because sqlite's unix VFS tries `/var/tmp` before `/tmp` and both are read-only here.

## Validation

Not yet validated live. Patching the running Deployment was blocked locally, and the operator reverts direct patches anyway, so the check happens after merge: re-run the three queries above and confirm the Home Assistant one returns tools instead of the I/O error.

## Follow-up

vmcp converting a sqlite I/O error into an empty result set is an upstream bug worth its own issue. A capability lookup that fails should surface an error, not report that nothing matched.