### PR TITLE
fix(hermes): set AGENT_BROWSER_ARGS to bypass Chromium sandbox detection gap

### DIFF
--- a/kubernetes/apps/ai/hermes/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/hermes/app/helmrelease.yaml
@@ -49,6 +49,10 @@ spec:
               S6_CMD_RECEIVE_SIGNALS: "1"
               HERMES_RESTART_DRAIN_TIMEOUT: "45"
               S6_SERVICES_GRACETIME: "80000"
+              # Chromium's sandbox can't work under non-root uid 10000, and browser_tool.py's
+              # own bypass detection doesn't recognise a containerd pod. Value matches the one
+              # it injects itself.
+              AGENT_BROWSER_ARGS: "--no-sandbox,--disable-dev-shm-usage"
             envFrom:
               - secretRef:
                   name: hermes-secret


### PR DESCRIPTION
## What

Every `browser_navigate` call was crashing before writing DevToolsActivePort. Reproduced directly in the pod: Chromium FATALs with "No usable sandbox" when launched without `--no-sandbox`.

## Why

`browser_tool.py`'s own sandbox-bypass auto-detection checks root euid, `/.dockerenv`, and an AppArmor userns-restriction file — none of which are true for a plain containerd/Kubernetes pod, so the detection never fires. Chromium's SUID sandbox can't work here regardless: the container runs `allowPrivilegeEscalation: false`, which structurally blocks the setuid mechanism the sandbox depends on.

Setting `AGENT_BROWSER_ARGS` unconditionally skips the broken detection — `browser_tool.py` already honours a pre-set value and never overwrites it. The flag values match exactly what the tool injects itself when its own detection does fire, so this doesn't diverge from upstream's canonical value on future image bumps.

## Verification

- Reproduced the crash: launched `chrome-headless-shell` as the `hermes` user without `--no-sandbox` → `FATAL: No usable sandbox!`
- Confirmed the fix: same launch with `--no-sandbox --disable-dev-shm-usage` → renders successfully
- Confirmed `allowPrivilegeEscalation: false` on the container, so the SUID sandbox was never viable here

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved browser reliability in the Hermes application by adjusting Chromium runtime settings.
  * Increased compatibility in containerized environments by configuring shared-memory usage and sandbox behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->