### PR TITLE
fix(karakeep): disable thinking mode on qwen35-2b

### DIFF
--- a/kubernetes/apps/ai/llmkube/models/qwen35-2b.yaml
+++ b/kubernetes/apps/ai/llmkube/models/qwen35-2b.yaml
@@ -50,6 +50,11 @@ spec:
     - "0.8"
     - "--presence-penalty"
     - "1.5"
+    # Qwen3.5's chat template thinks by default; without this it burns the whole
+    # output budget on reasoning_content and returns empty content (verified live
+    # 2026-08-02). Sampling flags above don't touch this — it's a template setting.
+    - "--reasoning"
+    - "off"
 
   # Both iGPU nodes advertise 2 squat.ai/dri slots; the embedders pair up on
   # qwen3-embedding's node (via podAffinity there), leaving the other iGPU


### PR DESCRIPTION
## What

`kubernetes/apps/ai/llmkube/models/qwen35-2b.yaml`: adds `--reasoning off` to the InferenceService's `extraArgs`.

## Why

Post-merge validation of #4298 found qwen35-2b thinks by default. Live test against the running pod (via litellm):

| Request | max_tokens | Result |
|---|---|---|
| "Reply with exactly one word: hello" | 300 | Entire budget spent on `reasoning_content`, `content: ""`, `finish_reason: "length"` |
| Same, + `chat_template_kwargs: {"enable_thinking": false}` | 50 | `content: "hello"`, `finish_reason: "stop"`, 2 completion tokens |

Karakeep's OpenAI client never sends `chat_template_kwargs`, and `qwen35-2b`'s `LiteLLMModel` is auto-registered by litellm-operator (not hand-authored like `qwen-3.6-fast`, which injects `enable_thinking: false` via its litellm alias's `extra_body`). So every real Karakeep tagging/summarization request would have hit this and returned empty output whenever reasoning ran past the token budget.

`--reasoning off` (confirmed present via `llama-server --help` on the live pod) disables thinking at the server regardless of what the caller sends.

## Verification

- YAML parses cleanly
- Root-caused and reproduced live against the deployed qwen35-2b pod before writing the fix
- Will re-verify live once merged and Flux reconciles: request without `chat_template_kwargs` should return non-empty `content` and `finish_reason: "stop"`
