### PR TITLE
fix(toolhive): run postgres-mcp over stdio and alert on vmcp readiness

### DIFF
--- a/kubernetes/apps/ai/toolhive/config/kustomization.yaml
+++ b/kubernetes/apps/ai/toolhive/config/kustomization.yaml
@@ -6,6 +6,7 @@ kind: Kustomization
 resources:
   - mcpgroups.yaml
   - virtualmcpservers.yaml
+  - prometheusrule.yaml
   - postgres-mcp.yaml
   - karakeep.yaml
   - searxng.yaml

--- a/kubernetes/apps/ai/toolhive/config/postgres-mcp.yaml
+++ b/kubernetes/apps/ai/toolhive/config/postgres-mcp.yaml
@@ -6,14 +6,14 @@ metadata:
   name: postgres-mcp
 spec:
   image: crystaldba/postgres-mcp:0.3.0@sha256:dbbd346860d29f1543e991f30f3284bf4ab5f096d049ecc3426528f20b1b6e6b
-  transport: sse
+  # sse leaves the proxy without the /mcp endpoint vmcp health-checks
+  transport: stdio
   proxyPort: 8080
-  mcpPort: 8000
   groupRef:
     name: database
   args:
     - "--access-mode=restricted"
-    - "--transport=sse"
+    - "--transport=stdio"
   secrets:
     - name: toolhive-secrets
       key: POSTGRES_MCP_DATABASE_URI
@@ -44,14 +44,14 @@ metadata:
   name: postgres-mcp-opt
 spec:
   image: crystaldba/postgres-mcp:0.3.0@sha256:dbbd346860d29f1543e991f30f3284bf4ab5f096d049ecc3426528f20b1b6e6b
-  transport: sse
+  # sse leaves the proxy without the /mcp endpoint vmcp health-checks
+  transport: stdio
   proxyPort: 8080
-  mcpPort: 8000
   groupRef:
     name: all
   args:
     - "--access-mode=restricted"
-    - "--transport=sse"
+    - "--transport=stdio"
   secrets:
     - name: toolhive-secrets
       key: POSTGRES_MCP_DATABASE_URI

--- a/kubernetes/apps/ai/toolhive/config/prometheusrule.yaml
+++ b/kubernetes/apps/ai/toolhive/config/prometheusrule.yaml
@@ -16,8 +16,8 @@ spec:
           for: 15m
           annotations:
             summary: >-
-              VirtualMCPServer {{ $labels.name }} is {{ $labels.phase }} — a backend is
-              unreachable and its tools are missing from the gateway
+              VirtualMCPServer {{ $labels.exported_namespace }}/{{ $labels.name }} is not
+              ready (phase={{ $labels.phase }}) — tools may be missing from the gateway
           labels:
             severity: warning
 

--- a/kubernetes/apps/ai/toolhive/config/prometheusrule.yaml
+++ b/kubernetes/apps/ai/toolhive/config/prometheusrule.yaml
@@ -1,0 +1,32 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: toolhive-rules
+spec:
+  groups:
+    - name: toolhive.rules
+      rules:
+        # Gatus probes each vmcp with a real MCP initialize, which stays green while
+        # individual backends drop out; only the CR reports per-backend health
+        - alert: VirtualMCPServerNotReady
+          expr: |-
+            toolhive_resource_info{ready!="True"} == 1
+          for: 15m
+          annotations:
+            summary: >-
+              VirtualMCPServer {{ $labels.name }} is {{ $labels.phase }} — a backend is
+              unreachable and its tools are missing from the gateway
+          labels:
+            severity: warning
+
+        - alert: VirtualMCPServerAbsent
+          expr: |-
+            absent(toolhive_resource_info)
+          for: 5m
+          annotations:
+            summary: >-
+              No VirtualMCPServer metrics — kube-state-metrics lost the toolhive CRs, gateway health is unmonitored
+          labels:
+            severity: warning

--- a/kubernetes/apps/observability/kube-state-metrics/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kube-state-metrics/app/helmrelease.yaml
@@ -43,6 +43,13 @@ spec:
           verbs:
             - list
             - watch
+        - apiGroups:
+            - toolhive.stacklok.dev
+          resources:
+            - virtualmcpservers
+          verbs:
+            - list
+            - watch
     customResourceState:
       enabled: true
       config:
@@ -384,3 +391,32 @@ spec:
                     webhook_path:
                       - status
                       - webhookPath
+            # vmcp readiness lives only in the CR: the gateway keeps serving on a
+            # dead backend, so nothing else in the cluster reports it
+            - groupVersionKind:
+                group: toolhive.stacklok.dev
+                version: v1beta1
+                kind: VirtualMCPServer
+              metricNamePrefix: toolhive
+              metrics:
+                - name: resource_info
+                  help: The current state of a Toolhive VirtualMCPServer resource.
+                  each:
+                    type: Info
+                    info:
+                      labelsFromPath:
+                        name:
+                          - metadata
+                          - name
+                  labelsFromPath:
+                    exported_namespace:
+                      - metadata
+                      - namespace
+                    ready:
+                      - status
+                      - conditions
+                      - "[type=Ready]"
+                      - status
+                    phase:
+                      - status
+                      - phase


### PR DESCRIPTION
## postgres-mcp

`postgres-mcp` was the only MCPServer running `transport: sse`. toolhive's SSE proxy has no `/mcp` endpoint, which is what the vmcp gateway health-checks, so vmcp read the backend as permanently unavailable.

| evidence | value |
|---|---|
| `vmcp unified` backend status | `postgres-mcp-opt: unavailable`, 5681 consecutive failures (~47h) |
| `vmcp database` | `BackendsUnavailable` (postgres-mcp is its only backend) |
| backend pod log | `GET /mcp HTTP/1.1" 404 Not Found`, repeating |
| other 7 backends | `stdio`, all `ready` |
| `postgres-mcp --help` (0.3.0) | `--transport {stdio,sse}`, no streamable-http |

stdio is the only transport that yields a `/mcp` endpoint here, since toolhive's proxy wraps it as streamable-http. `mcpPort: 8000` drops with sse.

## Alerting

Nothing in the cluster reported this. The MCPServer CRs stayed `Ready=True` throughout, and gatus's MCP probes stayed green because the gateway itself answers fine with 7 of 8 backends.

- `kube-state-metrics` gains a `customResourceState` block for `VirtualMCPServer`, emitting `toolhive_resource_info` with `ready`/`phase`, following the existing `gotk_resource_info` pattern.
- `VirtualMCPServerNotReady`: `ready!="True"` for 15m, matching the `gotk_resource_info` HelmRelease rule.
- `VirtualMCPServerAbsent`: 5m, matching `FluxInstanceAbsent`.

Complements gatus rather than duplicating it: gatus catches "gateway unusable", this catches "gateway degraded".

## Verification

`kustomize build` passes for both kustomizations. Rollout behaviour of stdio for this image is unverified: if it hits the v0.40.1 stdio health-check re-init bug that took out GitHub MCP (#5890), the backend status will show it within a minute and the transport flip reverts in one line.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added monitoring for Toolhive Virtual MCP Servers, including readiness and missing-metric alerts.
  - Added metrics covering server readiness, lifecycle phase, and namespace information.

- **Improvements**
  - Updated PostgreSQL MCP connectivity to use standard input/output transport, improving compatibility with the revised health-check behavior.
  - Included the new monitoring rules in the deployed configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->