### PR TITLE
fix(karakeep): restore the meilisearch upgrade flag under its new name

### DIFF
--- a/kubernetes/apps/default/karakeep/app/helmrelease.yaml
+++ b/kubernetes/apps/default/karakeep/app/helmrelease.yaml
@@ -132,6 +132,9 @@ spec:
               tag: v1.51.0@sha256:a9eb29ee09ab4943db3b4c68620bd6f3382e6b2b0ac4431c0e607b48dbcd4c14
             args:
               - /bin/meilisearch
+              # v1.51 renamed --experimental-dumpless-upgrade to this; without it
+              # the engine refuses to open a database written by the prior version.
+              - --upgrade-db
             env:
               MEILI_NO_ANALYTICS: true
               MEILI_MASTER_KEY:


### PR DESCRIPTION
Follow-up to #4202, which fixed half the problem.

v1.51 **renamed** `--experimental-dumpless-upgrade` to `--upgrade-db`; it did not retire it. #4202 dropped the old flag (correct, v1.51 rejects it) but added nothing back, so the engine now refuses to open the existing database:

```
Your database version (1.50.0) is incompatible with your current engine version (1.51.0).
... you can set the `--upgrade-db` flag (or the `MEILI_UPGRADE_DB` environment variable)
```

Still CrashLoopBackOff, karakeep search still down. Verified against the live pod after #4202 reconciled: args are `["/bin/meilisearch"]` and it fails on the version check rather than on argument parsing.