### PR TITLE
feat(hermes): wire the Home Assistant platform adapter

### DIFF
--- a/kubernetes/apps/ai/hermes/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/hermes/app/helmrelease.yaml
@@ -51,7 +51,7 @@ spec:
               S6_SERVICES_GRACETIME: "80000"
               # Home Assistant platform adapter. Reuses the token the homeassistant
               # MCPServer already consumes rather than duplicating it into hermes-secret.
-              HASS_URL: http://192.168.0.16:8123
+              HASS_URL: http://${HOME_ASSISTANT_IP}:8123
               HASS_TOKEN:
                 valueFrom:
                   secretKeyRef:

--- a/kubernetes/apps/ai/hermes/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/hermes/app/helmrelease.yaml
@@ -49,6 +49,14 @@ spec:
               S6_CMD_RECEIVE_SIGNALS: "1"
               HERMES_RESTART_DRAIN_TIMEOUT: "45"
               S6_SERVICES_GRACETIME: "80000"
+              # Home Assistant platform adapter. Reuses the token the homeassistant
+              # MCPServer already consumes rather than duplicating it into hermes-secret.
+              HASS_URL: http://192.168.0.16:8123
+              HASS_TOKEN:
+                valueFrom:
+                  secretKeyRef:
+                    name: toolhive-secrets
+                    key: HOMEASSISTANT_API_TOKEN
             envFrom:
               - secretRef:
                   name: hermes-secret


### PR DESCRIPTION
## What

Enables the bundled `homeassistant-platform` plugin, which subscribes to Home Assistant's WebSocket event bus and forwards filtered state changes to the agent. Outbound replies land as HA persistent notifications.

This is a gateway, like the Discord plugin, not a tool layer. The `homeassistant` MCP backend already covers *asking questions about* HA. What is missing is HA state changes **waking the agent up**.

## Why

The existing `homeassistant-improvement-daily` cron runs once a day and reasons over a config snapshot. Intermittent faults, particularly the 2.4GHz dropouts traced to the Cudy/Archer channel overlap, have a window of minutes. A daily or 6-hourly job structurally cannot see them.

Prometheus already covers the threshold-on-one-metric cases (NVMe thermal, power), and does it faster and cheaper than an LLM. This deliberately does not duplicate that. It targets the case Prometheus cannot express: a pattern across entities over time, where each individual dropout is noise and the correlation is the diagnostic.

## Scope

The watch list is four entities, one per WiFi-attached device that has historically dropped off, chosen by enumerating all 485 entities:

| entity | device |
|---|---|
| `sensor.sb3_6_1av_40_652_status` | SMA inverter |
| `sensor.techcave_wifi_temperature_humidity_sensor_temperature` | WiFi temp/humidity sensor |
| `sensor.p1_meter_power` | P1 meter |
| `sensor.boiler_actual_boiler_temperature` | EMS-ESP |

`watch_all` stays off and `cooldown_seconds` is 300, well above the 30s default. Every event is an LLM turn on the GPU shared with Jellyfin, so the cost model is the opposite of Prometheus and the filter has to be tight.

## This PR vs the PVC

Hermes splits config. The watch list, cooldown and `enabled: true` are in the runtime config on the PVC and are already applied (backup at `config.yaml.bak-ha-20260727`). This PR carries the part that must live in git: the credentials.

`HASS_TOKEN` is reused from `toolhive-secrets`, which the `homeassistant` MCPServer already consumes, rather than duplicated into `hermes-secret`. `HASS_URL` lives here too, and was removed from the PVC config so there is one source of truth (the adapter reads `extra.url` before the env var).

The adapter cannot connect until this merges.

## Validation

After merge: confirm the gateway logs a Home Assistant connection on startup, and that a state change on one of the four entities produces an event without the adapter warning about missing filters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Home Assistant integration for the Hermes controller.
  * Configured Hermes to connect to Home Assistant using `HASS_URL` and a securely provided `HASS_TOKEN`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->