### PR TITLE
fix(ai): resolve omniroute reliability issues (DNS collision, timeout race)

### DIFF
--- a/kubernetes/apps/ai/litellm/instance/models.yaml
+++ b/kubernetes/apps/ai/litellm/instance/models.yaml
@@ -72,7 +72,12 @@ spec:
     # a non-empty api_key (same convention as the qwen-3.6 sk-sglang-noauth).
     apiKey: sk-omniroute-noauth
     additional:
-      timeout: 300
+      # 300s + retry_policy's 2 retries could exceed the pr-reviewer-action's
+      # 600s curl timeout, so the action gives up and retries blind instead of
+      # letting the qwen-3.6-fast fallback fire (observed 2026-08-03: 60min
+      # run, fallback never triggered). 90s keeps worst case (3 attempts) at
+      # 270s, inside the action's window.
+      timeout: 90
       num_retries: 0
   info:
     mode: chat


### PR DESCRIPTION
## Summary
- **DNS collision (root cause of opencode failures):** default `ndots:5` search-expands the external domain `opencode.ai` to `opencode.ai.svc.cluster.local` before trying it as absolute — which exactly matches our own in-namespace `opencode` Service. Every lookup of the real opencode.ai provider was silently hijacked to our internal app instead, explaining the persistent 502s/timeouts previously blamed on the upstream provider. Fixed with `dnsConfig.options: ndots=1` (same pattern already used by seerr, prowlarr-exporter, etc.).
- **Timeout race:** omniroute's litellm timeout (300s) + retry_policy (2 retries) could exceed the pr-reviewer-action's 600s curl timeout, so the action's own retry loop always raced litellm's `qwen-3.6-fast` fallback and won. 90s timeout keeps worst case at 270s, inside the action's window.

## Evidence
| Run | PR | Total time |
|---|---|---|
| meilisearch bump | 2m |
| hermes-agent bump | 9m48s |
| searxng bump | 24m43s |
| oxfmt bump | 30m7s |
| litellm-operator bump | 31m3s |
| memini bump | 32m40s |
| renovate-presets bump | 60m48s (4 self-retries, ~10min apart) |

Slow runs correlate with `opencode` being picked by `auto` and hanging on the DNS-hijacked connection.

## Also done (live, not in this diff)
- Removed 11 permanently-dead provider connections (invalid keys, missing CLI binaries, internal-URL SSRF block, unsupported endpoint).
- Reconnected 4 that looked transient; `opencode` should now resolve correctly once this PR's DNS fix ships.

## Test plan
- [x] `kustomize build kubernetes/apps/ai/litellm/instance` clean
- [x] `kustomize build kubernetes/apps/ai/omniroute/app` clean
- [ ] Next Renovate PR review completes well under 10 minutes
- [ ] `opencode` provider resolves the real opencode.ai after rollout (verify via omniroute logs, no more `502`/timeout on `opencode.ai:443`)