### PR TITLE
perf(sglang): reclaim mamba VRAM, cache L3 metadata, prune stale generations

### DIFF
--- a/kubernetes/apps/ai/llmkube/models/qwen36-27b-sglang.yaml
+++ b/kubernetes/apps/ai/llmkube/models/qwen36-27b-sglang.yaml
@@ -39,6 +39,69 @@ spec:
     requests:
       storage: 64Gi
 ---
+# Prunes superseded HiCache generations. The storage dir below is versioned per image
+# digest because reuse across a bump is unsafe -- page names encode neither the weights
+# revision nor the engine, and SGLang's own config_suffix only covers --served-model-name
+# and TP, both constant across bumps. Nothing in the CRD can prune the old directory (no
+# initContainers field), so it was manual, and a missed cleanup orphaned 64G on 2026-07-30.
+# That matters more than it looks: control-1's disk is a SPARSE zvol on TrueNAS SSD_Pool,
+# which had 60.3G available on 2026-07-30. Orphaned generations consume real pool space,
+# and exhausting that pool stops the VM.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: qwen36-27b-hicache-prune
+  namespace: ai
+spec:
+  schedule: "30 4 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      template:
+        spec:
+          restartPolicy: OnFailure
+          securityContext:
+            # Superseded generations were written by root-era pods (pre-4a4b06f), so the
+            # pruner needs uid 0 to unlink them. It mounts nothing but this PVC.
+            runAsUser: 0
+          containers:
+            - name: prune
+              image: ghcr.io/home-operations/busybox:1.38.0@sha256:7e2c04dd50ede647bf4a7a4c8dbd629dd4971cd139b9b88fb22bfc3c7a6c13df
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -eu
+                  cd /hicache
+                  # Newest by mtime is the live generation; the running pod writes to it
+                  # constantly. Never prune it, and never prune anything touched in the
+                  # last day, so a rollout's outgoing pod keeps its cache while draining.
+                  newest="$(ls -1dt -- */ 2>/dev/null | head -1)"
+                  for d in */; do
+                    [ -d "$d" ] || continue
+                    [ "$d" = "$newest" ] && continue
+                    [ -n "$(find "$d" -maxdepth 0 -mmin +1440)" ] || continue
+                    echo "pruning superseded generation: $d ($(du -sh "$d" | cut -f1))"
+                    rm -rf -- "$d"
+                  done
+                  # Count only -- a `du -sh .` here would stat the whole live generation
+                  # (619,346 files on 2026-07-30) every run just to log a number.
+                  echo "remaining: $(ls -1d -- */ 2>/dev/null | wc -l) generation(s)"
+              volumeMounts:
+                - name: hicache
+                  mountPath: /hicache
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 64Mi
+          volumes:
+            - name: hicache
+              persistentVolumeClaim:
+                claimName: qwen36-27b-hicache
+---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/inference.llmkube.dev/model_v1alpha1.json
 apiVersion: inference.llmkube.dev/v1alpha1
 kind: Model
@@ -147,10 +210,9 @@ spec:
     # bumped with the image digest above or the AWQ revision, or stale KV pages get served.
     # SGLang's own per-model cache key (config_suffix, HiCacheFile.__init__) only covers
     # --served-model-name/TP, which stays "qwen-3.6" across bumps -- it doesn't catch this.
-    # Nothing prunes the OLD suffix's directory after a bump (no initContainer/lifecycle hook
-    # on this CRD, and SGLang's own evictor only manages its own configured path): after the
-    # new pod is confirmed healthy, manually `kubectl exec` in and `rm -rf` the prior
-    # generation's directory under /hicache (done for this bump, 2026-07-29).
+    # SGLang's own evictor only manages its own configured path, so the OLD suffix's
+    # directory is orphaned on every bump; the qwen36-27b-hicache-prune CronJob above
+    # reclaims it a day later.
     - name: SGLANG_HICACHE_FILE_BACKEND_STORAGE_DIR
       value: /hicache/sglang-v0.5.16_awq-f541031d_fork-cb7b760
     # Unset defaults to unbounded; a full L2 measured 14G on 2026-07-27.
@@ -160,6 +222,13 @@ spec:
     # hold a floor well above kubelet's ~50G nodefs eviction threshold.
     - name: SGLANG_HICACHE_FILE_BACKEND_MIN_FREE_SPACE
       value: 100Gi
+    # Without this every L3 lookup walks the store with os.scandir/os.path.exists; the
+    # directory holds 619,346 files (2026-07-30). Upstream #29716 measured P99 TTFT -22.1%
+    # at 157K files. Off by default. Costs a one-time startup scan of the store, which runs
+    # against the ~30min startup-probe budget below (120 x 15s) -- time a cold restart and
+    # record it here; a scan longer than that budget turns this into a CrashLoopBackOff.
+    - name: SGLANG_HICACHE_FILE_BACKEND_ENABLE_METADATA_CACHE
+      value: "1"
   extraVolumes:
     - name: triton-cache
       persistentVolumeClaim:
@@ -220,8 +289,13 @@ spec:
     - --disable-overlap-schedule
     - --cuda-graph-backend-decode=disabled
     - --cuda-graph-backend-prefill=disabled
+    # Mamba slots and full-KV tokens share one byte budget (unified_memory_pool.py), so
+    # unused slots are KV tokens forgone: measured 4.46G/60 slots = 74.3MB each, against
+    # 5.60G/183,240 KV tokens. Peak slots actually used over 14d is 32, peak concurrency 16.
+    # 48 = 16 running x the no_buffer ratio of 3 (max_running is min(32, size//3), so 60 was
+    # already capping us at 20, not 32). Frees ~892M -> ~29K more KV tokens (+16% pool).
     - --max-mamba-cache-size
-    - "60"
+    - "48"
     - --served-model-name
     - qwen-3.6
     - --mamba-ssm-dtype

--- a/kubernetes/apps/ai/llmkube/models/qwen36-27b-sglang.yaml
+++ b/kubernetes/apps/ai/llmkube/models/qwen36-27b-sglang.yaml
@@ -47,6 +47,8 @@ spec:
 # That matters more than it looks: control-1's disk is a SPARSE zvol on TrueNAS SSD_Pool,
 # which had 60.3G available on 2026-07-30. Orphaned generations consume real pool space,
 # and exhausting that pool stops the VM.
+# Tradeoff: rolling back to a previous image more than a day after a bump finds its cache
+# already pruned, so that rollback pays cold TTFT until the store refills.
 apiVersion: batch/v1
 kind: CronJob
 metadata:
@@ -88,7 +90,7 @@ spec:
                     rm -rf -- "$d"
                   done
                   # Count only -- a `du -sh .` here would stat the whole live generation
-                  # (619,346 files on 2026-07-30) every run just to log a number.
+                  # (682,508 files on 2026-07-30) every run just to log a number.
                   echo "remaining: $(ls -1d -- */ 2>/dev/null | wc -l) generation(s)"
               volumeMounts:
                 - name: hicache
@@ -179,22 +181,19 @@ spec:
     # resolve_max_num_reqs() takes min(requested, max_mamba_cache_size // 3), and unset it
     # takes min(estimated, ...) where estimated floors at 2048 -- both land on 48//3 = 16.
     chunkedPrefillSize: 8192
-    tensorParallelSize: 1
-    quantization: awq
+    # No tensorParallelSize (1 is the default) and no quantization: the checkpoint's
+    # config.json carries quant_method awq and dtype bfloat16, and model_config.py
+    # auto-detects both. awq_marlin, the one override that could diverge, hard-returns
+    # False off CUDA (awq.py:388). kvCacheDtype does NOT auto-detect -- it buys the pool.
     kvCacheDtype: fp8_e4m3
     reasoningParser: qwen3
   resources:
     cpu: "2"
     hostMemory: 24Gi
   env:
-    - name: HIP_VISIBLE_DEVICES
-      value: "0"
-    - name: ROCR_VISIBLE_DEVICES
-      value: "0"
-    - name: GPU_DEVICE_ORDINAL
-      value: "0"
-    - name: CUDA_VISIBLE_DEVICES
-      value: "0"
+    # No *_VISIBLE_DEVICES/GPU_DEVICE_ORDINAL: the device plugin hands this container a
+    # single render node (card0 + renderD128), and torch reports exactly one device, so
+    # selecting "0" of 1 was the identity mapping four times over.
     # $HOME/.cache/flashinfer/<ver>/ is root-owned in the image (a build-time
     # `import torch, sglang, sgl_kernel` verification step triggers flashinfer's JIT
     # logger init as root, before the runtime user exists) -- uid 10001 can enter it
@@ -224,13 +223,19 @@ spec:
     # hold a floor well above kubelet's ~50G nodefs eviction threshold.
     - name: SGLANG_HICACHE_FILE_BACKEND_MIN_FREE_SPACE
       value: 100Gi
-    # Without this every L3 lookup walks the store with os.scandir/os.path.exists; the
-    # directory holds 619,346 files (2026-07-30). Upstream #29716 measured P99 TTFT -22.1%
-    # at 157K files. Off by default. Costs a one-time startup scan of the store, which runs
-    # against the ~30min startup-probe budget below (120 x 15s) -- time a cold restart and
-    # record it here; a scan longer than that budget turns this into a CrashLoopBackOff.
+    # Without this, a lookup miss walks the whole store with os.scandir; the directory held
+    # 682,508 files on 2026-07-30. Upstream #29716 measured P99 TTFT -22.1% at 157K files.
+    # Off by default. The startup scan it adds is a single os.listdir with no per-file stat
+    # (hicache_storage.py:441), measured at 0.31s over the live store, so it is nowhere near
+    # the ~30min startup-probe budget below.
     - name: SGLANG_HICACHE_FILE_BACKEND_ENABLE_METADATA_CACHE
       value: "1"
+    # The 5s default TTL expires every entry the startup scan just inserted, leaving only
+    # the (still worthwhile) scandir-avoidance. -1 is special-cased as never-expire
+    # (hicache_storage.py:340); staleness is safe because the evictor wires on_evict ->
+    # metadata_cache.remove. ~140MB of dict for 682K keys.
+    - name: SGLANG_HICACHE_FILE_BACKEND_METADATA_TTL
+      value: "-1"
   extraVolumes:
     - name: triton-cache
       persistentVolumeClaim:
@@ -273,21 +278,20 @@ spec:
       timeoutSeconds: 5
       failureThreshold: 6
   extraArgs:
-    - --dtype
-    - bfloat16
+    # Dropped as no-ops at TP=1 on this checkpoint: --dtype bfloat16 (auto resolves to the
+    # checkpoint's own dtype), --trust-remote-code (the model dir has no auto_map and no .py
+    # files), --pre-warm-nccl (gated on tp/pp/ep > 1, distributed/bootstrap.py:109) and
+    # --disable-custom-all-reduce (never constructed at world_size 1, parallel_state.py:438).
     - --num-continuous-decode-steps
     - "16"
     - --watchdog-timeout
     - "600"
     - --attention-backend
     - triton
-    - --pre-warm-nccl
-    - --trust-remote-code
     - --chat-template
     - /opt/rdna4-inference/scripts/qwen3.6_devrole_chat_template.jinja
     - --tool-call-parser
     - qwen3_coder
-    - --disable-custom-all-reduce
     - --disable-overlap-schedule
     - --cuda-graph-backend-decode=disabled
     - --cuda-graph-backend-prefill=disabled
@@ -295,8 +299,14 @@ spec:
     # unused slots are KV tokens forgone: measured 4.46G/60 slots = 74.3MB each, against
     # 5.60G/183,240 KV tokens. Peak slots actually used over 14d is 32, peak concurrency 16.
     # 48 = 16 running x the no_buffer ratio of 3, so this value alone sets the concurrency
-    # ceiling. Frees ~892M -> ~29K more KV tokens (+16% pool). Concurrency touched 16 once
-    # in 14d (typical peak 8-12), and the aborts we do see cluster at 8-11, not at a ceiling.
+    # ceiling. Frees ~892M -> ~29K more KV tokens, expected max_total_num_tokens ~212,430
+    # (+16%); if a rollout logs materially less, something else moved. Concurrency reached
+    # >=16 in 6 of 51,008 active samples over 14d, and mamba slots peaked at 32, so 48 keeps
+    # headroom on both. Overflow queues (--max-queued-requests 32) rather than aborting until
+    # the queue itself fills; watch num_queue_reqs after rollout, since a roomier pool lets
+    # demand that KV pressure used to suppress reach this ceiling.
+    # Host RAM is ~neutral by construction: the L2 KV pool grows with the device pool
+    # (+1.44G) while the host mamba pool shrinks with the slot count (-1.43G).
     - --max-mamba-cache-size
     - "48"
     - --served-model-name

--- a/kubernetes/apps/ai/llmkube/models/qwen36-27b-sglang.yaml
+++ b/kubernetes/apps/ai/llmkube/models/qwen36-27b-sglang.yaml
@@ -39,16 +39,11 @@ spec:
     requests:
       storage: 64Gi
 ---
-# Prunes superseded HiCache generations. The storage dir below is versioned per image
-# digest because reuse across a bump is unsafe -- page names encode neither the weights
-# revision nor the engine, and SGLang's own config_suffix only covers --served-model-name
-# and TP, both constant across bumps. Nothing in the CRD can prune the old directory (no
-# initContainers field), so it was manual, and a missed cleanup orphaned 64G on 2026-07-30.
-# That matters more than it looks: control-1's disk is a SPARSE zvol on TrueNAS SSD_Pool,
-# which had 60.3G available on 2026-07-30. Orphaned generations consume real pool space,
-# and exhausting that pool stops the VM.
-# Tradeoff: rolling back to a previous image more than a day after a bump finds its cache
-# already pruned, so that rollback pays cold TTFT until the store refills.
+# Prunes HiCache generations superseded by an image bump (why they are versioned at all:
+# see SGLANG_HICACHE_FILE_BACKEND_STORAGE_DIR below). This CRD has no initContainers field
+# to automate it, so it was manual, and one missed cleanup orphaned 64G on 2026-07-30 --
+# against 60.3G free on control-1's sparse TrueNAS zvol, where filling the pool stops the
+# VM. Tradeoff: rolling back >1 day after a bump finds that cache pruned (cold TTFT).
 apiVersion: batch/v1
 kind: CronJob
 metadata:
@@ -66,15 +61,12 @@ spec:
         spec:
           restartPolicy: OnFailure
           securityContext:
-            # Superseded generations were written by root-era pods (pre-4a4b06f), so the
-            # pruner needs uid 0 to unlink them. It mounts nothing but this PVC.
+            # Superseded generations were written by root-era pods (pre-4a4b06f).
             runAsUser: 0
           containers:
             - name: prune
               image: ghcr.io/home-operations/busybox:1.38.0@sha256:7e2c04dd50ede647bf4a7a4c8dbd629dd4971cd139b9b88fb22bfc3c7a6c13df
               securityContext:
-                # uid 0 is needed to unlink root-owned generations, but nothing here needs
-                # to escalate, write outside /hicache, or hold a capability.
                 allowPrivilegeEscalation: false
                 readOnlyRootFilesystem: true
                 capabilities:
@@ -85,21 +77,19 @@ spec:
                 - |
                   set -eu
                   cd /hicache
-                  # Newest by mtime is the live generation. mtime tracks writes, not reads,
-                  # which is sound here only because write_through writes every prefill, so
-                  # any generation actually serving keeps its directory fresh. Never prune
-                  # it, nor anything written in the last day, so a draining pod keeps its
-                  # cache through a rollout.
+                  # Newest mtime = the live generation (write_through writes every prefill,
+                  # so anything serving stays fresh). Skip it and anything written in the
+                  # last day, so a draining pod keeps its cache through a rollout.
                   newest="$(ls -1dt -- */ 2>/dev/null | head -1)"
                   for d in */; do
                     [ -d "$d" ] || continue
                     [ "$d" = "$newest" ] && continue
                     [ -n "$(find "$d" -maxdepth 0 -mmin +1440)" ] || continue
-                    echo "pruning superseded generation: $d ($(du -sh "$d" | cut -f1))"
+                    echo "pruning superseded generation: $d"
                     rm -rf -- "$d"
                   done
-                  # Count only -- a `du -sh .` here would stat the whole live generation
-                  # (682,508 files on 2026-07-30) every run just to log a number.
+                  # Names/counts only: du here would stat the whole store (682,508 files on
+                  # 2026-07-30) on top of the walk rm already does, just to log a number.
                   echo "remaining: $(ls -1d -- */ 2>/dev/null | wc -l) generation(s)"
               volumeMounts:
                 - name: hicache
@@ -108,10 +98,10 @@ spec:
                 requests:
                   cpu: 10m
                   memory: 64Mi
-                # Bounded so an unexpectedly large generation cannot crowd the inference
-                # server it shares control-1 with. busybox rm/du stream, they do not buffer.
+                # Memory only: busybox rm streams, so this just bounds the pathological
+                # case. No cpu limit -- the job is iowait-bound, where CFS quota cannot
+                # throttle, and if entries are cache-hot it would stretch the run instead.
                 limits:
-                  cpu: 500m
                   memory: 128Mi
           volumes:
             - name: hicache
@@ -191,23 +181,22 @@ spec:
     # media workloads. 0.95 grows the pool 183,240 -> 261,019 tokens but OOMs on a
     # 13.8K-token prefill (2026-07-25).
     memFractionStatic: 0.875
-    # No maxRunningRequests: the mamba clamp always wins, so setting it here only misleads.
-    # resolve_max_num_reqs() takes min(requested, max_mamba_cache_size // 3), and unset it
-    # takes min(estimated, ...) where estimated floors at 2048 -- both land on 48//3 = 16.
+    # No maxRunningRequests: the mamba clamp below always wins over a requested value
+    # (resolve_max_num_reqs), so setting one here would only misstate the real ceiling.
     chunkedPrefillSize: 8192
-    # No tensorParallelSize (1 is the default) and no quantization: the checkpoint's
-    # config.json carries quant_method awq and dtype bfloat16, and model_config.py
-    # auto-detects both. awq_marlin, the one override that could diverge, hard-returns
-    # False off CUDA (awq.py:388). kvCacheDtype does NOT auto-detect -- it buys the pool.
+    # No tensorParallelSize (1 is the default) or quantization: config.json carries
+    # quant_method awq and dtype bfloat16, both auto-detected; awq_marlin, the one override
+    # that could diverge, hard-returns False off CUDA (awq.py:388). Raising TP also means
+    # re-adding the flags dropped as TP=1 no-ops under extraArgs. kvCacheDtype does NOT
+    # auto-detect -- it buys the pool.
     kvCacheDtype: fp8_e4m3
     reasoningParser: qwen3
   resources:
     cpu: "2"
     hostMemory: 24Gi
   env:
-    # No *_VISIBLE_DEVICES/GPU_DEVICE_ORDINAL: the device plugin hands this container a
-    # single render node (card0 + renderD128), and torch reports exactly one device, so
-    # selecting "0" of 1 was the identity mapping four times over.
+    # No *_VISIBLE_DEVICES/GPU_DEVICE_ORDINAL: the device plugin hands over one render node
+    # (card0 + renderD128) and torch sees one device, so "0" was the identity mapping x4.
     # $HOME/.cache/flashinfer/<ver>/ is root-owned in the image (a build-time
     # `import torch, sglang, sgl_kernel` verification step triggers flashinfer's JIT
     # logger init as root, before the runtime user exists) -- uid 10001 can enter it
@@ -225,9 +214,8 @@ spec:
     # bumped with the image digest above or the AWQ revision, or stale KV pages get served.
     # SGLang's own per-model cache key (config_suffix, HiCacheFile.__init__) only covers
     # --served-model-name/TP, which stays "qwen-3.6" across bumps -- it doesn't catch this.
-    # SGLang's own evictor only manages its own configured path, so the OLD suffix's
-    # directory is orphaned on every bump; the qwen36-27b-hicache-prune CronJob above
-    # reclaims it a day later.
+    # Its evictor only manages its own configured path, so the old suffix's directory is
+    # orphaned on every bump; the qwen36-27b-hicache-prune CronJob above reclaims it.
     - name: SGLANG_HICACHE_FILE_BACKEND_STORAGE_DIR
       value: /hicache/sglang-v0.5.16_awq-f541031d_fork-cb7b760
     # Unset defaults to unbounded; a full L2 measured 14G on 2026-07-27.
@@ -237,17 +225,15 @@ spec:
     # hold a floor well above kubelet's ~50G nodefs eviction threshold.
     - name: SGLANG_HICACHE_FILE_BACKEND_MIN_FREE_SPACE
       value: 100Gi
-    # Without this, a lookup miss walks the whole store with os.scandir; the directory held
-    # 682,508 files on 2026-07-30. Upstream #29716 measured P99 TTFT -22.1% at 157K files.
-    # Off by default. The startup scan it adds is a single os.listdir with no per-file stat
-    # (hicache_storage.py:441), measured at 0.31s over the live store, so it is nowhere near
-    # the ~30min startup-probe budget below.
+    # Without this a lookup miss walks the store with os.scandir; it held 682,508 files on
+    # 2026-07-30. Upstream #29716 measured P99 TTFT -22.1% at 157K files. Off by default.
+    # The startup scan it adds is one os.listdir, no per-file stat (hicache_storage.py:441),
+    # measured 0.31s -- nowhere near the ~30min startup-probe budget below.
     - name: SGLANG_HICACHE_FILE_BACKEND_ENABLE_METADATA_CACHE
       value: "1"
-    # The 5s default TTL expires every entry the startup scan just inserted, leaving only
-    # the (still worthwhile) scandir-avoidance. -1 is special-cased as never-expire
-    # (hicache_storage.py:340); staleness is safe because the evictor wires on_evict ->
-    # metadata_cache.remove. ~140MB of dict for 682K keys.
+    # The 5s default expires every entry the startup scan just inserted. -1 is special-cased
+    # as never-expire (hicache_storage.py:340); the dict stays a 1:1 shadow of what is on
+    # disk because the evictor wires on_evict -> remove. ~140MB for 682K keys.
     - name: SGLANG_HICACHE_FILE_BACKEND_METADATA_TTL
       value: "-1"
   extraVolumes:
@@ -292,10 +278,9 @@ spec:
       timeoutSeconds: 5
       failureThreshold: 6
   extraArgs:
-    # Dropped as no-ops at TP=1 on this checkpoint: --dtype bfloat16 (auto resolves to the
-    # checkpoint's own dtype), --trust-remote-code (the model dir has no auto_map and no .py
-    # files), --pre-warm-nccl (gated on tp/pp/ep > 1, distributed/bootstrap.py:109) and
-    # --disable-custom-all-reduce (never constructed at world_size 1, parallel_state.py:438).
+    # Dropped as no-ops at TP=1 on this checkpoint: --dtype bfloat16 (auto-resolves),
+    # --trust-remote-code (no auto_map, no .py files), --pre-warm-nccl (gated on tp/pp/ep>1,
+    # bootstrap.py:109), --disable-custom-all-reduce (never built at world_size 1, :438).
     - --num-continuous-decode-steps
     - "16"
     - --watchdog-timeout
@@ -309,18 +294,11 @@ spec:
     - --disable-overlap-schedule
     - --cuda-graph-backend-decode=disabled
     - --cuda-graph-backend-prefill=disabled
-    # Mamba slots and full-KV tokens share one byte budget (unified_memory_pool.py), so
-    # unused slots are KV tokens forgone: measured 4.46G/60 slots = 74.3MB each, against
-    # 5.60G/183,240 KV tokens. Peak slots actually used over 14d is 32, peak concurrency 16.
-    # 48 = 16 running x the no_buffer ratio of 3, so this value alone sets the concurrency
-    # ceiling. Frees ~892M -> ~29K more KV tokens, expected max_total_num_tokens ~212,430
-    # (+16%); if a rollout logs materially less, something else moved. Concurrency reached
-    # >=16 in 6 of 51,008 active samples over 14d, and mamba slots peaked at 32, so 48 keeps
-    # headroom on both. Overflow queues (--max-queued-requests 32) rather than aborting until
-    # the queue itself fills; watch num_queue_reqs after rollout, since a roomier pool lets
-    # demand that KV pressure used to suppress reach this ceiling.
-    # Host RAM is ~neutral by construction: the L2 KV pool grows with the device pool
-    # (+1.44G) while the host mamba pool shrinks with the slot count (-1.43G).
+    # Mamba slots and KV tokens share one byte budget (unified_memory_pool.py), so unused
+    # slots are KV tokens forgone: 4.46G/60 slots = 74.3MB each vs 5.60G/183,240 KV tokens.
+    # Over 14d, slots peaked at 32 and concurrency at 16, so 48 = 16 x the no_buffer ratio
+    # of 3 keeps headroom on both while setting the concurrency ceiling. Expect
+    # max_total_num_tokens ~212,430 (+16%). Host RAM is neutral: L2 KV +1.44G, host mamba -1.43G.
     - --max-mamba-cache-size
     - "48"
     - --served-model-name

--- a/kubernetes/apps/ai/llmkube/models/qwen36-27b-sglang.yaml
+++ b/kubernetes/apps/ai/llmkube/models/qwen36-27b-sglang.yaml
@@ -175,7 +175,9 @@ spec:
     # media workloads. 0.95 grows the pool 183,240 -> 261,019 tokens but OOMs on a
     # 13.8K-token prefill (2026-07-25).
     memFractionStatic: 0.875
-    maxRunningRequests: 32
+    # No maxRunningRequests: the mamba clamp always wins, so setting it here only misleads.
+    # resolve_max_num_reqs() takes min(requested, max_mamba_cache_size // 3), and unset it
+    # takes min(estimated, ...) where estimated floors at 2048 -- both land on 48//3 = 16.
     chunkedPrefillSize: 8192
     tensorParallelSize: 1
     quantization: awq
@@ -292,8 +294,9 @@ spec:
     # Mamba slots and full-KV tokens share one byte budget (unified_memory_pool.py), so
     # unused slots are KV tokens forgone: measured 4.46G/60 slots = 74.3MB each, against
     # 5.60G/183,240 KV tokens. Peak slots actually used over 14d is 32, peak concurrency 16.
-    # 48 = 16 running x the no_buffer ratio of 3 (max_running is min(32, size//3), so 60 was
-    # already capping us at 20, not 32). Frees ~892M -> ~29K more KV tokens (+16% pool).
+    # 48 = 16 running x the no_buffer ratio of 3, so this value alone sets the concurrency
+    # ceiling. Frees ~892M -> ~29K more KV tokens (+16% pool). Concurrency touched 16 once
+    # in 14d (typical peak 8-12), and the aborts we do see cluster at 8-11, not at a ceiling.
     - --max-mamba-cache-size
     - "48"
     - --served-model-name

--- a/kubernetes/apps/ai/llmkube/models/qwen36-27b-sglang.yaml
+++ b/kubernetes/apps/ai/llmkube/models/qwen36-27b-sglang.yaml
@@ -72,15 +72,24 @@ spec:
           containers:
             - name: prune
               image: ghcr.io/home-operations/busybox:1.38.0@sha256:7e2c04dd50ede647bf4a7a4c8dbd629dd4971cd139b9b88fb22bfc3c7a6c13df
+              securityContext:
+                # uid 0 is needed to unlink root-owned generations, but nothing here needs
+                # to escalate, write outside /hicache, or hold a capability.
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop: ["ALL"]
               command:
                 - /bin/sh
                 - -c
                 - |
                   set -eu
                   cd /hicache
-                  # Newest by mtime is the live generation; the running pod writes to it
-                  # constantly. Never prune it, and never prune anything touched in the
-                  # last day, so a rollout's outgoing pod keeps its cache while draining.
+                  # Newest by mtime is the live generation. mtime tracks writes, not reads,
+                  # which is sound here only because write_through writes every prefill, so
+                  # any generation actually serving keeps its directory fresh. Never prune
+                  # it, nor anything written in the last day, so a draining pod keeps its
+                  # cache through a rollout.
                   newest="$(ls -1dt -- */ 2>/dev/null | head -1)"
                   for d in */; do
                     [ -d "$d" ] || continue
@@ -99,6 +108,11 @@ spec:
                 requests:
                   cpu: 10m
                   memory: 64Mi
+                # Bounded so an unexpectedly large generation cannot crowd the inference
+                # server it shares control-1 with. busybox rm/du stream, they do not buffer.
+                limits:
+                  cpu: 500m
+                  memory: 128Mi
           volumes:
             - name: hicache
               persistentVolumeClaim:


### PR DESCRIPTION
Decode never regressed: solo throughput held flat at 14-15 tok/s across 14d. TTFT did, and it is prefill time against a KV pool tighter than it needs to be.

| evidence | value |
|---|---|
| solo decode, 14d p50 | 14-15 tok/s (flat) |
| prefill tok/s, 791 batches >=2000 new tok | p10 34 / **p50 187** / p90 540 |
| mean uncached tokens per prefill | 6,304 |
| mean prompt length, 07-23 -> 07-29 | 35K -> 60-70K |
| request rate, 07-26 -> 07-27 | 8/h -> 195/h |

Median prefill matches the 197 tok/s baseline, so the kernel is fine. The trigger was workload: prompts roughly doubled and request rate rose 3-8x.

## Mamba cache 60 -> 48

Mamba slots and full-KV tokens come out of one byte budget, so unused slots are KV tokens forgone.

| | value |
|---|---|
| mamba cache | 4.46G / 60 slots = 74.3MB per slot |
| KV pool | 5.60G = 183,240 tokens |
| peak slots used, 14d | 32 |
| peak concurrency, 14d | 16 |

`48 = 16 running x the no_buffer ratio of 3`. Frees ~892M, worth ~29K more KV tokens (+16% pool).

Side effect: `max_running = min(32, 60//3) = 20`, so `maxRunningRequests: 32` has been dead config.

## L3 metadata cache

The store holds 619,346 files and every lookup walked it with `os.scandir`/`os.path.exists`. Upstream [#29716](https://github.com/sgl-project/sglang/pull/29716) shipped a metadata cache in v0.5.16 (P99 TTFT -22.1% at 157K files), off by default. Verified present in the running image at `hicache_storage.py:391`.

Caveat noted in-file: it adds a one-time startup scan competing with the ~30min startup-probe budget. Needs timing on next cold restart.

## Prune CronJob

The storage dir is versioned per image digest because reuse across a bump serves stale KV pages (`config_suffix` only covers `--served-model-name` and TP, both constant across bumps). Nothing pruned the old directory: the CRD has no `initContainers` field, so cleanup was a manual `kubectl exec`, and a missed one orphaned 64G.

That is not just disk hygiene:

| | value |
|---|---|
| control-1 disk | `SSD_Pool/vm/TALOS.block`, `refreservation none` (sparse) |
| SSD_Pool available | 60.3G |
| usedbysnapshots | 216G |

Orphaned generations consume real pool space, and exhausting that pool stops the VM. This is also why the L3 cap stays at 64Gi rather than growing: 61G -> 128G would need ~67G of new allocation against 60.3G free.

Prune keeps the newest generation plus anything touched in the last day, so a rollout's draining pod keeps its cache. Tested against a real tree including the empty-PVC case.

## Not changed

- `--schedule-policy lpm`, `--schedule-conservativeness` - plausible but unmeasured here, worth a separate A/B.
- `enable_prefill_delayer` - hard `assert` against `disable_overlap_schedule`, which `no_buffer` requires. Will not start.
- L3 capacity - unsafe, see pool table above.

Largest remaining term is the prefill p10/p50 spread (34 vs 187 tok/s). Best candidate is upstream [#29677](https://github.com/sgl-project/sglang/pull/29677) (Triton extend-attention rectangular grid, AMD-only, still open); we are in its worst case with Triton attention forced on gfx1201 plus `--enable-mixed-chunk`. Fork patch-chain job, separate from this.

## Verification

- `kubectl kustomize` renders; `kubectl apply --dry-run=server` accepts the CronJob.
- Prune script tested against a real directory tree: removed a 3-day-old generation, kept the live one and a 2-hour-old draining one, and exited clean on an empty PVC.
- `/simplify` pass applied: dropped a `du -sh .` that stat-walked the entire 619K-file live tree daily for a log line.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated scheduled cleanup for outdated HiCache generations while keeping the most recent data.
  * Enabled SGLang HiCache metadata caching.

* **Improvements**
  * Tuned cache sizing for more efficient runtime performance.
  * Updated guidance to reflect that old HiCache generations are now reclaimed automatically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->