### PR TITLE
docs(sglang): trim the L3 comments to the load-bearing facts

### DIFF
--- a/docs/llm-hosting/sglang-blockers.md
+++ b/docs/llm-hosting/sglang-blockers.md
@@ -219,8 +219,7 @@ upstream of that measurement, and neither is a property of L3.
    4,538-of-61,600 backup figure. Any L3 test must run under plain `write_through`.
 
 The 07-15 run did not crash, so it cannot have been on an image with defect 1 — meaning it is not
-comparable to current builds and should not be quoted as evidence either way. **L3 was untested,
-not failed.**
+comparable to current builds and should not be quoted as evidence either way.
 
 **Retest (2026-07-27): L3 works.** Run on image `sha256:72d934d3` under plain `write_through`,
 with `--hicache-storage-backend file` and `SGLANG_HICACHE_FILE_BACKEND_STORAGE_DIR`.

--- a/kubernetes/apps/ai/llmkube/models/qwen36-27b-sglang.yaml
+++ b/kubernetes/apps/ai/llmkube/models/qwen36-27b-sglang.yaml
@@ -77,7 +77,6 @@ spec:
   runtime: sglang
   # Operator default binds :: (IPv6-only on this IPv4 cluster); override to v4.
   bindAddress: 0.0.0.0
-  # L3 needs OpenSSL headers in the runtime stage; earlier digests kill the scheduler.
   image: ghcr.io/tanguille/sglang-rdna4:v0.5.15-gfx1201@sha256:72d934d335529934bf73cd480b728cd08ae61178c9204dc37a025302b31fd61e
   containerPort: 30000
   endpoint:
@@ -122,12 +121,8 @@ spec:
       value: "0"
     - name: TRITON_CACHE_DIR
       value: /cache/sglang/triton
-    # Correctness knob, not a layout preference. The on-disk page name is
-    # sha256(token_ids, prior_hash, page_size) + "_{model_name}_{tp_rank}_{tp_size}",
-    # so nothing in it encodes the weights revision, the KV dtype or the KV layout.
-    # Same served-model-name plus same tokens hits the same file, which means a
-    # Renovate bump of either the AWQ revision below or the sglang image would serve
-    # KV pages computed by the previous one. Bump this suffix with either of them.
+    # Page names encode neither the weights revision nor the engine, so this suffix MUST be
+    # bumped with the image digest above or the AWQ revision, or stale KV pages get served.
     - name: SGLANG_HICACHE_FILE_BACKEND_STORAGE_DIR
       value: /hicache/sglang-v0.5.15_awq-f541031d
     # Unset defaults to unbounded; a full L2 measured 14G on 2026-07-27.


### PR DESCRIPTION
Follow-up to #4213, comments only. No config or behaviour changes.

A `/simplify` pass flagged three things in the merged L3 change:

- The `SGLANG_HICACHE_FILE_BACKEND_STORAGE_DIR` comment ran six lines and re-derived the reasoning that already lives in `docs/llm-hosting/sglang-blockers.md`. Cut to the two load-bearing facts: page names cover neither the weights nor the engine, and the suffix must be bumped with either pin.
- The comment above `image:` is on a Renovate-managed line with no digest anchor, so after the next bump a reader cannot tell whether it still applies. The build gate in the Dockerfile enforces the same constraint, so the comment was assertion without enforcement. Dropped.
- `L3 was untested, not failed` was stated immediately before the retest section that supersedes it.

## Not done

The hand-bumped revision suffix is still hand-bumped. The reviewer's point is fair: `.renovaterc.json5` already has customManagers on this file, so a third one could bump the suffix automatically, and nothing today fails if a Renovate digest bump lands without it. I left it alone because a regex manager stitching two datasources into one string is easy to get subtly wrong, and a half-working one would be worse than the documented manual step. Worth doing deliberately rather than as part of a comment cleanup.