### PR TITLE
feat(kopiur): alert on backup freshness and enable weekly verification

### DIFF
--- a/kubernetes/apps/kopiur-system/kopiur/app/kustomization.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/app/kustomization.yaml
@@ -5,3 +5,4 @@ kind: Kustomization
 resources:
   - helmrelease.yaml
   - ocirepository.yaml
+  - prometheusrule.yaml

--- a/kubernetes/apps/kopiur-system/kopiur/app/prometheusrule.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/app/prometheusrule.yaml
@@ -1,0 +1,73 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: kopiur-rules
+spec:
+  groups:
+    # The chart ships its own `kopiur.rules` group (monitoring.prometheusRule.enabled
+    # in the HelmRelease); group and alert names here must not collide with it.
+    - name: kopiur.freshness.rules
+      rules:
+        # Backups were down 44h in July before anyone noticed: nothing watched
+        # freshness. Snapshots run hourly, so 6h is 6 missed runs, not a slow one.
+        # Named Overdue, not Stale: the chart's KopiurBackupStale fires off the same
+        # metric with the same severity, so a shared name is one alert fingerprint.
+        - alert: KopiurBackupOverdue
+          expr: |-
+            time() - kopiur_policy_last_backup_success_timestamp_seconds > 6 * 60 * 60
+          for: 30m
+          annotations:
+            summary: >-
+              kopiur {{ $labels.namespace }}/{{ $labels.policy }} has no successful backup
+              for {{ $value | humanizeDuration }} — restore point is aging
+          labels:
+            severity: warning
+
+        - alert: KopiurBackupCritical
+          expr: |-
+            time() - kopiur_policy_last_backup_success_timestamp_seconds > 24 * 60 * 60
+          for: 30m
+          annotations:
+            summary: >-
+              kopiur {{ $labels.namespace }}/{{ $labels.policy }} has not backed up
+              successfully in {{ $value | humanizeDuration }}
+          labels:
+            severity: critical
+
+        # The July outage removed the CSI snapshot CRDs, so policies stopped reporting
+        # rather than reporting failure. Absence is the failure mode to catch.
+        - alert: KopiurPolicyMetricsAbsent
+          expr: |-
+            absent(kopiur_policy_last_backup_success_timestamp_seconds)
+          for: 30m
+          annotations:
+            summary: >-
+              No kopiur policy backup metrics at all — the controller is down or every
+              policy stopped reporting; backup state is unknown, not healthy
+          labels:
+            severity: critical
+
+        # A repo whose snapshot count only ever grows means retention is not pruning;
+        # a drop to zero means the repo was emptied under us.
+        - alert: KopiurRepoEmpty
+          expr: |-
+            kopiur_repo_snapshot_count == 0
+          for: 1h
+          annotations:
+            summary: >-
+              kopiur repository {{ $labels.name }} reports zero snapshots — the repo is
+              empty or unreadable
+          labels:
+            severity: critical
+
+        - alert: KopiurControllerNotLeader
+          expr: |-
+            max(kopiur_leader_is_leader) == 0
+          for: 30m
+          annotations:
+            summary: >-
+              No kopiur controller holds the leader lease — nothing is scheduling backups
+          labels:
+            severity: critical

--- a/kubernetes/components/kopiur/backup/snapshotpolicy.yaml
+++ b/kubernetes/components/kopiur/backup/snapshotpolicy.yaml
@@ -34,6 +34,16 @@ spec:
       runAsGroup: ${KOPIUR_PGID:=568}
       capabilities:
         add: ${KOPIUR_MOVER_CAPS_ADD:=[]}
+  # Verification is opt-in and nobody had opted in: snapshots ran hourly for 18d with
+  # LAST-VERIFIED empty on all 18 policies. A repo that stops being restorable reads
+  # identical to a healthy one until the restore. Fixed hour + 3h jitter spreads the
+  # fleet wider than `H 3 * * 0` would (a single hashed minute inside one hour), which
+  # matters because quick verify walks the whole repo.
+  verification:
+    quick:
+      schedule:
+        cron: 0 3 * * 0
+        jitter: 3h
   compression:
     compressor: zstd
   retention:


### PR DESCRIPTION
Backups ran hourly for 18d with `LAST-VERIFIED` empty on **all 18 policies**, and nothing watched freshness. A repo that stops being restorable reads identical to a healthy one until a restore is attempted.

## Alerts
`KopiurBackupOverdue` (6h), `KopiurBackupCritical` (24h), `KopiurPolicyMetricsAbsent`, `KopiurRepoEmpty`, `KopiurControllerNotLeader`.

## Name collision avoided

The chart ships its own `kopiur.rules` group (via `monitoring.prometheusRule.enabled`) containing a `KopiurBackupStale` on the **same metric at the same severity with the same `for:`**. Identical result labels mean identical alert fingerprints, which Alertmanager cannot distinguish — and crossing the threshold downward would make one rule resolve while the other kept firing.

Hence group `kopiur.freshness.rules` and alert `KopiurBackupOverdue`. The chart's other 8 alerts are not duplicated; freshness, metric-absence, empty-repo and never-leader are genuine gaps.

## Verification

`spec.verification` is opt-in and nobody had opted in. Enables the `quick` (blob-level) tier weekly with 3h jitter so 18 policies do not hit the NAS at once. Concrete cron rather than the `H` placeholder.

## Validation
`kustomize build`, `kubectl apply --dry-run=server` on the rule and an envsubst'd SnapshotPolicy, every expression run against live VictoriaMetrics. All 18 policies are currently under 1h old, so these are silent on merge.

## Known, not addressed
`KopiurBackupCritical` at 24h double-notifies with `KopiurBackupOverdue` at 6h — the inhibit rule matches on `alertname`, which differs. A 24h-dead backup arguably deserves the noise.