### PR TITLE
fix(gitignore): ignore suffixed age key backups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,9 @@
 *.pub
 *.key
 *.decrypted~*.yaml
-/age.key
+# `*.key` misses suffixed backups like age.key.bak-x25519-only, which decrypt the
+# tracked sops files in this PUBLIC repo. Supersedes the old `/age.key`.
+age.key*
 /cloudflare-tunnel.json
 bootstrap/github-deploy.key
 bootstrap/github-deploy.key.pub


### PR DESCRIPTION
`age.key.bak-x25519-only` was sitting untracked in this **public** repo.

```
gh repo view          -> {"isPrivate": false}
git check-ignore -v age.key.bak-x25519-only   -> no match
git add -A --dry-run  -> add 'age.key.bak-x25519-only'
git log --all -- age.key.bak-x25519-only      -> never committed
```

`.gitignore` had `*.key` and `/age.key`; the filename ends `-only` so neither matched. Verified by decryption that this key opens the tracked sops files.

Nothing leaked. It was one `git add -A` away.

`age.key*` also makes the existing `/age.key` redundant, so that line is removed rather than left dead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ignore rules to exclude backup and variant files associated with `age.key`, helping prevent them from being tracked accidentally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->