### PR TITLE
feat(observability): alert when TrueNAS SSD_Pool free space runs low

### DIFF
--- a/kubernetes/apps/observability/exporters/node-exporter/app/prometheusrule.yaml
+++ b/kubernetes/apps/observability/exporters/node-exporter/app/prometheusrule.yaml
@@ -87,3 +87,23 @@ spec:
               NodeGTTMemoryHigh is blind until it recovers
           labels:
             severity: warning
+        - alert: TrueNASSSDPoolSpaceLow
+          # control-1's disk is a SPARSE zvol on this pool (SSD_Pool/vm/TALOS.block,
+          # refreservation none), so exhausting the pool fails guest writes and stops the
+          # VM rather than just filling a share. Every other node alert here is scoped
+          # kubernetes_node!="", which excludes this external target, so the pool backing
+          # the cluster's only VM had no space alerting at all.
+          # It has already run dry once, unnoticed: 2026-07-28 21:10-22:26 the pool sat
+          # under 20GiB for 76 minutes and bottomed at 0.00GiB, during back-to-back image
+          # bumps that wrote a second 64G HiCache generation alongside the live one.
+          expr: |-
+            node_filesystem_avail_bytes{job="node-exporter", fstype="zfs", mountpoint="/mnt/SSD_Pool"} < 21474836480
+          # 15m would have fired at 21:25 in that event, ~1h before it hit zero, while
+          # still riding out the 04:00 snapshot task that frees and re-pins tens of GB.
+          for: 15m
+          annotations:
+            summary: >-
+              TrueNAS SSD_Pool has under 20GiB free —
+              control-1's thin-provisioned disk fails writes if this pool fills
+          labels:
+            severity: critical


### PR DESCRIPTION
`SSD_Pool` had no free-space alerting. It has already hit **0.00 GiB** once, unnoticed.

## Why it matters

`control-1`'s disk is a sparse zvol on this pool:

```
SSD_Pool/vm/TALOS.block
  volsize          501G
  refreservation   none     <-- thin provisioned
  referenced       416G
```

With no refreservation, exhausting the pool fails guest writes and stops the VM. It does not merely fill a share.

Every other rule in this file is scoped `kubernetes_node!=""`, which excludes the external TrueNAS target, so the pool backing the cluster's only VM was never covered.

## It already happened

2026-07-28, at 1m scrape resolution:

| | |
|---|---|
| first sample under 20 GiB | 21:10 (16.57 GiB) |
| minimum reached | **0.00 GiB** |
| last sample under 20 GiB | 22:26 |
| sustained duration | **76 minutes**, 77 samples |

Cause was back-to-back image bumps (#4227 at 20:01, #4234 at 22:17) writing a second 64G HiCache generation alongside the live one. `for: 15m` would have fired at 21:25, about an hour before it bottomed out.

Worth noting: this window overlaps the unexplained 07-28/29 performance drop, which was previously attributed to a FORK_REF bump. A pool at zero free space is a much better candidate.

## The rule

```yaml
expr: node_filesystem_avail_bytes{job="node-exporter", fstype="zfs", mountpoint="/mnt/SSD_Pool"} < 21474836480
for: 15m
severity: critical
```

No exporter needed, the metric is already scraped from `192.168.0.27:9100`.

## Verification

| check | result |
|---|---|
| selector matches | exactly 1 series |
| fires now (58.9 GiB free) | no |
| fires across the 07-28 event | yes, all 77 samples |
| existing TrueNAS silence conflicts | no, scoped to `alertname: NodeMemoryHighUtilization` |
| renders + server dry-run | pass |

## Caveat on the threshold

20 GiB is roughly half a day of runway, not more. Daily snapshot deltas on this volume have been 43.4 G (07-30) and 143 G (07-29), against a 2-day retention. Fine as a "wake up now" line, but it will not give days of notice. A second, higher warning tier could be added later if that proves too tight.