### PR TITLE
chore(gitignore): ignore .slim/worktrees, it holds live git worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,8 @@ work/
 .venv/
 .agents/pr-review/
 .slim/deepwork/
+# .slim/worktrees/ holds live git worktrees
+.slim/worktrees/
 .DS_Store
 Thumbs.db
 __pycache__/


### PR DESCRIPTION
`.slim/worktrees/` holds registered git worktrees but was not covered by the committed `.gitignore`, so `git clean -fdx` could destroy them and `git add -A` would stage them.

`.worktrees/` and `.slim/deepwork/` were already ignored; this brings `.slim/worktrees/` in line with them.

```
$ git check-ignore -v .slim/worktrees          # before
(no match, exit 1)

$ git check-ignore -v .slim/worktrees          # after
.gitignore:28:.slim/worktrees/	.slim/worktrees
```

Two lines, one file, no behaviour change.