### PR TITLE
perf(llmkube): right-size the iGPU embedders after measuring GTT

### DIFF
--- a/kubernetes/apps/ai/llmkube/models/qwen3-embedding.yaml
+++ b/kubernetes/apps/ai/llmkube/models/qwen3-embedding.yaml
@@ -42,11 +42,16 @@ spec:
   # Two slots are the Vulkan-safe floor; more interleaving did not improve
   # throughput on this compute-bound iGPU. VMCP has its own embedder now.
   parallelSlots: 2 # Vulkan warmup hangs at parallel=1 (llama.cpp #24307)
-  contextSize: 8192
-  # Raise the logical batch ceiling without increasing the 2048-token Vulkan
-  # micro-batch; benchmark against the prior implicit 2048 default.
-  batchSize: 4096
-  uBatchSize: 2048
+  # 30d peak prompt is 4030 tokens, and contextSize splits across parallelSlots,
+  # so 8192 left each slot 4096 with 66 tokens of headroom. 10240 restores a
+  # ~27% margin; anything an input overruns fails the embedding outright.
+  contextSize: 10240
+  # No batchSize: llama.cpp forces n_batch = n_ubatch when embeddings are
+  # enabled, so any value above uBatchSize is logged as a warning and discarded.
+  # 512 over 2048: benchmarked identical on this iGPU (194-item batch 3.61s vs
+  # 3.68s median, single 65ms vs 69ms, 4k input 402 vs 390 tok/s) while cutting
+  # GTT ~49%, since the attention scratch scales with the square of the micro-batch.
+  uBatchSize: 512
   extraArgs:
     - "--alias"
     - "qwen3-embedding" # served model name memini sends in /v1/embeddings

--- a/kubernetes/apps/ai/llmkube/models/vmcp-embedding.yaml
+++ b/kubernetes/apps/ai/llmkube/models/vmcp-embedding.yaml
@@ -61,8 +61,10 @@ spec:
   # 2155 tokens under harrier's Gemma3 tokenizer (~1.85x qwen3's count for the
   # same text; 2048/slot rejected it live 2026-07-02). Harrier's native window
   # is 32K and KV for a 270m model is tens of MB, so headroom is cheap.
-  contextSize: 16384
-  uBatchSize: 2048
+  # 30d peak prompt is 4102 tokens; 12288 keeps ~50% headroom per slot.
+  contextSize: 12288
+  # See qwen3-embedding.yaml: 512 measured identical on throughput, ~49% less GTT.
+  uBatchSize: 512
   # mode: embedding makes the operator inject --embedding --pooling last and
   # --metrics itself (verified on the live qwen3-embedding pod) — don't repeat them.
   extraArgs:


### PR DESCRIPTION
Right-sizes the two iGPU embedders after measuring per-process `drm-memory-gtt` on the node. Their memory is GPU-mapped host memory, so the cgroup shows 91 MiB while the driver holds GiB, which is why the requests were backwards: vmcp-embedding asked for 512Mi and used 4775 MiB, qwen3-embedding asked for 4Gi and used 2442 MiB.

**uBatchSize is the dominant term** (attention scratch scales with its square). At a fixed 8192 tokens/slot: `ubatch=2048` 4194 MiB → `ubatch=512` **2119 MiB**.

**And it is free.** qwen3-embedding, 194-item tool-description batch, control-3 iGPU. Prefill-only, so prompt rate is the only meaningful throughput number.

| | 2048 | 512 |
|---|---|---|
| batch median | 3.68s | **3.61s** |
| batch best | 8641 tok/s | **8715 tok/s** |
| single | 69ms | **65ms** |
| 4002-token input | 390 tok/s | **402 tok/s** |

A 4203-token input still embeds at ubatch 512, so llama.cpp splits sequences rather than needing the micro-batch to cover the input.

**contextSize divides across parallelSlots.** 30d peak from `llamacpp:n_tokens_max`:

- qwen3-embedding **8192 → 10240**: 2 slots left 4096/slot against a 4030-token peak, i.e. 66 tokens of margin. Overrunning a slot fails the embedding and degrades Hermes tool discovery. This one needed to go up.
- vmcp-embedding **16384 → 12288**: ~50% headroom over its 4102-token peak.

**`batchSize: 4096` removed** — never applied, llama.cpp forces `n_batch = n_ubatch` in embeddings mode and logs it on every startup.

Not included: `parallelSlots: 1` works (tested; #24307's warmup hang is Gemma-4-specific, which this repo no longer runs) and saves ~12% more, but halves concurrency for a small win next to the micro-batch change.
