### PR TITLE
feat(sglang): cut qwen36-27b over to the v0.5.16 engine

### DIFF
--- a/kubernetes/apps/ai/llmkube/models/qwen36-27b-sglang.yaml
+++ b/kubernetes/apps/ai/llmkube/models/qwen36-27b-sglang.yaml
@@ -77,7 +77,7 @@ spec:
   runtime: sglang
   # Operator default binds :: (IPv6-only on this IPv4 cluster); override to v4.
   bindAddress: 0.0.0.0
-  image: ghcr.io/tanguille/sglang-rdna4:v0.5.15-gfx1201@sha256:72d934d335529934bf73cd480b728cd08ae61178c9204dc37a025302b31fd61e
+  image: ghcr.io/tanguille/sglang-rdna4:v0.5.16-gfx1201@sha256:37bfc2e96b74d6f1b5024646f860db4053e621eb847c6691577badcb9752f461
   containerPort: 30000
   endpoint:
     # v0.9.8 maps endpoint.port to both Service port and targetPort; use the
@@ -124,7 +124,7 @@ spec:
     # Page names encode neither the weights revision nor the engine, so this suffix MUST be
     # bumped with the image digest above or the AWQ revision, or stale KV pages get served.
     - name: SGLANG_HICACHE_FILE_BACKEND_STORAGE_DIR
-      value: /hicache/sglang-v0.5.15_awq-f541031d
+      value: /hicache/sglang-v0.5.16_awq-f541031d
     # Unset defaults to unbounded; a full L2 measured 14G on 2026-07-27.
     - name: SGLANG_HICACHE_FILE_BACKEND_MAX_SIZE
       value: 64Gi


### PR DESCRIPTION
Live-validated on control-1 before this PR: the InferenceService was patched to the v0.5.16
digest, loaded clean, and has been serving production traffic since 21:26 UTC.

| | v0.5.15 | v0.5.16 |
|---|---|---|
| KV pool | 183,240 tok | 183,240 tok |
| Mamba cache / ssm | 60 / 4.29 GB | 60 / 4.29 GB |
| HiCache host alloc | 9.01 GB | 9.01 GB |
| avail GPU after pool | — | 3.71 GB |
| L3 backend | works | works, 117,832 tok / 7.3 G written |

Production A/B from VictoriaMetrics, v0.5.15 over the 3h to 21:15 UTC vs v0.5.16 over the
17m to 21:44 UTC:

| | v0.5.15 | v0.5.16 |
|---|---|---|
| TPOT p50 | 0.3087 s | 0.3033 s |
| TPOT p90 | 0.3957 s | 0.3993 s |
| TTFT p50 | 14.85 s | 7.33 s |
| mean running reqs | 4.53 | 3.74 |
| mean gen throughput | 17.1 tok/s | 15.9 tok/s |

**Decode is flat** — TPOT moves under 2% either way, which is what the same kernels on the
same hardware should do. The TTFT halving is not claimed as a win: the windows differ in
concurrency and the v0.5.16 one is only 17 minutes against a cold L3 cache.

The case for merging is the split, not the numbers. #4219 moved the build to v0.5.16 while
serving stayed pinned to a v0.5.15 digest, so the next Renovate digest bump would roll prod
onto an engine nothing had exercised. The hicache `STORAGE_DIR` suffix moves in the same
commit because page names encode neither the engine nor the weights revision, so a bare image
bump would serve v0.5.15 KV pages to a v0.5.16 engine. Verified: the new suffix started a
fresh directory rather than reusing the old pages.

Merging re-applies what is already live, so Flux converges without another reload.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Qwen3.6-27B model’s SGLang hicache storage directory to align with the newer runtime revision.
  * Improves compatibility and cache handling for the updated AWQ model configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->