### PR TITLE
chore(rook-ceph): suppress mon debug log spam

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -51,6 +51,9 @@ spec:
           # Network optimization for 2.5Gbps
           ms_osd_compress_min_size: "1024"
           ms_osd_compression_algorithm: snappy
+        mon:
+          # Suppress pgmap/audit debug spam; keeps INF/WRN/ERR (was debug).
+          mon_cluster_log_level: info
       cleanupPolicy:
         wipeDevicesFromOtherClusters: true
       csi:


### PR DESCRIPTION
Follow-up to [onedr0p/home-ops#11429](https://github.com/onedr0p/home-ops/pull/11429), reproduced for this cluster.

## Change

Pin `mon_cluster_log_level: info` under `cephConfig.mon` in the rook-ceph-cluster HelmRelease (chart `v1.20.3`).

The ceph mon emits sustained `pgmap`/audit debug output (in upstream's analysis, ~4 lines/sec per mon, 73% of mon output was DBG). Raising the log floor to `info` suppresses that while keeping all INF/WRN/ERR entries — the audit trail for mutating commands, osdmap changes, and health transitions.

The option is runtime-changeable and `info` is a valid value per Ceph's `LogEntry::str_to_level`; entries below the threshold never reach stderr, so the collector picks up nothing.

## Not applied

The other half of the upstream PR (`prometheus-adapter logLevel: 1`) does not apply here — this cluster has no prometheus-adapter (observability is VictoriaMetrics + KEDA).

## Verification

- `flate test all` — 280 passed
- validate-pr.sh — exit 0, no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced overly verbose Ceph cluster logging by suppressing debug-level messages while retaining informational, warning, and error logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->