### PR TITLE
feat(ai): deploy omniroute AI gateway and expose in litellm

### DIFF
--- a/kubernetes/apps/ai/kustomization.yaml
+++ b/kubernetes/apps/ai/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   - ./hermes/ks.yaml
   - ./litellm/ks.yaml
   - ./memini/ks.yaml
+  - ./omniroute/ks.yaml
   - ./llmkube/ks.yaml
   - ./opencode/ks.yaml
   - ./odysseus/ks.yaml

--- a/kubernetes/apps/ai/litellm/instance/models.yaml
+++ b/kubernetes/apps/ai/litellm/instance/models.yaml
@@ -53,3 +53,25 @@ spec:
     mode: chat
     maxInputTokens: 171808
     maxOutputTokens: 8192
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/litellm.home-operations.com/litellmmodel_v1alpha1.json
+apiVersion: litellm.home-operations.com/v1alpha1
+kind: LiteLLMModel
+metadata:
+  name: omniroute
+spec:
+  modelName: omniroute
+  proxyRef: litellm
+  params:
+    # "auto" is OmniRoute's zero-config smart-routing model id — it builds a
+    # virtual combo from whichever free/keyed providers are connected.
+    model: openai/auto
+    apiBase: http://omniroute.ai.svc.cluster.local:20128/v1
+    # REQUIRE_API_KEY=false internally; LiteLLM's OpenAI provider still needs
+    # a non-empty api_key (same convention as the qwen-3.6 sk-sglang-noauth).
+    apiKey: sk-omniroute-noauth
+    additional:
+      timeout: 300
+      num_retries: 0
+  info:
+    mode: chat

--- a/kubernetes/apps/ai/omniroute/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/omniroute/app/helmrelease.yaml
@@ -39,10 +39,10 @@ spec:
             resources:
               requests:
                 cpu: 100m
-                memory: 256Mi
+                memory: 128Mi
               limits:
                 cpu: 1000m
-                memory: 1Gi
+                memory: 512Mi
     defaultPodOptions:
       securityContext:
         runAsNonRoot: true
@@ -56,7 +56,6 @@ spec:
             port: *port
     persistence:
       data:
-        enabled: true
-        storageClass: ceph-block
-        accessMode: ReadWriteOnce
-        size: 5Gi
+        existingClaim: omniroute
+        globalMounts:
+          - path: /app/data

--- a/kubernetes/apps/ai/omniroute/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/omniroute/app/helmrelease.yaml
@@ -1,0 +1,62 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: omniroute
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  interval: 30m
+
+  values:
+    controllers:
+      omniroute:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: docker.io/diegosouzapw/omniroute
+              tag: 3.8.49
+            env:
+              TZ: ${TIMEZONE}
+              DATA_DIR: /app/data
+              PORT: &port 20128
+              # Internal-only ClusterIP — litellm is the sole caller, same
+              # unauthenticated-backend + non-empty-apiKey convention as the
+              # qwen-3.6 SGLang model (LiteLLMModel requires apiKey non-empty).
+              REQUIRE_API_KEY: "false"
+            envFrom:
+              - secretRef:
+                  name: "{{ .Release.Name }}-secret"
+            probes:
+              liveness:
+                enabled: true
+              readiness:
+                enabled: true
+            resources:
+              requests:
+                cpu: 100m
+                memory: 256Mi
+              limits:
+                cpu: 1000m
+                memory: 1Gi
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+    service:
+      app:
+        ports:
+          http:
+            port: *port
+    persistence:
+      data:
+        enabled: true
+        storageClass: ceph-block
+        accessMode: ReadWriteOnce
+        size: 5Gi

--- a/kubernetes/apps/ai/omniroute/app/kustomization.yaml
+++ b/kubernetes/apps/ai/omniroute/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrelease.yaml
+  - secret.sops.yaml

--- a/kubernetes/apps/ai/omniroute/app/secret.sops.yaml
+++ b/kubernetes/apps/ai/omniroute/app/secret.sops.yaml
@@ -1,0 +1,56 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: omniroute-secret
+stringData:
+  JWT_SECRET: ENC[AES256_GCM,data:PuqUvXJR826enHwvq6p3kiiIfu3Dt+nZICJIhU2lokxZFlbbgZYVgu947WYB2Ga3/Pcf4bHOcnc4e1axjpg+tw==,iv:f202RHk5uB4juwaro49gGh5RZ4HtDl5Q04/QuiVF2Jg=,tag:Vrm3IVzPuf/t6ERKHBSK4Q==,type:str]
+  API_KEY_SECRET: ENC[AES256_GCM,data:DGPkNnb8+6VUM00DWjodfC5nNzQPfkDh3a+QN2HGI+b2Pw3c+ayXb0xet+Rnxjp29BBKT7vphLk4j6KvgODh4Q==,iv:7nJgUysktjzK9Zi5h31XCJdmHz2vzF8GFIeYj4ke5/Y=,tag:sMTsMHl9/4gddabxVEcyfQ==,type:str]
+  STORAGE_ENCRYPTION_KEY: ENC[AES256_GCM,data:vfRAcHIT83vqqRgVgG5yeb3E8Z+ulBAtiPpMB8wRnvaWaGAtLaB8cMFWVov/XBYaP7gBFq3kzgArNQpmBTkq7Q==,iv:LuRX31HZM28AD52yRBZ/Nc/JBxRd5UtMrg0AScWjxPs=,tag:RpBvyIiKU2mbY6M8QvFTrA==,type:str]
+  INITIAL_PASSWORD: ENC[AES256_GCM,data:/Ew1BFnvEPBbC5qql6rukZSfQXkTQUtX+CzLi11jtKo=,iv:1HbrJ6U+Cbn6kS/xjvNwVqKuUWiL/LMfIdBrXBPHKsU=,tag:PtubP2j0PIl3bs+0G+clSQ==,type:str]
+sops:
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IG1sa2VtNzY4eDI1NTE5IFRXRWFHcUFS
+        THUxR00zK3F5WmdoVkxiMGsvcW5wZUMxQkR2NDV6b3MvdzJTV1gxS2h4QmNSanRq
+        a0U0RTBKVlJrL3FnQ2QzeE54aTZOQWE5OU4vOFhtMWgzZnl3Y1BzNzV6NkJKTEtw
+        dmthRGhoVytoQmV6SUQ2b2hzaGNHbWpYNmtCZDNmNGp6RHpjSjdQQm5zbTFSTHpj
+        cFJLbE05TEZXSGdPbDJwcHpVa0QvcUVaRjFOOU9NazVLTkpXZlljQ09QRkFHalZW
+        MC9TQVoyTFFCcnRMQml5OTBMd0tBTk9BbWZJSDh4TWFvMGFwWTFqQTJGZDRKQlpR
+        MXNRTGVLczRsRldhbjhQVEZPZ0N0bXlqUmRxTUpFRGZJQzZ4Y2ZYejc3SHNCZmhr
+        VUVkS1ZpT0tHYXFTencxcUFHUnpDdUtlbWM3OU1ZSTdISEdxakFrK21vL3NZNGVp
+        aWh6dzhlOWxhcXNMRXc2Y1dXRXd3eVpKbGFzMmpFV1pTRDduZDR6OSsxd0ZUT3Fa
+        a21kamdXMDhXV1dpYkU2RG9nQWs0TkhMbFZFNnBVRmRvREEyZTlTTXQxbkphbUJF
+        YmRPcUtwZ2FjRHExODF4U2lrUWNrSFpXc1B1K0FzczREVU8rTVlwSkpxNnZISnZQ
+        MHI0a0piVzRHZzlvZjlsZVRoYnl0Q0Jva29kWU11Y3pUa2xjRDVDWktPNCtTc1dX
+        Mkx6ZGxLMDEzb0RySE11MDArMTRub0lXbXFZT3M3eko2ZTZBbHhKS2VneVVkellW
+        NzhFbDJKTWU5Zzd3WE5RdERaT09KRGhqRFpQWHM2VHlEZHZZaWYvVkdqUUt4UnZU
+        SFR6VzRTRXVwaklSdnIvZmdWUDZZbVdGK1dhMkx6ZjNFeVFFWEt1cDdmaWw2bnhE
+        dVZlYkNtQms0NVVNSk1yZXV2YjhyOUxoZUlRM1A1M2JYSlFwOE55QWtHRkhxcEUz
+        ZUcvSEV5dVB5eFZnL0VYaE1xWjVJcytUVUdVd2xPcWlTdXpNUFprUFFob09xUUll
+        WmdjU2tjWGJsQ25CS2JvSm1YOG44UUtWSTBKR1VJWlFsZjFJV21BZ2V3UGdUb05H
+        YnIyck5yaDlmbHJ3Z1pubWNYcitOWlpsMnhwcDFuNkxxQUg5a1plbFF2SDVHWHF4
+        YnJDbk9FdHkwaVdTR3ZpSmpNanRxd05xYTFvWlEwdXdPL0hDc0lyWXptZXc1U2hh
+        N0pVNmtMMGcvVTlTOUM0d2d2Rk5vS0ZaOVNMV0d2OVE5Q3RvM0RCeTFHRThrZ1BC
+        UlRRM1FIS0RDRlNmNFhZQWpSQkxiN2xPKzVSa2xLUitLY2hRQ1hFVHMxR3lIakM4
+        cTVyMHZGM1hDZUNXNjB5dTQwSWlCMjNtZ2VkRkRCL3RDNVNPK20zTEcwVG5RV1Rr
+        NVlpeCt4V0dhTnR3Ty91SGoycmVISkJtSnJxbU8vWjZ2RkxFSlJ3aEpYWEN1YnBq
+        RkRJTGU2ZmFBekU5akd3WjNSWU9xa3pIWXdCN0NQUkJaN0QvcjFPSmxmc0ZtTjU0
+        U0VwOXJ4dVp0K1Azd25VZjcvWk96RVdhMWZ3OFcxeCtTUHBzZEVLYTNuOFlXQ0xM
+        QmIxenhnQS9QS1FBVWlWSkQzY0Q2ZUFHOUIzeXg0RGt1VmFnZWdRSzRualFDS1d3
+        a3BTRmtxMnFTMHdnZktZdmRjeFRvWTM4UnkyMHNhRHRVWVJtdlBsWGEzYk5ydUR2
+        c2pxTmUxcGZCQng3YmFNN3BvbUhnUHVHbCtlZTc5WGpGaXFjMlA1TnRBcG5QVERq
+        eWpWY0hwSk00bkY1NWNZaFhDd09JejdSSlRvOTlKV3VpOG1EL0p0b2lTcHQ2NzAz
+        VGZPQmZUbGV4UTNhMTg0RWFnNFNyL3VwMkkwQjZtLzUvTWRtR3oxN3J1T1NaRzhx
+        ZmsyR002d01jYU9CODhpMklxK0lVUXNPNERtUkp1N1BudEtXdVE1OG5OODZTZwpN
+        Mnh5cUtNSklWY253QUNEalFvMWUwc09GTUxsU201K0lScTJTMS9iUEE0Ci0tLSBJ
+        bXczNk5GRFM5OTl4V3JBVVFqT1FQUzJhWGFxOElKdURab1c0Y3REZU0wCjq/Ivan
+        zOBDrjzpDCROKQVE/vyV47BqjyZC95ZYPA3Ck8piQjaghMig4sLSjWN/cS0pCXGs
+        WvGB5ZsS5Z0kP1s=
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1pq1f696t70thmae32r7s6eqscyncz4tveaqsd53k2pw82kems2v02mcmeuj4j85swr6zdp3z3ay6kuq26z9d37928w58se3a7cvghzzlthmhfmdcn66sc8kcwp56672yjn5szvqet5q5v46a3kphepytfstdah95v95awn25jvc8ce2nmes0cqykax6n2tkf94pxqcjkn55wjjrgmk2dgh2xggl5gskxy4t20x88pqqtgnfe8pyymfuwmy3e9muvja9x3gf8can07seky8hv6ve9v0auzdyhpa2xwczme5ejxtdx6xtqp47cwe8q026gzh5wz0x82dezz5jkgznskq960ltwtfxsdj27seql0rtu3jqqkkm4xgqcfzjnxrzyevea8vgz5hr8053yt56qd9r6umydx93usfuzznen9wlew6500ydcqpjk2jm4x0ewy34ngjpj4uwu4p5dzynca4grrfghsnllum865u9f8py3nq69r0kjarppxfgvfgptuqpxkar2wvq7r8ys4vuuc2pj0433ceax49znp8sfqj5dl29ulcczqqw20pcjygxkc26tzv35ln8c7jjfre957v88wq9n8xxf4qgw3wpv2hh74gwuacnr2f4krkxzjs45a46v62jdkgmq0qnk3vhe9s2kgfjw3dzn6d4fnwyrt4ke6fverqc4x4mxpj6ffahw3mqv8g6vjgg2p46u53zrhgsnyr4x5dmxsmmpzdhjdu436ey89qmxgca8sjdwuzjhcvtewm9yppzjs9ef2p8q2mdjfcjh3uu3fq5py04sv8pskjvqd9y0ta8axmh239u4zlrgpdmwfe7r0wpgt788xgjwjx0vxdjr5gzk4quukyv2rvefjacg38mpwqyjaxv9q294v4f03g5x3ve79c27fgt3u34vmrcty09sje3yw2rraa5x9y5t3u4rtcpu5ay8jrx44u8dfehw5ulgfgqjza0lce4tz6s34uq00ayrg6vk6hgjuql55z6taltx04mjehmkk487ddd5zuzguqu8nvz2d5fhgl6sx3x775zdw29xnr8jgmltyfze2ymsz92u2dk4v70jzfsvc34m3ajkg9965rcqe9nn3aehwcr047p6xfnc55cv6tjewdrg6mff4glrwd9p8q5sa9repr0w3hzw42d9dys6u8hr50v83v8y5lzncql6ty9gfkcc4pcst683ddz2vky7u9g8gkrjy440r8yrsdw5cq6cpj23fjqxrj0t2gj5cpyv6407luycyd8p6pmjym3g46w2aj7f79nce73g30zwr4hx7mz2emrwkkgst53q85zyveg7fen5vtfjc3y6m0f5mkwj3yq5643c3jstgcz9fgsgu5hdx4u27wud5a3kgv8ysdh9z295mxh6j2pp96qwk34jevrqhn8zutwvvzwla53mrqh6czjpq6ud0c0psd7zznkgjczqsppq36ujygqnz4nc5sg40ngkfh3k5qyfdvx4slv9xcaceu83mzzr0unc3y4fznt0dal42z2kye8vxjz4yur33azljufrzg3d0lmxw2n53efhjr8wxtfstz4jjhn9pynzf425jryfpgf23pc6ykm4049qgu2xsz2nyrhty5yjla9xueyxwka77ztx7n6ndak0lg5n2fpveff8j2g49dyp3wqsvqmnm638nxwrd3g4hxqese8mmwt3cmr0jdykdnvqsmd9zumt0e6jkaktpppspsw4szfu7ft79r8gqwspdw7256lqmpr6r6hm2xxv0uwzqw6q3ffcy4y9n7tzxzhr22gf3qwxu8rhq9ceuj8jd4qsc7yexsa27d3dkwelklhk77c8zlf5aeg8y3usluk4y749ltlt7eh5xyf8al09nwljekxe74s7uj0hd07sm0zxgqal48prwgvl9svx0ucvze2yy3yygsqjwpc
+  encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-08-02T15:57:44Z"
+  mac: ENC[AES256_GCM,data:oyR1p78dyTmYlD6chWM4y0BfluOY3jCOD6JcV3dwaz6+R5EW672arM04YJtHa64nKpeweXv9cxXvwVAzvRQAS+wEUA+0frLg7fSv9tcDk0HhZ01Ys7soJz6ZtGxTr4bI+1locyKZ8MNYt8RaiEj7/klIAuQ3EgpnmTy1MgrYgqY=,iv:uNk4+BTOMI12UD4O0EIQhPosEZCJFUQojb0KLt1hDF4=,tag:P2FnyPCQR6di4RmCfKvBpg==,type:str]
+  mac_only_encrypted: true
+  version: 3.13.3

--- a/kubernetes/apps/ai/omniroute/ks.yaml
+++ b/kubernetes/apps/ai/omniroute/ks.yaml
@@ -1,0 +1,17 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: omniroute
+  namespace: &namespace ai
+spec:
+  targetNamespace: *namespace
+  path: ./kubernetes/apps/ai/omniroute/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: true
+  interval: 30m

--- a/kubernetes/apps/ai/omniroute/ks.yaml
+++ b/kubernetes/apps/ai/omniroute/ks.yaml
@@ -3,7 +3,7 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: omniroute
+  name: &app omniroute
   namespace: &namespace ai
 spec:
   targetNamespace: *namespace
@@ -15,3 +15,11 @@ spec:
     namespace: flux-system
   wait: true
   interval: 30m
+  components:
+    - ../../../../components/kopiur
+  postBuild:
+    substitute:
+      APP: *app
+      PVC_CAPACITY: 2Gi
+      KOPIUR_PUID: "1000"
+      KOPIUR_PGID: "1000"


### PR DESCRIPTION
## Summary
- Deploy [OmniRoute](https://github.com/diegosouzapw/OmniRoute) (`docker.io/diegosouzapw/omniroute:3.8.49`) as a new `ai/` app-template HelmRelease — internal ClusterIP only, no ingress.
- PVC routed through the shared kopiur backup/restore component (matches every other stateful `ai/` app).
- Add a `LiteLLMModel` (`omniroute`) pointing at `openai/auto` — OmniRoute's zero-config smart-routing model, works with no upstream provider keys.

## Notes
- `REQUIRE_API_KEY=false` internally (ClusterIP-only, litellm is the sole caller) — same unauthenticated-backend convention as the existing `sk-sglang-noauth` qwen-3.6 entries.
- Dashboard login (`INITIAL_PASSWORD`, random, in `omniroute-secret`) needed once to connect any paid/keyed providers beyond the free `auto` tier.

## Test plan
- [x] `kustomize build kubernetes/apps/ai` — builds clean
- [x] `kustomize build kubernetes/apps/ai/omniroute/app` — builds clean
- [ ] Flux reconcile + confirm pod healthy, `curl` `/v1/chat/completions` via litellm `omniroute` model alias

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the OmniRoute application to the AI platform.
  * Added routing for automatic OpenAI model requests through OmniRoute.
  * Configured persistent storage, health monitoring, resource limits, and secure non-root operation.
  * Added encrypted configuration for authentication, API access, storage, and initial setup.
  * Enabled automated deployment and readiness management through Flux.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->