### PR TITLE
feat(toolhive): re-enable the GitHub MCP over streamable-http

### DIFF
--- a/kubernetes/apps/ai/toolhive/config/github.yaml
+++ b/kubernetes/apps/ai/toolhive/config/github.yaml
@@ -1,82 +1,101 @@
-# Disabled: ToolHive v0.40.1 virtual-MCP health monitoring repeatedly initializes
-# GitHub's stdio backend, which returns `duplicate "initialize" received` and
-# degrades the resources and unified virtual MCPs. Restore after an upstream fix.
-# ---
-# apiVersion: toolhive.stacklok.dev/v1beta1
-# kind: MCPServer
-# metadata:
-#   name: &name github
-# spec:
-#   image: ghcr.io/github/github-mcp-server:v1.6.0
-#   transport: stdio
-#   groupRef:
-#     name: resources
-#   args:
-#     - stdio
-#   secrets:
-#     - name: toolhive-secrets
-#       key: GITHUB_PERSONAL_ACCESS_TOKEN
-#       targetEnvName: GITHUB_PERSONAL_ACCESS_TOKEN
-#   toolConfigRef:
-#     name: *name
-#   podTemplateSpec:
-#     spec:
-#       containers:
-#         - name: mcp
-#           resources:
-#             requests:
-#               cpu: 10m
-#               memory: 64Mi
-#             limits:
-#               cpu: 500m
-#               memory: 256Mi
-#   resources:
-#     requests:
-#       cpu: 10m
-#       memory: 64Mi
-#     limits:
-#       cpu: 200m
-#       memory: 200Mi
-# ---
-# apiVersion: toolhive.stacklok.dev/v1beta1
-# kind: MCPServer
-# metadata:
-#   name: github-opt
-# spec:
-#   image: ghcr.io/github/github-mcp-server:v1.6.0
-#   transport: stdio
-#   groupRef:
-#     name: all
-#   args:
-#     - stdio
-#   secrets:
-#     - name: toolhive-secrets
-#       key: GITHUB_PERSONAL_ACCESS_TOKEN
-#       targetEnvName: GITHUB_PERSONAL_ACCESS_TOKEN
-#   toolConfigRef:
-#     name: github
-#   podTemplateSpec:
-#     spec:
-#       containers:
-#         - name: mcp
-#           resources:
-#             requests:
-#               cpu: 10m
-#               memory: 64Mi
-#             limits:
-#               cpu: 500m
-#               memory: 256Mi
-#   resources:
-#     requests:
-#       cpu: 10m
-#       memory: 64Mi
-#     limits:
-#       cpu: 200m
-#       memory: 200Mi
 ---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/toolhive.stacklok.dev/mcpexternalauthconfig_v1beta1.json
 apiVersion: toolhive.stacklok.dev/v1beta1
-kind: MCPToolConfig
+kind: MCPExternalAuthConfig
 metadata:
   name: github
 spec:
-  toolsFilter: []
+  # The `http` subcommand takes no server-side token: unlike stdio, its ServerConfig
+  # carries no Token field and it authenticates per request. The proxy injects the
+  # PAT as an Authorization: Bearer header instead.
+  type: bearerToken
+  bearerToken:
+    tokenSecretRef:
+      name: toolhive-secrets
+      key: GITHUB_PERSONAL_ACCESS_TOKEN
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/toolhive.stacklok.dev/mcpserver_v1beta1.json
+apiVersion: toolhive.stacklok.dev/v1beta1
+kind: MCPServer
+metadata:
+  name: &name github
+spec:
+  # streamable-http, not stdio: ToolHive health monitoring re-runs `initialize`,
+  # which the stdio backend rejects with `duplicate "initialize" received` and
+  # which degraded the resources and unified gateways (upstream #5890).
+  image: ghcr.io/github/github-mcp-server:v1.7.0
+  transport: streamable-http
+  mcpPort: 8082 # `http` binds 8082 by default and exposes no env-bound port flag
+  proxyPort: 8080
+  groupRef:
+    name: resources
+  permissionProfile:
+    type: builtin
+    name: network
+  externalAuthConfigRef:
+    name: *name
+  args:
+    - http
+    - --read-only
+    # The full server is ~79 tools; this subset keeps the optimizer's index small.
+    - --toolsets
+    - context,repos,issues,pull_requests
+  podTemplateSpec:
+    spec:
+      containers:
+        - name: mcp
+          resources:
+            requests:
+              cpu: 10m
+              memory: 64Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+  resources:
+    requests:
+      cpu: 10m
+      memory: 64Mi
+    limits:
+      cpu: 200m
+      memory: 200Mi
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/toolhive.stacklok.dev/mcpserver_v1beta1.json
+apiVersion: toolhive.stacklok.dev/v1beta1
+kind: MCPServer
+metadata:
+  name: github-opt
+spec:
+  image: ghcr.io/github/github-mcp-server:v1.7.0
+  transport: streamable-http
+  mcpPort: 8082
+  proxyPort: 8080
+  groupRef:
+    name: all
+  permissionProfile:
+    type: builtin
+    name: network
+  externalAuthConfigRef:
+    name: github
+  args:
+    - http
+    - --read-only
+    - --toolsets
+    - context,repos,issues,pull_requests
+  podTemplateSpec:
+    spec:
+      containers:
+        - name: mcp
+          resources:
+            requests:
+              cpu: 10m
+              memory: 64Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+  resources:
+    requests:
+      cpu: 10m
+      memory: 64Mi
+    limits:
+      cpu: 200m
+      memory: 200Mi


### PR DESCRIPTION
Re-enables the GitHub MCP server, disabled since ToolHive v0.40.1 health monitoring re-ran `initialize` against its stdio backend and degraded the `resources` and `unified` gateways (upstream #5890).

## Why a transport change, not a different server

| Question | Answer |
|---|---|
| Is there a newer toolhive that fixes it? | No. v0.40.1 is latest (released 2026-07-20) and is what we pin. Issue #5890 is open, untriaged, zero linked PRs |
| Does the same server support HTTP? | Yes, since [PR #1849](https://github.com/github/github-mcp-server/pull/1849). Read-only enforcement in HTTP mode was broken at first and fixed by [#2208](https://github.com/github/github-mcp-server/pull/2208), in every release from v1.0.0 |
| Better alternative? | No. `octocode-mcp` is stdio-only with no container image; Docker Hub `mcp/github` wraps the archived implementation, stdio-only, `latest` tag only |

## The part the transport change forces

`http` takes **no server-side token**. Unlike the stdio path, its `ServerConfig` has no `Token` field and it authenticates per request, so the PAT cannot stay an env var:

```go
// cmd/github-mcp-server/main.go - stdio
stdioServerConfig := ghmcp.StdioServerConfig{ ... Token: token, ... }
// http - no Token field anywhere in httpConfig
```

So the PAT moves to an `MCPExternalAuthConfig` of type `bearerToken`, which makes the proxy attach it as an `Authorization` header. **This is the first MCPExternalAuthConfig in the cluster.**

## Scoping

`--read-only` plus `--toolsets context,repos,issues,pull_requests`. The full server exposes ~79 tools and every one lands in the unified gateway's semantic tool index. No `MCPToolConfig`: `toolsFilter: []` is a proven no-op (see #4211), so scoping is done on the server itself.

## Verified

- `ghcr.io/github/github-mcp-server:v1.7.0` manifest exists on ghcr (amd64+arm64), released 2026-07-23
- all three objects pass `kubectl apply --dry-run=server`
- `toolhive-secrets` still carries `GITHUB_PERSONAL_ACCESS_TOKEN`

**Not runtime-verified — no pods have been started.** Draft until someone watches the first rollout: confirm the pod goes Ready, `github_*` tools appear on `vmcp-resources`, and the `unified` gateway does not report a degraded backend.