### PR TITLE
fix(litellm): route omniroute through auto/smart instead of bare auto

### DIFF
--- a/kubernetes/apps/ai/litellm/instance/models.yaml
+++ b/kubernetes/apps/ai/litellm/instance/models.yaml
@@ -63,10 +63,9 @@ spec:
   modelName: omniroute
   proxyRef: litellm
   params:
-    # "auto" is OmniRoute's zero-config smart-routing model id — it builds a
-    # virtual combo from whichever free/keyed providers are connected and
-    # picks the best-scoring one live per request (quota/health/cost/taskFit).
-    model: openai/auto
+    # Bare "auto" sticks to the last-known-good provider regardless of quality;
+    # auto/smart scores live on quota/health/cost/taskFit instead.
+    model: openai/auto/smart
     apiBase: http://omniroute.ai.svc.cluster.local:20128/v1
     # REQUIRE_API_KEY=false internally; LiteLLM's OpenAI provider still needs
     # a non-empty api_key (same convention as the qwen-3.6 sk-sglang-noauth).


### PR DESCRIPTION
## Summary
Bare `auto` classifies review-shaped payloads as `intent=medium / task=default` and selects via OmniRoute's sticky `lkgp` (last-known-good-provider) strategy — the same free provider every time it last succeeded, regardless of whether a better one is currently available. `auto/smart` is a distinct OmniRoute model id that forces its `RulesStrategy` live scorer (quota/health/cost/taskFit) on every request instead.

## Evidence
Direct test against omniroute:
- `model: auto` → `Auto selection: opencode/big-pickle | strategy=lkgp | LKGP: using last known good provider opencode` (no scoring, pure stickiness)
- `model: auto/smart` → `Auto selection: kimi-coding/k3 | RulesStrategy: score=0.828 (quota=1.00, health=1.00, cost=1.00, taskFit=0.85)` (live quality scoring)

## Test plan
- [x] `kustomize build kubernetes/apps/ai/litellm/instance` clean, `model: openai/auto/smart` present
- [ ] Post-rollout, confirm omniroute logs show `RulesStrategy` scoring (not `lkgp`) for real litellm calls

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic AI provider routing by evaluating quota, health, cost, and task suitability.
  * Updated the OmniRoute model configuration to use smart routing for more effective provider selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->