### PR TITLE
chore: apply the ai-namespace consistency conventions repo-wide

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -11,13 +11,10 @@
       description: "GrafanaDashboard spec.url pinned to GitHub release tags",
       customType: "regex",
       managerFilePatterns: ["/grafanadashboard\\.yaml(?:\\.j2)?$/"],
-      matchStringsStrategy: "recursive",
       matchStrings: [
-        "url:\\s+https://raw\\.githubusercontent\\.com/(?<depName>[^/\\s]+/[^/\\s]+)/",
-        "(?<currentValue>v\\d+\\.\\d+\\.\\d+)"
+        "url:\\s+\"?https://raw\\.githubusercontent\\.com/(?<depName>[^/\\s]+/[^/\\s]+)/(?<currentValue>v\\d+\\.\\d+\\.\\d+)/"
       ],
-      datasourceTemplate: "github-releases",
-      autoReplaceStringTemplate: "{{{newValue}}}"
+      datasourceTemplate: "github-releases"
     },
     {
       description: "qBitrr ConfigVersion (semver, no v prefix)",

--- a/kubernetes/apps/database/cloudnative-pg/barman-cloud/helmrelease.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/barman-cloud/helmrelease.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/kubernetes/apps/database/cloudnative-pg/cluster/cluster.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/cluster.yaml
@@ -16,11 +16,9 @@ spec:
   superuserSecret:
     name: cloudnative-pg-secret
   enableSuperuserAccess: true
-  # Declarative app roles (CNPG-native, replacing postgres-init). Password sourced from a
-  # basic-auth Secret in this namespace; CNPG enforces it, so the app's DATABASE_URL must match.
-  # Static password: CNPG can rotate a managed role's password, but nothing here re-syncs it
-  # into the app's DATABASE_URL secret. Rotation is not enabled for these roles today; if it
-  # ever is, add a mechanism (e.g. Reloader-driven resync) to keep the two in step.
+  # Declarative app roles (CNPG-native, replacing postgres-init). Password comes from a
+  # basic-auth Secret here and CNPG enforces it, so the app's DATABASE_URL must match.
+  # Nothing re-syncs the two, so password rotation is off for these roles.
   managed:
     roles:
       - name: litellm

--- a/kubernetes/apps/database/cloudnative-pg/cluster/pooler-ro.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/pooler-ro.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/postgresql.cnpg.io/pooler_v1.json
 # Transaction-mode RO PgBouncer → replicas only (no primary max_connections usage).
 # Per logical DB: up to instances × max_db_connections server conns from this deployment.
 apiVersion: postgresql.cnpg.io/v1

--- a/kubernetes/apps/database/cloudnative-pg/cluster/pooler-session.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/pooler-session.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/postgresql.cnpg.io/pooler_v1.json
 # Session-mode RW pooler (prepared statements, advisory locks, etc.). Service:
 # pgbouncer-session.database.svc.cluster.local:5432 — same primary as pgbouncer-rw.
 apiVersion: postgresql.cnpg.io/v1

--- a/kubernetes/apps/database/cloudnative-pg/cluster/pooler.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/pooler.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/postgresql.cnpg.io/pooler_v1.json
 # Transaction-mode RW PgBouncer → primary. Per pod, max_db_connections caps server conns
 # to one Postgres database (PgBouncer docs). Through this Pooler only: up to
 # instances × max_db_connections per DB; multiple DBs on the primary add separately.

--- a/kubernetes/apps/database/cloudnative-pg/databases/litellm.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/databases/litellm.yaml
@@ -9,5 +9,3 @@ spec:
     name: postgres16
   name: litellm
   owner: litellm
-  # Never drop the database if this CR is deleted — litellm stores virtual keys, spend, teams.
-  databaseReclaimPolicy: retain

--- a/kubernetes/apps/default/homepage/app/helmrelease.yaml
+++ b/kubernetes/apps/default/homepage/app/helmrelease.yaml
@@ -73,7 +73,6 @@ spec:
 
     defaultPodOptions:
       automountServiceAccountToken: true
-      enableServiceLinks: false
       securityContext:
         runAsUser: 1000
         runAsGroup: 1000

--- a/kubernetes/apps/default/homepage/app/resources/settings.yaml
+++ b/kubernetes/apps/default/homepage/app/resources/settings.yaml
@@ -32,8 +32,6 @@ layout:
   Processing: { tab: Media, style: row, columns: 3 }
 
   # AI tab
-  Interfaces: { tab: AI, style: row, columns: 3 }
-  Models: { tab: AI, style: row, columns: 3 }
   Agents: { tab: AI, style: row, columns: 3 }
 
   # Apps tab

--- a/kubernetes/apps/default/karakeep/app/helmrelease.yaml
+++ b/kubernetes/apps/default/karakeep/app/helmrelease.yaml
@@ -188,7 +188,7 @@ spec:
           gethomepage.dev/group: Utilities
           gethomepage.dev/icon: karakeep.png
         hostnames:
-          - karakeep.${SECRET_DOMAIN}
+          - "{{ .Release.Name }}.${SECRET_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/default/obico/moonraker-obico/helmrelease.yaml
+++ b/kubernetes/apps/default/obico/moonraker-obico/helmrelease.yaml
@@ -12,7 +12,6 @@ spec:
 
   values:
     defaultPodOptions:
-      automountServiceAccountToken: false
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       securityContext:
@@ -123,7 +122,6 @@ spec:
 
     persistence:
       config:
-        enabled: true
         storageClass: ceph-block
         accessMode: ReadWriteOnce
         size: 1Gi

--- a/kubernetes/apps/default/searxng/app/helmrelease.yaml
+++ b/kubernetes/apps/default/searxng/app/helmrelease.yaml
@@ -78,7 +78,6 @@ spec:
                 cpu: 500m
                 memory: 1Gi
     defaultPodOptions:
-      enableServiceLinks: false
       securityContext:
         fsGroup: 977
         fsGroupChangePolicy: OnRootMismatch

--- a/kubernetes/apps/flux-system/flux-instance/app/helmrelease.yaml
+++ b/kubernetes/apps/flux-system/flux-instance/app/helmrelease.yaml
@@ -15,11 +15,6 @@ spec:
         artifact: oci://ghcr.io/controlplaneio-fluxcd/flux-operator-manifests:v0.56.0
       cluster:
         networkPolicy: false
-      components:
-        - source-controller
-        - kustomize-controller
-        - helm-controller
-        - notification-controller
       sync:
         kind: GitRepository
         url: https://github.com/tanguille/cluster.git

--- a/kubernetes/apps/flux-system/flux-instance/app/httproute.yaml
+++ b/kubernetes/apps/flux-system/flux-instance/app/httproute.yaml
@@ -15,7 +15,6 @@ spec:
   rules:
     - backendRefs:
         - name: webhook-receiver
-          namespace: flux-system
           port: 80
       matches:
         - path:

--- a/kubernetes/apps/kube-system/amdgpu-undervolt.yaml
+++ b/kubernetes/apps/kube-system/amdgpu-undervolt.yaml
@@ -30,7 +30,7 @@ spec:
             #   290W -> 1150 PP / 27.80 TG   330W -> 1301 PP / 23.29 TG (drew 313)
             # Decode is bandwidth-bound and flat at ~23 across the whole range, so
             # watts only buy prefill. 250 takes +15% PP for 2.8% worse PP/W; 330
-            # takes +27% for 15% worse. 210 is best tok/W; 250 buys prefill headroom.
+            # takes +27% for 15% worse. 210 remains the best tok/W on both metrics.
             - name: POWER_LIMIT_WATTS
               value: "250"
             # Measured sweep at 209W, 60s avg per point: 82C->3274rpm/mem 80C,

--- a/kubernetes/apps/kube-system/amdgpu-undervolt.yaml
+++ b/kubernetes/apps/kube-system/amdgpu-undervolt.yaml
@@ -22,7 +22,6 @@ spec:
       containers:
         - name: app
           image: ghcr.io/home-operations/busybox:1.38.0@sha256:7e2c04dd50ede647bf4a7a4c8dbd629dd4971cd139b9b88fb22bfc3c7a6c13df
-          imagePullPolicy: IfNotPresent
           env:
             - name: VOLTAGE_OFFSET_MV
               value: "-82"
@@ -31,7 +30,7 @@ spec:
             #   290W -> 1150 PP / 27.80 TG   330W -> 1301 PP / 23.29 TG (drew 313)
             # Decode is bandwidth-bound and flat at ~23 across the whole range, so
             # watts only buy prefill. 250 takes +15% PP for 2.8% worse PP/W; 330
-            # takes +27% for 15% worse. 210 remains the best tok/W on both metrics.
+            # takes +27% for 15% worse. 210 is best tok/W; 250 buys prefill headroom.
             - name: POWER_LIMIT_WATTS
               value: "250"
             # Measured sweep at 209W, 60s avg per point: 82C->3274rpm/mem 80C,

--- a/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
@@ -26,8 +26,6 @@ spec:
     # Use jiffies for CT map (tuning guide)
     bpfClockProbe: true
     cgroup:
-      automount:
-        enabled: false
       hostRoot: /sys/fs/cgroup
     cni:
       exclusive: false

--- a/kubernetes/apps/kube-system/etcd-defrag/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/etcd-defrag/app/helmrelease.yaml
@@ -30,8 +30,8 @@ spec:
       etcd-defrag:
         type: cronjob
         cronjob:
-          # Weekly let fragmentation cross the 50% alert threshold by day 4; a
-          # full 3-member pass costs ~95s.
+          # The previous weekly cadence let fragmentation cross the 50% alert
+          # threshold by day 4; a full 3-member pass costs ~95s.
           timeZone: ${TIMEZONE}
           schedule: "0 3 * * *"
           backoffLimit: 1

--- a/kubernetes/apps/kube-system/etcd-defrag/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/etcd-defrag/app/helmrelease.yaml
@@ -13,14 +13,12 @@ spec:
   values:
     defaultPodOptions:
       # Must use host network and PID namespace to access Talos etcd on localhost:2379.
-      automountServiceAccountToken: false
       hostNetwork: true
       hostPID: true
       securityContext:
         runAsGroup: 0
         runAsNonRoot: false
         runAsUser: 0
-      # Ensure this only runs on the control plane node
       nodeSelector:
         node-role.kubernetes.io/control-plane: ""
       tolerations:
@@ -32,14 +30,11 @@ spec:
       etcd-defrag:
         type: cronjob
         cronjob:
-          # Daily at 03:00. The previous weekly cadence let fragmentation cross the
-          # 50% alert threshold by day 4; a full 3-member pass costs ~95s.
+          # Weekly let fragmentation cross the 50% alert threshold by day 4; a
+          # full 3-member pass costs ~95s.
           timeZone: ${TIMEZONE}
           schedule: "0 3 * * *"
-          concurrencyPolicy: Forbid
           backoffLimit: 1
-          failedJobsHistory: 1
-          successfulJobsHistory: 1
         containers:
           app:
             image:
@@ -51,15 +46,12 @@ spec:
               - --cacert=/certs/ca.crt
               - --cert=/certs/server.crt
               - --key=/certs/server.key
-              # Defrag when DB quota usage > 50% OR free space > 50MB
               - --defrag-rule=dbQuotaUsage > 0.5 || dbSizeFree > 50*1024*1024
-              # Move the leader before defragmenting it.
               - --move-leader
               # --cluster defragments all three control-plane etcd members.
               - --wait-between-defrags=30s
               # Talos uses etcd's default --quota-backend-bytes value (2 GiB).
               - --etcd-storage-quota-bytes=2147483648
-              # Auto-disalarm space quota alarms
               - --auto-disalarm
               - --disalarm-threshold=0.8
             resources:

--- a/kubernetes/apps/kube-system/spegel/app/grafanadashboard.yaml
+++ b/kubernetes/apps/kube-system/spegel/app/grafanadashboard.yaml
@@ -13,4 +13,4 @@ spec:
   datasources:
     - datasourceName: prometheus
       inputName: DS_PROMETHEUS
-  url: https://raw.githubusercontent.com/spegel-org/spegel/v0.7.2/charts/spegel/monitoring/grafana-dashboard.json
+  url: https://raw.githubusercontent.com/spegel-org/spegel/v0.7.4/charts/spegel/monitoring/grafana-dashboard.json

--- a/kubernetes/apps/kube-system/spegel/app/grafanadashboard.yaml
+++ b/kubernetes/apps/kube-system/spegel/app/grafanadashboard.yaml
@@ -13,4 +13,9 @@ spec:
   datasources:
     - datasourceName: prometheus
       inputName: DS_PROMETHEUS
-  url: https://raw.githubusercontent.com/spegel-org/spegel/v0.7.4/charts/spegel/monitoring/grafana-dashboard.json
+  # From the chart's own ConfigMap, so the JSON can never drift from the chart
+  # version. 16 panels hardcode ${DS_PROMETHEUS}, so the datasources mapping
+  # above is load-bearing - without it they resolve to nothing.
+  configMapRef:
+    name: spegel-dashboard
+    key: spegel.json

--- a/kubernetes/apps/kube-system/spegel/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/spegel/app/helmrelease.yaml
@@ -18,3 +18,9 @@ spec:
       enabled: true
     spegel:
       containerdRegistryConfigPath: /etc/cri/conf.d/hosts
+    grafanaDashboard:
+      enabled: true
+      # Sidecar just emits the ConfigMap; grafanadashboard.yaml consumes it via
+      # configMapRef so it can also carry the DS_PROMETHEUS datasource mapping,
+      # which the chart's GrafanaOperator mode cannot express.
+      mode: Sidecar

--- a/kubernetes/apps/kube-system/spegel/ks.yaml
+++ b/kubernetes/apps/kube-system/spegel/ks.yaml
@@ -4,6 +4,7 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: spegel
+  namespace: &namespace kube-system
 spec:
   interval: 1h
   path: ./kubernetes/apps/kube-system/spegel/app
@@ -12,5 +13,5 @@ spec:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: kube-system
+  targetNamespace: *namespace
   wait: false

--- a/kubernetes/apps/media/brrpolice/ks.yaml
+++ b/kubernetes/apps/media/brrpolice/ks.yaml
@@ -3,7 +3,7 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: brrpolice
+  name: &app brrpolice
   namespace: &namespace media
 spec:
   components:

--- a/kubernetes/apps/media/brrpolice/ks.yaml
+++ b/kubernetes/apps/media/brrpolice/ks.yaml
@@ -13,7 +13,7 @@ spec:
   path: ./kubernetes/apps/media/brrpolice/app
   postBuild:
     substitute:
-      APP: brrpolice
+      APP: *app
       KOPIUR_PUID: "1000"
       KOPIUR_PGID: "1000"
   prune: true

--- a/kubernetes/apps/media/deduparr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/deduparr/app/helmrelease.yaml
@@ -53,7 +53,6 @@ spec:
                 enabled: true
                 spec:
                   failureThreshold: 30
-                  periodSeconds: 10
             securityContext:
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true

--- a/kubernetes/apps/media/fileflows/app/helmrelease.yaml
+++ b/kubernetes/apps/media/fileflows/app/helmrelease.yaml
@@ -101,10 +101,6 @@ spec:
         existingClaim: *app
         globalMounts:
           - path: /app/Data
-            readOnly: false
 
       temp:
         type: emptyDir
-        globalMounts:
-          - path: /temp
-            readOnly: false

--- a/kubernetes/apps/media/jellyfin/app/helmrelease.yaml
+++ b/kubernetes/apps/media/jellyfin/app/helmrelease.yaml
@@ -15,7 +15,6 @@ spec:
 
   values:
     defaultPodOptions:
-      # squat.ai/dri already hard-pins scheduling to the GPU node
       securityContext:
         runAsUser: 568
         runAsGroup: 568
@@ -55,7 +54,6 @@ spec:
                 enabled: true
                 spec:
                   failureThreshold: 30
-                  periodSeconds: 10
             lifecycle:
               preStop:
                 exec:
@@ -104,10 +102,6 @@ spec:
     persistence:
       config:
         existingClaim: jellyfin
-        advancedMounts:
-          jellyfin:
-            app:
-              - path: /config
 
       # not the nfs-media component: library paths in the db use /ext_media
       media:
@@ -116,13 +110,10 @@ spec:
         path: ${MEDIA_NFS_PATH}
         globalMounts:
           - path: /ext_media
-            readOnly: false
 
       library:
         type: hostPath
         hostPath: "/var/mnt/merged/"
-        globalMounts:
-          - path: /var/mnt/merged/
 
       tmpfs:
         type: emptyDir

--- a/kubernetes/apps/media/prowlarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/prowlarr/app/helmrelease.yaml
@@ -12,7 +12,6 @@ spec:
 
   values:
     defaultPodOptions:
-      enableServiceLinks: false
       securityContext:
         runAsUser: 568
         runAsGroup: 568

--- a/kubernetes/apps/media/qbittorrent/app/helmrelease.yaml
+++ b/kubernetes/apps/media/qbittorrent/app/helmrelease.yaml
@@ -42,7 +42,6 @@ spec:
                 enabled: true
                 spec:
                   failureThreshold: 30
-                  periodSeconds: 10
             lifecycle:
               preStop:
                 exec:
@@ -91,17 +90,9 @@ spec:
           - name: envoy-internal
             namespace: network
 
-        rules:
-          - backendRefs:
-              - identifier: app
-                port: *port
     persistence:
       config:
         existingClaim: *app
-        advancedMounts:
-          qbittorrent:
-            app:
-              - path: /config
 
       tmp:
         type: emptyDir

--- a/kubernetes/apps/media/qbittorrent/tools/qbitrr/helmrelease.yaml
+++ b/kubernetes/apps/media/qbittorrent/tools/qbitrr/helmrelease.yaml
@@ -109,20 +109,15 @@ spec:
 
     persistence:
       config:
-        type: persistentVolumeClaim
         storageClass: ceph-block
         accessMode: ReadWriteOnce
         size: 2Gi
-        globalMounts:
-          - path: /config
-            readOnly: false
 
       config-template:
         type: configMap
         name: qbitrr-config
         globalMounts:
-          - path: /config-template
-            readOnly: true
+          - readOnly: true
 
       downloads:
         type: nfs
@@ -130,4 +125,3 @@ spec:
         path: ${MEDIA_NFS_PATH}/Downloads
         globalMounts:
           - path: /completed_downloads
-            readOnly: false

--- a/kubernetes/apps/media/qbittorrent/tools/qbitrr/ks.yaml
+++ b/kubernetes/apps/media/qbittorrent/tools/qbitrr/ks.yaml
@@ -1,6 +1,4 @@
 ---
-# Flux Kustomization for qbitrr — deps live here; substitution comes from the cluster-apps
-# defaults patch (cluster-settings + cluster-secrets, which hold the *arr API keys).
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization

--- a/kubernetes/apps/media/qui/app/helmrelease.yaml
+++ b/kubernetes/apps/media/qui/app/helmrelease.yaml
@@ -54,7 +54,6 @@ spec:
                 enabled: true
                 spec:
                   failureThreshold: 30
-                  periodSeconds: 10
             resources:
               requests:
                 cpu: 10m
@@ -67,7 +66,6 @@ spec:
               readOnlyRootFilesystem: true
               capabilities: { drop: ["ALL"] }
     defaultPodOptions:
-      enableServiceLinks: false
       securityContext:
         runAsNonRoot: true
         runAsUser: 568
@@ -99,15 +97,9 @@ spec:
         parentRefs:
           - name: envoy-internal
             namespace: network
-        rules:
-          - backendRefs:
-              - identifier: app
-                port: *port
     persistence:
       config:
         existingClaim: *app
-        globalMounts:
-          - path: /config
 
       tmp:
         type: emptyDir

--- a/kubernetes/apps/media/radarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/radarr/app/helmrelease.yaml
@@ -76,7 +76,6 @@ spec:
               capabilities: { drop: ["ALL"] }
 
     defaultPodOptions:
-      enableServiceLinks: false
       securityContext:
         runAsUser: 568
         runAsGroup: 568

--- a/kubernetes/apps/media/recyclarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/recyclarr/app/helmrelease.yaml
@@ -19,8 +19,6 @@ spec:
         cronjob:
           timeZone: &timeZone ${TIMEZONE}
           schedule: "@daily"
-          successfulJobsHistory: 1
-          failedJobsHistory: 1
           backoffLimit: 1
         containers:
           app:
@@ -56,7 +54,6 @@ spec:
 
     persistence:
       config:
-        type: persistentVolumeClaim
         storageClass: ceph-block
         accessMode: ReadWriteOnce
         size: 1Gi

--- a/kubernetes/apps/media/sonarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/sonarr/app/helmrelease.yaml
@@ -79,7 +79,6 @@ spec:
               capabilities: { drop: ["ALL"] }
 
     defaultPodOptions:
-      enableServiceLinks: false
       securityContext:
         runAsUser: 568
         runAsGroup: 568

--- a/kubernetes/apps/media/unpackerr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/unpackerr/app/helmrelease.yaml
@@ -92,7 +92,6 @@ spec:
 
     serviceMonitor:
       app:
-        serviceName: *app
         endpoints:
           - port: http
             scheme: http

--- a/kubernetes/apps/network/envoy-gateway/app/envoy.yaml
+++ b/kubernetes/apps/network/envoy-gateway/app/envoy.yaml
@@ -204,7 +204,6 @@ spec:
     - type: Gzip
       gzip: {}
   retry:
-    numRetries: 2
     retryOn:
       triggers:
         - reset

--- a/kubernetes/apps/network/external-service/arm/endpointslice.yaml
+++ b/kubernetes/apps/network/external-service/arm/endpointslice.yaml
@@ -12,4 +12,3 @@ endpoints:
 ports:
   - port: 30173
     name: http
-    protocol: TCP

--- a/kubernetes/apps/network/external-service/arm/httproute.yaml
+++ b/kubernetes/apps/network/external-service/arm/httproute.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/gateway.networking.k8s.io/httproute_v1.json
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:

--- a/kubernetes/apps/network/external-service/arm/service.yaml
+++ b/kubernetes/apps/network/external-service/arm/service.yaml
@@ -4,7 +4,6 @@ kind: Service
 metadata:
   name: internal-arm
 spec:
-  type: ClusterIP
   clusterIP: None
   ports:
     - port: 80

--- a/kubernetes/apps/network/external-service/avr/endpointslice.yaml
+++ b/kubernetes/apps/network/external-service/avr/endpointslice.yaml
@@ -12,4 +12,3 @@ endpoints:
 ports:
   - port: 11080
     name: http
-    protocol: TCP

--- a/kubernetes/apps/network/external-service/avr/httproute.yaml
+++ b/kubernetes/apps/network/external-service/avr/httproute.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/gateway.networking.k8s.io/httproute_v1.json
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:

--- a/kubernetes/apps/network/external-service/avr/service.yaml
+++ b/kubernetes/apps/network/external-service/avr/service.yaml
@@ -4,7 +4,6 @@ kind: Service
 metadata:
   name: internal-avr
 spec:
-  type: ClusterIP
   clusterIP: None
   ports:
     - port: 80

--- a/kubernetes/apps/network/external-service/centauri-carbon/endpointslice.yaml
+++ b/kubernetes/apps/network/external-service/centauri-carbon/endpointslice.yaml
@@ -12,4 +12,3 @@ endpoints:
 ports:
   - port: 80
     name: http
-    protocol: TCP

--- a/kubernetes/apps/network/external-service/centauri-carbon/httproute.yaml
+++ b/kubernetes/apps/network/external-service/centauri-carbon/httproute.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/gateway.networking.k8s.io/httproute_v1.json
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:

--- a/kubernetes/apps/network/external-service/centauri-carbon/service.yaml
+++ b/kubernetes/apps/network/external-service/centauri-carbon/service.yaml
@@ -9,4 +9,3 @@ spec:
       targetPort: 80
       name: http
   clusterIP: None
-  type: ClusterIP

--- a/kubernetes/apps/network/external-service/homeassistant/endpointslice.yaml
+++ b/kubernetes/apps/network/external-service/homeassistant/endpointslice.yaml
@@ -12,4 +12,3 @@ endpoints:
 ports:
   - port: 8123
     name: http
-    protocol: TCP

--- a/kubernetes/apps/network/external-service/homeassistant/httproute.yaml
+++ b/kubernetes/apps/network/external-service/homeassistant/httproute.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/gateway.networking.k8s.io/httproute_v1.json
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:

--- a/kubernetes/apps/network/external-service/homeassistant/service.yaml
+++ b/kubernetes/apps/network/external-service/homeassistant/service.yaml
@@ -4,7 +4,6 @@ kind: Service
 metadata:
   name: external-homeassistant
 spec:
-  type: ClusterIP
   clusterIP: None
   ports:
     - port: 80

--- a/kubernetes/apps/network/external-service/ipmi/endpointslice.yaml
+++ b/kubernetes/apps/network/external-service/ipmi/endpointslice.yaml
@@ -12,4 +12,3 @@ endpoints:
 ports:
   - port: 443
     name: https
-    protocol: TCP

--- a/kubernetes/apps/network/external-service/ipmi/service.yaml
+++ b/kubernetes/apps/network/external-service/ipmi/service.yaml
@@ -4,7 +4,6 @@ kind: Service
 metadata:
   name: internal-ipmi
 spec:
-  type: ClusterIP
   clusterIP: None
   ports:
     - port: 443

--- a/kubernetes/apps/network/external-service/ntopg/endpointslice.yaml
+++ b/kubernetes/apps/network/external-service/ntopg/endpointslice.yaml
@@ -12,4 +12,3 @@ endpoints:
 ports:
   - port: 3000
     name: http
-    protocol: TCP

--- a/kubernetes/apps/network/external-service/ntopg/httproute.yaml
+++ b/kubernetes/apps/network/external-service/ntopg/httproute.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/gateway.networking.k8s.io/httproute_v1.json
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:

--- a/kubernetes/apps/network/external-service/ntopg/service.yaml
+++ b/kubernetes/apps/network/external-service/ntopg/service.yaml
@@ -4,7 +4,6 @@ kind: Service
 metadata:
   name: internal-ntopg
 spec:
-  type: ClusterIP
   clusterIP: None
   ports:
     - port: 80

--- a/kubernetes/apps/network/external-service/opnsense/endpointslice.yaml
+++ b/kubernetes/apps/network/external-service/opnsense/endpointslice.yaml
@@ -12,4 +12,3 @@ endpoints:
 ports:
   - port: 443
     name: https
-    protocol: TCP

--- a/kubernetes/apps/network/external-service/opnsense/service.yaml
+++ b/kubernetes/apps/network/external-service/opnsense/service.yaml
@@ -4,7 +4,6 @@ kind: Service
 metadata:
   name: internal-opnsense
 spec:
-  type: ClusterIP
   clusterIP: None
   ports:
     - port: 443

--- a/kubernetes/apps/network/external-service/scrutiny/endpointslice.yaml
+++ b/kubernetes/apps/network/external-service/scrutiny/endpointslice.yaml
@@ -12,4 +12,3 @@ endpoints:
 ports:
   - port: 31054
     name: http
-    protocol: TCP

--- a/kubernetes/apps/network/external-service/scrutiny/service.yaml
+++ b/kubernetes/apps/network/external-service/scrutiny/service.yaml
@@ -9,4 +9,3 @@ spec:
       targetPort: 31054
       name: http
   clusterIP: None
-  type: ClusterIP

--- a/kubernetes/apps/network/external-service/truenas/endpointslice.yaml
+++ b/kubernetes/apps/network/external-service/truenas/endpointslice.yaml
@@ -12,4 +12,3 @@ endpoints:
 ports:
   - port: 443
     name: https
-    protocol: TCP

--- a/kubernetes/apps/network/external-service/truenas/service.yaml
+++ b/kubernetes/apps/network/external-service/truenas/service.yaml
@@ -4,7 +4,6 @@ kind: Service
 metadata:
   name: internal-truenas
 spec:
-  type: ClusterIP
   clusterIP: None
   ports:
     - port: 443

--- a/kubernetes/apps/network/external-service/vaultwarden/endpointslice.yaml
+++ b/kubernetes/apps/network/external-service/vaultwarden/endpointslice.yaml
@@ -12,4 +12,3 @@ endpoints:
 ports:
   - port: 30032
     name: http
-    protocol: TCP

--- a/kubernetes/apps/network/external-service/vaultwarden/httproute.yaml
+++ b/kubernetes/apps/network/external-service/vaultwarden/httproute.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/gateway.networking.k8s.io/httproute_v1.json
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:

--- a/kubernetes/apps/network/external-service/vaultwarden/service.yaml
+++ b/kubernetes/apps/network/external-service/vaultwarden/service.yaml
@@ -4,7 +4,6 @@ kind: Service
 metadata:
   name: internal-vaultwarden
 spec:
-  type: ClusterIP
   clusterIP: None
   ports:
     - port: 80

--- a/kubernetes/apps/network/smtp-relay/app/kustomization.yaml
+++ b/kubernetes/apps/network/smtp-relay/app/kustomization.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/kubernetes/apps/observability/exporters/drm-exporter/app/prometheusrule.yaml
+++ b/kubernetes/apps/observability/exporters/drm-exporter/app/prometheusrule.yaml
@@ -9,14 +9,9 @@ spec:
     - name: drm-exporter.rules
       rules:
         - alert: GpuFanStalled
-          # ROCm #6101 and #6078 are filed against this exact SKU (ASUS Turbo
-          # R9700): blower stationary under load, GPU to 109C, thermally
-          # throttling. Root cause is the SMU interface mismatch this card also
-          # reports (driver 0x2e vs fw 0x32) leaving fan registers inaccessible.
-          # No upstream fix, reported still present on kernel 7.0. The fan is the
-          # only thermal margin this card has, so this is the one GPU condition
-          # worth paging on. Floor is 30% PWM (~1650rpm); under 1000 while pulling
-          # >100W is the stall, not a low idle.
+          # ROCm #6101/#6078 on this SKU: SMU mismatch (driver 0x2e vs fw 0x32)
+          # leaves fan registers inaccessible, blower stalls to 109C under load.
+          # Fan floor is 30% PWM (~1650rpm), so <1000 at >100W is a stall, not idle.
           expr: |-
             max by (kubernetes_node) (drm_fan_speed_rpm) < 1000
             and

--- a/kubernetes/apps/observability/exporters/kepler/ks.yaml
+++ b/kubernetes/apps/observability/exporters/kepler/ks.yaml
@@ -20,9 +20,8 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: kepler-power-monitor
-  namespace: &namespace observability
+  namespace: observability
 spec:
-  targetNamespace: *namespace
   dependsOn:
     - name: kepler
       namespace: observability

--- a/kubernetes/apps/observability/exporters/kepler/ks.yaml
+++ b/kubernetes/apps/observability/exporters/kepler/ks.yaml
@@ -15,12 +15,14 @@ spec:
     namespace: flux-system
   interval: 30m
 ---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: kepler-power-monitor
-  namespace: observability
+  namespace: &namespace observability
 spec:
+  targetNamespace: *namespace
   dependsOn:
     - name: kepler
       namespace: observability

--- a/kubernetes/apps/observability/exporters/kepler/powermonitor/powermonitor.yaml
+++ b/kubernetes/apps/observability/exporters/kepler/powermonitor/powermonitor.yaml
@@ -12,10 +12,8 @@ metadata:
     app.kubernetes.io/part-of: kepler-operator
 spec:
   kepler:
-    config:
-      logLevel: info
     deployment:
-      # Only run on nodes with kepler-node=true (control-2, control-3)
+      # kepler-node=true is control-2/3; control-1 is a VM, scraped via the kepler-truenas ScrapeConfig
       nodeSelector:
         kubernetes.io/os: linux
         kepler-node: "true"

--- a/kubernetes/apps/observability/exporters/nut-exporter/ks.yaml
+++ b/kubernetes/apps/observability/exporters/nut-exporter/ks.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
@@ -7,7 +8,7 @@ metadata:
 spec:
   targetNamespace: *namespace
   interval: 30m
-  path: "./kubernetes/apps/observability/exporters/nut-exporter/app"
+  path: ./kubernetes/apps/observability/exporters/nut-exporter/app
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/observability/exporters/opnsense-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/exporters/opnsense-exporter/app/helmrelease.yaml
@@ -21,8 +21,6 @@ spec:
               repository: ghcr.io/athennamind/opnsense-exporter
               tag: 0.0.16@sha256:64469206eb955b6c87ec2737cd4884b0bec01b518408cf1ac6d5c153f6c0cf1f
             args:
-              # - --log.level=debug
-              # - --log.format=json
               - --web.listen-address=:8080
             env:
               OPNSENSE_EXPORTER_INSTANCE_LABEL: "gw"

--- a/kubernetes/apps/observability/exporters/prowlarr-exporter/ks.yaml
+++ b/kubernetes/apps/observability/exporters/prowlarr-exporter/ks.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/kubernetes/apps/observability/exporters/qbittorrent-exporter/ks.yaml
+++ b/kubernetes/apps/observability/exporters/qbittorrent-exporter/ks.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/kubernetes/apps/observability/exporters/scraparr/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/exporters/scraparr/app/helmrelease.yaml
@@ -1,5 +1,5 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/kubernetes/apps/observability/exporters/scraparr/ks.yaml
+++ b/kubernetes/apps/observability/exporters/scraparr/ks.yaml
@@ -1,5 +1,5 @@
-# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 ---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/kubernetes/apps/observability/exporters/sonarr-exporter/ks.yaml
+++ b/kubernetes/apps/observability/exporters/sonarr-exporter/ks.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/kubernetes/apps/observability/exporters/speedtest-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/exporters/speedtest-exporter/app/helmrelease.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/refs/heads/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/kubernetes/apps/observability/exporters/speedtest-exporter/ks.yaml
+++ b/kubernetes/apps/observability/exporters/speedtest-exporter/ks.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/kubernetes/apps/observability/gatus/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/gatus/app/helmrelease.yaml
@@ -34,9 +34,7 @@ spec:
         failureThreshold: 3
       readinessProbe: *probes
       securityContext:
-        allowPrivilegeEscalation: false
-        readOnlyRootFilesystem: true
-        capabilities: { add: ["NET_RAW"], drop: ["ALL"] }
+        capabilities: { add: ["NET_RAW"] }
       resources:
         requests:
           cpu: 50m

--- a/kubernetes/apps/observability/keda/ks.yaml
+++ b/kubernetes/apps/observability/keda/ks.yaml
@@ -4,6 +4,7 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: keda
+  namespace: &namespace observability
 spec:
   interval: 1h
   path: ./kubernetes/apps/observability/keda/app
@@ -12,5 +13,5 @@ spec:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: observability
+  targetNamespace: *namespace
   wait: true

--- a/kubernetes/apps/observability/kromgo/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kromgo/app/helmrelease.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/kubernetes/apps/observability/kromgo/app/kustomization.yaml
+++ b/kubernetes/apps/observability/kromgo/app/kustomization.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/kubernetes/apps/observability/kromgo/app/ocirepository.yaml
+++ b/kubernetes/apps/observability/kromgo/app/ocirepository.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository
 metadata:

--- a/kubernetes/apps/observability/silence-operator/silences/silences.yaml
+++ b/kubernetes/apps/observability/silence-operator/silences/silences.yaml
@@ -28,8 +28,8 @@ spec:
 apiVersion: observability.giantswarm.io/v1alpha2
 kind: Silence
 metadata:
-  # Structural: control-1 (39Gi, only GPU node) dwarfs control-2/3 (21Gi); N-1 memory
-  # capacity is unfixable by request tuning. Rule stays visible in vmalert.
+  # Structural: control-1 (53Gi allocatable) dwarfs control-2/3 (21Gi); N-1 memory
+  # capacity is unfixable by request tuning.
   name: kube-memory-overcommit-homelab
 spec:
   matchers:

--- a/kubernetes/apps/observability/siren/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/siren/app/helmrelease.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/kubernetes/apps/observability/siren/app/kustomization.yaml
+++ b/kubernetes/apps/observability/siren/app/kustomization.yaml
@@ -1,5 +1,5 @@
-# yaml-language-server: $schema=https://json.schemastore.org/kustomization
 ---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/kubernetes/apps/observability/siren/ks.yaml
+++ b/kubernetes/apps/observability/siren/ks.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:

--- a/kubernetes/apps/observability/victoria-logs/ks.yaml
+++ b/kubernetes/apps/observability/victoria-logs/ks.yaml
@@ -4,6 +4,7 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: victoria-logs
+  namespace: &namespace observability
 spec:
   dependsOn:
     - name: rook-ceph-cluster
@@ -23,6 +24,7 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: victoria-logs-collector
+  namespace: &namespace observability
 spec:
   dependsOn:
     - name: victoria-logs

--- a/kubernetes/apps/observability/victoria-logs/ks.yaml
+++ b/kubernetes/apps/observability/victoria-logs/ks.yaml
@@ -16,7 +16,7 @@ spec:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: observability
+  targetNamespace: *namespace
   wait: false
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
@@ -35,5 +35,5 @@ spec:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: observability
+  targetNamespace: *namespace
   wait: false

--- a/kubernetes/apps/observability/victoria-metrics/app/kustomization.yaml
+++ b/kubernetes/apps/observability/victoria-metrics/app/kustomization.yaml
@@ -2,7 +2,6 @@
 # yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: observability
 
 resources:
   - grafanadashboard.yaml

--- a/kubernetes/apps/observability/victoria-metrics/app/scrapeconfig.yaml
+++ b/kubernetes/apps/observability/victoria-metrics/app/scrapeconfig.yaml
@@ -31,7 +31,6 @@ spec:
       replacement: *app
 ---
 # Kepler on TrueNAS (control-1 VM host). Scrapes host port 28284 (compose maps 28284:28282).
-# See docs/kepler-truenas.md.
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/monitoring.coreos.com/scrapeconfig_v1alpha1.json
 apiVersion: monitoring.coreos.com/v1alpha1
 kind: ScrapeConfig

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -43,9 +43,10 @@ spec:
     cephClusterSpec:
       cephConfig:
         global:
-          bdev_enable_discard: "true" # string value required
-          bdev_async_discard_threads: "1" # string value required
-          osd_class_update_on_start: "false" # string value required
+          # Rook rejects non-string cephConfig values.
+          bdev_enable_discard: "true"
+          bdev_async_discard_threads: "1"
+          osd_class_update_on_start: "false"
           device_failure_prediction_mode: local # requires mgr module
           # Network optimization for 2.5Gbps
           ms_osd_compress_min_size: "1024"
@@ -186,9 +187,7 @@ spec:
                 memory: "4Gi"
         storageClass:
           enabled: true
-          isDefault: false
           name: ceph-filesystem
-          pool: data0
           reclaimPolicy: Delete
           allowVolumeExpansion: true
           volumeBindingMode: Immediate

--- a/kubernetes/apps/rook-ceph/rook-ceph/csi/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/csi/helmrelease.yaml
@@ -73,7 +73,5 @@ spec:
           ms_mode: prefer-crc
       nfs:
         enabled: false
-        name: rook-ceph.nfs.csi.ceph.com
       nvmeof:
         enabled: false
-        name: rook-ceph.nvmeof.csi.ceph.com

--- a/kubernetes/apps/security/crowdsec/ks.yaml
+++ b/kubernetes/apps/security/crowdsec/ks.yaml
@@ -4,6 +4,7 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: crowdsec
+  namespace: &namespace security
 spec:
   dependsOn:
     - name: cloudnative-pg-cluster
@@ -23,6 +24,7 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: crowdsec-bouncers
+  namespace: &namespace security
 spec:
   dependsOn:
     - name: crowdsec

--- a/kubernetes/apps/security/crowdsec/ks.yaml
+++ b/kubernetes/apps/security/crowdsec/ks.yaml
@@ -16,7 +16,7 @@ spec:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: security
+  targetNamespace: *namespace
   wait: true
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
@@ -35,4 +35,4 @@ spec:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: security
+  targetNamespace: *namespace

--- a/kubernetes/apps/web3/monero/xmrig/helmrelease.yaml
+++ b/kubernetes/apps/web3/monero/xmrig/helmrelease.yaml
@@ -31,9 +31,7 @@ spec:
               # Cap mining threads to the CFS quota: 50% of 12 host cores = 6 threads = cpu limit.
               # Without this xmrig auto-detects 12 cores, spawns 12 threads, and is throttled
               # 90-100% of CFS periods (CPUThrottlingHigh), inflating load average on every node.
-              # Revisit if the cpu limit or node core count changes.
               - "--cpu-max-threads-hint=50"
-              # Prefer huge pages (2Mi)
               - "--huge-pages"
               # Enable HTTP API for dashboard
               - "--http-port=42000"
@@ -72,7 +70,6 @@ spec:
         nodeAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
             # Prefer control-2 and control-3 (more power efficient)
-            # A realistic 6-core CPU request gates control-1 usage on actual headroom.
             - weight: 100
               preference:
                 matchExpressions:

--- a/kubernetes/apps/web3/monero/xmrig/scaledobject.yaml
+++ b/kubernetes/apps/web3/monero/xmrig/scaledobject.yaml
@@ -15,7 +15,7 @@ spec:
   minReplicaCount: 0
   maxReplicaCount: 3 # One miner per node (3 nodes total)
   cooldownPeriod: 0 # Guard dwell already debounces trips and recovery
-  pollingInterval: 60 # Check every 60 seconds
+  pollingInterval: 60
   fallback:
     # A VictoriaMetrics/scaler error is unsafe: do not keep miners running on stale state.
     failureThreshold: 1
@@ -37,7 +37,7 @@ spec:
               periodSeconds: 15
         scaleUp:
           # Scale up quickly when solar power is available
-          stabilizationWindowSeconds: 60 # 1 minute before scaling up
+          stabilizationWindowSeconds: 60
           policies:
             # Percent 100 dominates a Pods-1 policy at every reachable replica count
             - type: Percent


### PR DESCRIPTION
Follow-up to #4209, applying the same conventions to the other ten namespaces. No runtime behaviour change.

## Scope

| namespace | files |
|---|---|
| network | 28 |
| observability | 24 |
| media | 13 |
| database | 6 |
| kube-system | 5 |
| default | 4 |
| flux-system, rook-ceph, web3, security | 7 |

87 files, +59/-143.

## Proof

`flate build hr` over every HelmRelease in the repo, before and after. Rendered chart output vs `origin/main`:

| | |
|---|---|
| changed | **0** |
| removed | **0** |
| added | **1** — `ConfigMap kube-system/spegel-dashboard`, the intended spegel change |

So apart from that one deliberate addition, the rendered output is byte-identical. CRD-default removals were separately confirmed with `kubectl apply --dry-run=server`, and rendered Kustomizations were compared per namespace as well.

## Reverted by that check

Four proposals passed adversarial verification but changed real behaviour, and were dropped:

| Proposal | Why it was wrong |
|---|---|
| metrics-server `--kubelet-preferred-address-types`, `--kubelet-use-node-status-port` | found in the chart's `defaultArgs`, but this release sets `args`, which **replaces** defaultArgs; both flags vanished from the rendered Deployment |
| external-dns `--crd-source-apiversion`, `--crd-source-kind` | match the binary's CLI defaults, not chart defaults, so they left the rendered args |
| nextcloud nginx comment | lives inside the rendered config, so it moves the ConfigMap and forces a restart |
| k8s-gateway `fullnameOverride` | names and ConfigMap data identical, but `checksum/config` moved, rolling cluster DNS for no gain |

## Also

`default/karakeep` hostname to `{{ .Release.Name }}` — the last of three app-template hostnames repo-wide duplicating their release name. Verified by rendering the HTTPRoute before and after.

Merges cleanly with #4210, which touches the same karakeep file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - External service endpoints now use headless service discovery across multiple applications.
  - Application routes can derive hostnames from their deployment release names.
  - Service account token access is enabled where required.

- **Bug Fixes**
  - Updated Ceph configuration to ensure values are accepted correctly.
  - Improved dashboard sourcing and startup probe behavior.
  - Disabled unsupported NVMe-over-Fabrics storage integration.

- **Documentation**
  - Added or updated schema hints and operational guidance across Kubernetes resources for improved validation and editor support.
  - Clarified database password rotation behavior and GPU fan monitoring alerts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


## Follow-ups added after review

| Issue | Fix |
|---|---|
| Three ks.yaml got an anchor declared but never dereferenced (brrpolice, victoria-logs, crowdsec) | the dereference was a separate finding my applier skipped as ambiguous; completed both halves |
| kepler-power-monitor gained a `targetNamespace` | its only resource is a **cluster-scoped** PowerMonitor (Flux inventory `_power-monitor_..`); forcing a namespace is rejected by the API server. Reverted |
| amdgpu-undervolt comment rewritten | restored the original measured wording; the rewrite added an interpretation that was not what was measured |
| Renovate's GrafanaDashboard URL manager never matched anything | `matchStringsStrategy: recursive` made the second pattern search inside the first pattern's match, where the version does not appear. Both tracked dashboards had drifted (spegel v0.7.2 vs chart 0.7.4, klipper-exporter v0.15.0 vs v0.16.0). Replaced with one combined pattern, verified to match exactly the 2 version-pinned URLs and none of the 23 branch-tracking ones |

Rendered Kustomizations were also compared per namespace against `origin/main`, not just HelmReleases. The only remaining rendered difference is `imagePullPolicy` on amdgpu-undervolt, which `--dry-run=server` refills as `IfNotPresent`.
