### PR TITLE
ci(sglang): reclaim / space before the sglang-rdna4 build

### DIFF
--- a/.github/workflows/build-sglang-rdna4.yaml
+++ b/.github/workflows/build-sglang-rdna4.yaml
@@ -37,11 +37,17 @@ jobs:
         with:
           persist-credentials: false
 
+      # / does get used after all: run 30277992056 died at 43min with "No space left on device"
+      # writing the runner's own diag log under /home/runner. Reclaiming the preinstalled
+      # toolchains is ~30GB and costs seconds; the df lines are the evidence for next time.
+      - name: Reclaim / space
+        run: |
+          df -h /
+          sudo rm -rf /opt/hostedtoolcache /usr/share/dotnet /usr/local/lib/android /opt/ghc
+          df -h /
+
       # The `builder` stage (ROCm "complete" ~20GB + conda env ~22GB) outgrows /'s free space, so
-      # point docker's data root at the larger ~75GB /mnt volume. That volume alone is enough — a
-      # green build fit in it without touching /, so no disk-reclaim action is needed (the earlier
-      # easimon/maximize-build-space and jlumbroso/free-disk-space steps both only freed /, which
-      # the build never uses).
+      # point docker's data root at the larger ~75GB /mnt volume.
       - name: Move docker storage to /mnt
         run: |
           sudo systemctl stop docker.service docker.socket


### PR DESCRIPTION
Run `30277992056` failed at 43 minutes with:

```
System.IO.IOException: No space left on device :
  "/home/runner/actions-runner/cached/2.336.0/_diag/Worker_20260727-150201-utc.log"
```

No failing step was recorded and the log blob was never uploaded, which is host disk exhaustion rather than a build error.

The existing comment claimed no disk reclaim was needed because the build "never uses /". That premise no longer holds: the runner writes its own diag logs there, and the run died on `/`, not `/mnt`. Reclaiming the preinstalled toolchains frees ~30GB and takes seconds.

`df -h /` is printed before and after so the next failure has evidence attached rather than needing another guess.

## Testing

A rerun of the same commit was cancelled in favour of this, so whether the failure was transient or systematic is still unproven. If it was transient this change is harmless; if systematic, this is the fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build reliability by reclaiming disk space earlier in the build process.
  * Added disk-usage checks before and after cleanup to help prevent storage-related build failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->