### PR TITLE
chore(resources): right-size four over-requested memory requests

### DIFF
--- a/kubernetes/apps/default/karakeep/app/helmrelease.yaml
+++ b/kubernetes/apps/default/karakeep/app/helmrelease.yaml
@@ -145,7 +145,8 @@ spec:
             resources:
               requests:
                 cpu: 10m
-                memory: 256Mi
+                # 91Mi cgroup peak over 30d; recheck after a meilisearch version bump
+                memory: 128Mi
               limits:
                 cpu: 1
                 memory: 4Gi

--- a/kubernetes/apps/default/nextcloud/facerecognition/helmrelease.yaml
+++ b/kubernetes/apps/default/nextcloud/facerecognition/helmrelease.yaml
@@ -36,7 +36,8 @@ spec:
             resources:
               requests:
                 cpu: 100m
-                memory: 512Mi
+                # 237Mi cgroup peak over 30d; 320Mi keeps ~35% headroom on control-2
+                memory: 320Mi
               limits:
                 cpu: 4
                 memory: 14Gi

--- a/kubernetes/apps/default/nextcloud/facerecognition/helmrelease.yaml
+++ b/kubernetes/apps/default/nextcloud/facerecognition/helmrelease.yaml
@@ -36,8 +36,8 @@ spec:
             resources:
               requests:
                 cpu: 100m
-                # 237Mi cgroup peak over 30d; 320Mi keeps ~35% headroom on control-2
-                memory: 320Mi
+                # 237Mi cgroup peak over 30d, so this still covers peak; limit stays 14Gi
+                memory: 256Mi
               limits:
                 cpu: 4
                 memory: 14Gi

--- a/kubernetes/apps/kube-system/metrics-server/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/metrics-server/app/helmrelease.yaml
@@ -25,6 +25,13 @@ spec:
       - --kubelet-use-node-status-port
       - --metric-resolution=10s
       - --kubelet-request-timeout=2s
+    # 79Mi cgroup peak over 30d against the chart's 200Mi default. Both replicas currently land
+    # on control-3, which the soft topologySpreadConstraint above permits, so this counts twice
+    # on the node that has the least headroom.
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
     metrics:
       enabled: true
     serviceMonitor:

--- a/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
@@ -283,7 +283,7 @@ spec:
       rbac:
         namespaced: false
       spec:
-        priorityClassName: homelab-critical # 274Mi, sole scrape path
+        priorityClassName: homelab-critical # 512Mi, sole scrape path
         selectAllByDefault: true
         resources:
           requests:
@@ -299,7 +299,15 @@ spec:
         operated-prometheus: "true"
         self-monitor: "true"
       spec:
-        priorityClassName: homelab-critical # 122Mi, Grafana's query path
+        priorityClassName: homelab-critical # 89Mi, Grafana's query path
+        # 28Mi cgroup peak over 30d against the chart's 100Mi default. config-reloader keeps its
+        # 25Mi default, which its 39Mi peak already exceeds; raising that is a separate change.
+        resources:
+          requests:
+            cpu: 50m
+            memory: 64Mi
+          limits:
+            memory: 256Mi
         extraArgs:
           requestBufferSize: "65536"
         managedMetadata:


### PR DESCRIPTION
control-3 hit **99.91% committed memory** today, leaving 19Mi free against the 32Mi an xmrig miner needs. That cost 190 minutes of mining (`NodeResourcesFit`). These four workloads request well above their measured peak.

## Changes

| workload | request | 30d cgroup peak | headroom after | node |
|---|---|---|---|---|
| `kube-system/metrics-server` | 200Mi → **128Mi** | 79Mi | 62% | control-3 (**both** replicas) |
| `observability/vmauth` | 100Mi → **64Mi** | 28Mi | 129% | control-3 |
| `default/facerecognition` | 512Mi → **256Mi** | 237Mi | 8% | control-2 |
| `default/karakeep` meilisearch | 256Mi → **128Mi** | 91Mi | 41% | control-1 |

Freed: **180Mi on control-3**, **256Mi on control-2**, 128Mi on control-1.

control-3 goes from 19Mi to ~199Mi free, clearing the cliff that blocked the 32Mi pod.

## Method

Sized against `container_memory_max_usage_bytes` (true cgroup peak) over 30d, not `container_memory_working_set_bytes`. Peak is the number that causes OOMKills and eviction; p95 working set understates it.

facerecognition is the tightest at 8%, but 256Mi still sits above its 237Mi peak, so the pod does not exceed its request even at peak.

No limits were lowered. Every change is a request only, so nothing gains a new OOM path: a pod over its request becomes an earlier eviction candidate under node pressure, it is not killed.

## Verification

| check | result |
|---|---|
| `kubectl kustomize`, all four dirs | clean |
| `vmauth.spec.resources` exists in CRD | confirmed (bogus field errors, this one does not) |
| metrics-server chart renders top-level `resources` | confirmed against the live Deployment |
| peak vs new request, all four | every new request exceeds 30d peak |

## Deliberately excluded

Ten-plus candidates from the same audit were rejected after adversarial re-measurement. Recording them so they are not re-proposed:

- **`network/envoy`** — largest raw candidate (1212Mi over p95), but true cgroup peak is 156Mi, already above the proposed 128Mi request on control-2. Would move it to the front of the eviction queue.
- **`database/pgbouncer`** — peak 104.5Mi exceeds the proposed 96Mi, and 128Mi was set deliberately to protect eviction ranking.
- **`media/brrpolice`** — cutting the request flips Guaranteed → Burstable QoS on control-3, an eviction-priority regression.
- **`rook-ceph` cephfs nodePlugin** — control-1 peaks at 154.6Mi, above both proposed and current request.
- **vmagent / vmsingle / victoria-logs / kube-state-metrics** — raised three separate times after OOMKills caused metrics and logging blackouts.
- **actions-runner ephemeral runners** — requests added after a node OOM cascade.
- **qwen3-embedding, vmcp-embedding, envoy-gateway, postgres16 (CNPG)** — measured *under*-requested; usage already meets or exceeds request.
- **rook-ceph OSDs and mgr** — no explicit `osd_memory_target`; the limit drives bluestore cache sizing on a latency-marginal cluster, and mgr-a is already restart-flapping.

## Not included, pending a decision

The Ceph CSI `logRotator` sidecars request 64Mi each against a **5Mi** 30d peak across all 12 containers, with 4 on each of control-2 and control-3. Dropping them to 16Mi frees **192Mi per node** — larger than everything in this PR combined for the constrained nodes — and the file's own convention is ~2x steady state, which 16Mi exceeds at 3.2x.

Left out because it lives in `csi/helmrelease.yaml`. Easy to add as a separate commit.

## Follow-up noted, not fixed

`vmauth`'s `config-reloader` sidecar requests 25Mi against a 39Mi peak, so it is under-requested. Raising it costs memory rather than saving it, so it is out of scope here.
