### PR TITLE
fix(karakeep): drop the flag meilisearch v1.51 removed

### DIFF
--- a/kubernetes/apps/default/karakeep/app/helmrelease.yaml
+++ b/kubernetes/apps/default/karakeep/app/helmrelease.yaml
@@ -132,7 +132,6 @@ spec:
               tag: v1.51.0@sha256:a9eb29ee09ab4943db3b4c68620bd6f3382e6b2b0ac4431c0e607b48dbcd4c14
             args:
               - /bin/meilisearch
-              - --experimental-dumpless-upgrade
             env:
               MEILI_NO_ANALYTICS: true
               MEILI_MASTER_KEY:


### PR DESCRIPTION
karakeep-meilisearch has been in CrashLoopBackOff (10 restarts) since #4194 bumped meilisearch v1.50.0 to v1.51.0 earlier today. v1.51 graduated dumpless upgrade out of experimental and removed the flag, so the pinned arg now aborts startup:

```
error: unexpected argument '--experimental-dumpless-upgrade' found
  tip: a similar argument exists: '--experimental-logs-mode'
```

(The "similar argument" tip is just fuzzy matching, not a rename.) Dropping the arg restores the default behaviour, which is now what the flag used to opt into.

Karakeep search is down until this lands, so this is not a draft.