### PR TITLE
fix(omniroute): fix ndots DNS collision hijacking opencode.ai lookups

### DIFF
--- a/kubernetes/apps/ai/omniroute/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/omniroute/app/helmrelease.yaml
@@ -47,6 +47,14 @@ spec:
                 cpu: 1000m
                 memory: 2Gi
     defaultPodOptions:
+      # Default ndots:5 search-expands "opencode.ai" to
+      # "opencode.ai.svc.cluster.local" first, which matches our own
+      # in-namespace opencode Service — silently hijacking every lookup of
+      # the real opencode.ai provider. ndots:1 tries the absolute name first.
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000


### PR DESCRIPTION
## Summary
- Root cause of the persistent `opencode` provider failures in omniroute (previously attributed to the upstream `opencode.ai` service in #4323): default `ndots:5` search-expands the external domain `opencode.ai` (1 dot, < ndots) to `opencode.ai.svc.cluster.local` **before** trying it as an absolute name. That search-expanded name exactly matches our own in-namespace `opencode` Service (`ai` namespace, unrelated self-hosted app), so every DNS lookup of the real provider was silently hijacked to our internal app instead.
- Fixed with `dnsConfig.options: ndots=1`, the same pattern already used by `seerr` and the `*-exporter` apps for this exact class of bug — absolute-looking names try direct resolution first.
- This was meant to ship together with #4323 but the commit landed 5 minutes after that PR was merged, so it never made it into main. Standalone now.

## Test plan
- [x] `kustomize build kubernetes/apps/ai/omniroute/app` clean, `dnsConfig` present in rendered Deployment
- [ ] After rollout, confirm `dig opencode.ai` / omniroute logs show the real provider resolving instead of `10.43.254.109` (our internal opencode Service ClusterIP)
- [ ] omniroute's `opencode` provider connection stops erroring

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved provider hostname resolution for the Omniroute service.
  * Absolute hostnames are now checked before Kubernetes search-domain expansion, helping prevent connection and lookup issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->