### PR TITLE
chore(toolhive): pin the MCP server images to digests

### DIFF
--- a/kubernetes/apps/ai/toolhive/config/flux-operator.yaml
+++ b/kubernetes/apps/ai/toolhive/config/flux-operator.yaml
@@ -4,7 +4,7 @@ kind: MCPServer
 metadata:
   name: &name flux-operator
 spec:
-  image: ghcr.io/controlplaneio-fluxcd/flux-operator-mcp:v0.57.0
+  image: ghcr.io/controlplaneio-fluxcd/flux-operator-mcp:v0.57.0@sha256:a53ae414ec4f7671697707c69a61f0209842dfc108ad2fb13461b118d7475e3d
   transport: stdio
   groupRef:
     name: flux
@@ -50,7 +50,7 @@ kind: MCPServer
 metadata:
   name: flux-operator-opt
 spec:
-  image: ghcr.io/controlplaneio-fluxcd/flux-operator-mcp:v0.57.0
+  image: ghcr.io/controlplaneio-fluxcd/flux-operator-mcp:v0.57.0@sha256:a53ae414ec4f7671697707c69a61f0209842dfc108ad2fb13461b118d7475e3d
   transport: stdio
   groupRef:
     name: all

--- a/kubernetes/apps/ai/toolhive/config/github.yaml
+++ b/kubernetes/apps/ai/toolhive/config/github.yaml
@@ -23,7 +23,7 @@ spec:
   # streamable-http, not stdio: ToolHive health monitoring re-runs `initialize`,
   # which the stdio backend rejects with `duplicate "initialize" received` and
   # which degraded the resources and unified gateways (upstream #5890).
-  image: ghcr.io/github/github-mcp-server:v1.7.0
+  image: ghcr.io/github/github-mcp-server:v1.7.0@sha256:c491ffdf6f4c85cb5397021bc655edb8ab825c6f5f568e7597d77a1bd7c4d308
   transport: streamable-http
   mcpPort: 8082 # `http` binds 8082 by default and exposes no env-bound port flag
   proxyPort: 8080
@@ -65,7 +65,7 @@ kind: MCPServer
 metadata:
   name: github-opt
 spec:
-  image: ghcr.io/github/github-mcp-server:v1.7.0
+  image: ghcr.io/github/github-mcp-server:v1.7.0@sha256:c491ffdf6f4c85cb5397021bc655edb8ab825c6f5f568e7597d77a1bd7c4d308
   transport: streamable-http
   mcpPort: 8082
   proxyPort: 8080

--- a/kubernetes/apps/ai/toolhive/config/grafana.yaml
+++ b/kubernetes/apps/ai/toolhive/config/grafana.yaml
@@ -4,7 +4,7 @@ kind: MCPServer
 metadata:
   name: &name grafana
 spec:
-  image: grafana/mcp-grafana:0.17.2
+  image: grafana/mcp-grafana:0.17.2@sha256:d5b51db0c8eaafc6ed3fede5bfcc8d67b2384a40cf3d493086e378855ceba882
   transport: stdio
   groupRef:
     name: observability
@@ -40,7 +40,7 @@ kind: MCPServer
 metadata:
   name: grafana-opt
 spec:
-  image: grafana/mcp-grafana:0.17.2
+  image: grafana/mcp-grafana:0.17.2@sha256:d5b51db0c8eaafc6ed3fede5bfcc8d67b2384a40cf3d493086e378855ceba882
   transport: stdio
   groupRef:
     name: all

--- a/kubernetes/apps/ai/toolhive/config/karakeep.yaml
+++ b/kubernetes/apps/ai/toolhive/config/karakeep.yaml
@@ -4,7 +4,7 @@ kind: MCPServer
 metadata:
   name: &name karakeep
 spec:
-  image: ghcr.io/karakeep-app/karakeep-mcp:0.32.0
+  image: ghcr.io/karakeep-app/karakeep-mcp:0.32.0@sha256:8b2f784ad0ffc5dbc75485f125e23fdd033d4c9d05d680e8f090b6b6aa93c2f6
   transport: stdio
   groupRef:
     name: resources
@@ -41,7 +41,7 @@ kind: MCPServer
 metadata:
   name: karakeep-opt
 spec:
-  image: ghcr.io/karakeep-app/karakeep-mcp:0.32.0
+  image: ghcr.io/karakeep-app/karakeep-mcp:0.32.0@sha256:8b2f784ad0ffc5dbc75485f125e23fdd033d4c9d05d680e8f090b6b6aa93c2f6
   transport: stdio
   groupRef:
     name: all

--- a/kubernetes/apps/ai/toolhive/config/kubesearch.yaml
+++ b/kubernetes/apps/ai/toolhive/config/kubesearch.yaml
@@ -4,7 +4,7 @@ kind: MCPServer
 metadata:
   name: &name kubesearch
 spec:
-  image: ghcr.io/perfectra1n/kubesearch-mcp:master
+  image: ghcr.io/perfectra1n/kubesearch-mcp:master@sha256:7a8b6910dfb6ccbff807932d8054f11d645e66fcdcb707aab88102aab6f1729f
   transport: streamable-http
   mcpPort: &port 3000
   groupRef:
@@ -60,7 +60,7 @@ kind: MCPServer
 metadata:
   name: kubesearch-opt
 spec:
-  image: ghcr.io/perfectra1n/kubesearch-mcp:master
+  image: ghcr.io/perfectra1n/kubesearch-mcp:master@sha256:7a8b6910dfb6ccbff807932d8054f11d645e66fcdcb707aab88102aab6f1729f
   transport: streamable-http
   mcpPort: 3000
   groupRef:

--- a/kubernetes/apps/ai/toolhive/config/postgres-mcp.yaml
+++ b/kubernetes/apps/ai/toolhive/config/postgres-mcp.yaml
@@ -4,7 +4,7 @@ kind: MCPServer
 metadata:
   name: &name postgres-mcp
 spec:
-  image: crystaldba/postgres-mcp:0.3.0
+  image: crystaldba/postgres-mcp:0.3.0@sha256:dbbd346860d29f1543e991f30f3284bf4ab5f096d049ecc3426528f20b1b6e6b
   transport: stdio
   groupRef:
     name: database
@@ -40,7 +40,7 @@ kind: MCPServer
 metadata:
   name: postgres-mcp-opt
 spec:
-  image: crystaldba/postgres-mcp:0.3.0
+  image: crystaldba/postgres-mcp:0.3.0@sha256:dbbd346860d29f1543e991f30f3284bf4ab5f096d049ecc3426528f20b1b6e6b
   transport: stdio
   groupRef:
     name: all

--- a/kubernetes/apps/ai/toolhive/config/searxng.yaml
+++ b/kubernetes/apps/ai/toolhive/config/searxng.yaml
@@ -4,7 +4,7 @@ kind: MCPServer
 metadata:
   name: &name searxng
 spec:
-  image: ghcr.io/rcdailey/mcp-searxng:0.8.0
+  image: ghcr.io/rcdailey/mcp-searxng:0.8.0@sha256:5f4359be5f43b3bb77daabc60884dcd8c1d05a3c0b761ad78730da8453a660a2
   transport: stdio
   groupRef:
     name: search
@@ -38,7 +38,7 @@ kind: MCPServer
 metadata:
   name: searxng-opt
 spec:
-  image: ghcr.io/rcdailey/mcp-searxng:0.8.0
+  image: ghcr.io/rcdailey/mcp-searxng:0.8.0@sha256:5f4359be5f43b3bb77daabc60884dcd8c1d05a3c0b761ad78730da8453a660a2
   transport: stdio
   groupRef:
     name: all

--- a/kubernetes/apps/ai/toolhive/config/talos-mcp.yaml
+++ b/kubernetes/apps/ai/toolhive/config/talos-mcp.yaml
@@ -11,7 +11,7 @@ kind: MCPServer
 metadata:
   name: &name talos-mcp
 spec:
-  image: registry.erwanleboucher.dev/eleboucher/talos-mcp:0.0.2
+  image: registry.erwanleboucher.dev/eleboucher/talos-mcp:0.0.2@sha256:ad1b388e20cbe171763ba0ff85ed32856f2573c9c40f5081a83c96b3b57f0d35
   transport: streamable-http
   mcpPort: 8080
   proxyPort: 8080
@@ -64,7 +64,7 @@ kind: MCPServer
 metadata:
   name: talos-mcp-opt
 spec:
-  image: registry.erwanleboucher.dev/eleboucher/talos-mcp:0.0.2
+  image: registry.erwanleboucher.dev/eleboucher/talos-mcp:0.0.2@sha256:ad1b388e20cbe171763ba0ff85ed32856f2573c9c40f5081a83c96b3b57f0d35
   transport: streamable-http
   mcpPort: 8080
   proxyPort: 8080


### PR DESCRIPTION
The MCP servers were the only container-image gap in the repo: 59 of 67 image tag references already carry a digest, and these 8 were the remainder. Flux `OCIRepository` chart tags stay unpinned, which is the existing convention (0 of ~48 pinned) and is untouched here.

Renovate maintains a digest once one exists but never adds one, so it has to be written by hand once. Proof it maintains them, from `d4ec78f73`:

```
- image: ghcr.io/homeassistant-ai/ha-mcp:7.14.1@sha256:68f386d9...
+ image: ghcr.io/homeassistant-ai/ha-mcp:7.14.2@sha256:7917b2d3...
```

`.renovaterc.json5` already groups these as `toolhive-mcp`, so no config change is needed.

Every digest was verified against the live pod `imageID` in namespace `ai`, so this is a zero-rollout change:

| image | pinned digest | live |
|---|---|---|
| flux-operator-mcp:v0.57.0 | `a53ae414` | match |
| github-mcp-server:v1.7.0 | `c491ffdf` | not yet scheduled (#4212 just merged) |
| mcp-grafana:0.17.2 | `d5b51db0` | match |
| karakeep-mcp:0.32.0 | `8b2f784a` | match |
| kubesearch-mcp:master | `7a8b6910` | match |
| postgres-mcp:0.3.0 | `dbbd3468` | match |
| mcp-searxng:0.8.0 | `5f4359be` | match |
| talos-mcp:0.0.2 | `ad1b388e` | match |

**kubesearch is a separate commit.** It tracks a rolling `master` tag and had already drifted: pods run `7a8b6910` while the registry's `master` now resolves to `6d37df97`. It is pinned to the digest already running, so nothing changes now; the pending drift becomes a reviewable Renovate digest PR instead of arriving on the next unrelated restart. Drop that commit if the rolling tag is preferred, the other seven are independent.

`kustomize build` renders all 18 refs digest-pinned, 0 unpinned.

Not included, both worth a separate PR: a `pinDigests: true` rule scoped to `kubernetes/apps/ai/toolhive/config/**` so future MCP images arrive pinned, and a digest-automerge rule for these eight (today only `/home-operations/` images automerge digests). Also noted: `kubesearch-mcp` publishes semver tags (`1.0.1`), so it does not have to stay on a rolling tag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security & Reliability**
  - Pinned container images for multiple MCP servers to immutable SHA256 digests.
  - Improved deployment consistency and protection against unexpected image changes.
  - Updated Flux Operator, GitHub, Grafana, Karakeep, KubeSearch, PostgreSQL, SearXNG, and Talos MCP services.
  - No other service configuration or behavior was changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->