### PR TITLE
fix(toolhive): raise vmcp-unified healthCheckTimeout to 20s

### DIFF
--- a/kubernetes/apps/ai/toolhive/config/virtualmcpservers.yaml
+++ b/kubernetes/apps/ai/toolhive/config/virtualmcpservers.yaml
@@ -77,6 +77,11 @@ spec:
     operational:
       timeouts:
         default: &embeddingTimeout 120s
+      # Default healthCheckTimeout (10s) marks a backend "degraded" past ~5s (half-timeout
+      # heuristic) -- routine control-1 latency blips cross that and flap every backend's
+      # status at once. Raised so a transient node stall doesn't read as a backend outage.
+      failureHandling:
+        healthCheckTimeout: 20s
     aggregation:
       conflictResolution: prefix
       conflictResolutionConfig:


### PR DESCRIPTION
## Summary
- Default `healthCheckTimeout` (10s) marks a backend degraded past ~5s, so a routine control-1 latency blip flaps every backend's status at once and can drop active MCP sessions.
- Raised to 20s so a transient node stall doesn't read as a backend outage.

## Test plan
- [ ] `kubectl kustomize kubernetes/apps/ai/toolhive/config/` builds clean (verified locally)
- [ ] After merge, confirm `VirtualMCPServer/unified` reconciles and backend status stops flapping to `degraded` during normal control-1 latency blips

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a 20-second health check timeout to improve handling of slow or unresponsive virtual MCP server health checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->