### PR TITLE
fix(litellm-operator): grant RBAC for LiteLLMTeam/LiteLLMVirtualKey

### DIFF
--- a/kubernetes/apps/ai/litellm/app/kustomization.yaml
+++ b/kubernetes/apps/ai/litellm/app/kustomization.yaml
@@ -6,3 +6,4 @@ kind: Kustomization
 resources:
   - helmrelease.yaml
   - ocirepository.yaml
+  - rbac.yaml

--- a/kubernetes/apps/ai/litellm/app/rbac.yaml
+++ b/kubernetes/apps/ai/litellm/app/rbac.yaml
@@ -1,0 +1,31 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/rbac.authorization.k8s.io/clusterrole_v1.json
+# litellm-operator 0.0.10 added LiteLLMTeam/LiteLLMVirtualKey controllers
+# without matching RBAC in the chart's ClusterRole, so the manager's
+# informer cache never syncs and it crashloops on every startup
+# (leader election lost -> shutdown -> restart). Additive grant, survives
+# chart upgrades; drop once upstream ships the missing rules.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: litellm-operator-team-rbac-patch
+rules:
+  - apiGroups: ["litellm.home-operations.com"]
+    resources: ["litellmteams", "litellmvirtualkeys"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["litellm.home-operations.com"]
+    resources: ["litellmteams/status", "litellmvirtualkeys/status"]
+    verbs: ["get", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: litellm-operator-team-rbac-patch
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: litellm-operator-team-rbac-patch
+subjects:
+  - kind: ServiceAccount
+    name: litellm-operator
+    namespace: ai


### PR DESCRIPTION
## Summary
This is why tonight's `LiteLLMModel omniroute` changes (90s timeout in #4323/#4324, `auto/smart` in #4325) never actually reached the live litellm proxy despite the K8s CRs updating correctly and Flux reconciling clean.

`litellm-operator` 0.0.10 (bumped in #4318) added `LiteLLMTeam` and `LiteLLMVirtualKey` controllers without matching RBAC rules in the chart's ClusterRole. The manager blocks on all informer caches syncing at startup; `litellmteams`/`litellmvirtualkeys` time out (403 forbidden), the whole manager fails, and kubelet restarts the pod — 50 restarts observed over 171 minutes, i.e. it's been crashlooping continuously and never actually held leadership long enough to reconcile any `LiteLLMModel` change since the version bump.

## Evidence
```
litellmteams.litellm.home-operations.com is forbidden: User
"system:serviceaccount:ai:litellm-operator" cannot list resource
"litellmteams" in API group "litellm.home-operations.com" at the cluster scope
...
"problem running manager","error":"failed to wait for litellmteam caches to sync"
```
`kubectl get clusterrole litellm-operator-manager-role` confirms `litellmteams`/`litellmvirtualkeys` are absent from the rules, while sibling resources (`litellmmodels`, `litellmproxies`, etc.) are present.

## Fix
Standalone additive `ClusterRole`/`ClusterRoleBinding` granting the same verb pattern already used for `litellmmodels` (get/list/watch + CRUD + status). Checked `helm show values` for the chart — no `rbac.rules`/`extraObjects` extension point exists, so this can't be expressed as a HelmRelease values patch; drop this once upstream ships the missing rules.

## Test plan
- [x] `kustomize build kubernetes/apps/ai/litellm/app` clean, ClusterRole/ClusterRoleBinding render without a namespace field
- [ ] After rollout: operator pod stops restarting, `kubectl -n ai logs deploy/litellm-operator` shows no more cache-sync timeout
- [ ] `curl .../model/info` on litellm shows `omniroute`'s live config matching the CR (`model: openai/auto/smart`, `timeout: 90`)