### PR TITLE
fix(ci): set ai_fallback_model to satisfy pr-reviewer-action v2.1.10

### DIFF
--- a/.github/workflows/agent-pr-review.yaml
+++ b/.github/workflows/agent-pr-review.yaml
@@ -33,7 +33,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Run reviewer
-        uses: misospace/pr-reviewer-action@1cb6bed7a29f0d528ff5ba56bcf57092bf096af1 # v2.1.9
+        uses: misospace/pr-reviewer-action@6f4fb724b222f6d9a83096d6b41cd636ef3a044e # v2.1.10
         with:
           github_token: ${{ github.token }}
           ai_base_url: http://litellm.ai.svc.cluster.local/v1
@@ -42,6 +42,14 @@ jobs:
           # (see litellm routerSettings.fallbacks); falls back to qwen-3.6-fast
           # automatically if the free provider fails or times out.
           ai_model: omniroute
+          # v2.1.10 inherits ai_fallback_base_url from ai_base_url when unset, then
+          # requires ai_fallback_model whenever ai_fallback_base_url is set (even
+          # inherited) — fails fast with no model call otherwise. Point this at
+          # qwen-3.6-fast directly (same litellm endpoint) rather than duplicating
+          # ai_model: litellm's routerSettings.fallbacks already retries omniroute
+          # failures internally, so this only fires if that whole chain fails —
+          # a real second attempt via a distinct model, not a no-op retry.
+          ai_fallback_model: qwen-3.6-fast
           # omniroute's proxied models don't share SGLang's sampling_defaults, so
           # an empty temperature has no known-good fallback here — pin explicitly.
           ai_temperature: "0.2"


### PR DESCRIPTION
## Summary
Supersedes/absorbs #4329 (the Renovate bump to v2.1.10) by also fixing the validation break it introduces.

v2.1.10 changelog: "Make fallback base_url/api_format/api_key inherit from primary" — `ai_fallback_base_url` now silently inherits from `ai_base_url` when unset. The same release also validates that `ai_fallback_model` is set whenever `ai_fallback_base_url` is set (even inherited), and fails before making any model call otherwise.

## Fix
- Bump the pinned digest to v2.1.10.
- Set `ai_fallback_model: qwen-3.6-fast` — a real, distinct second attempt via the self-hosted model, not a duplicate of `ai_model`. litellm's own `routerSettings.fallbacks` already retries `omniroute` failures internally with `qwen-3.6-fast`, so this action-level fallback only fires if that whole internal chain fails too.

## Evidence
Run 30878353953 (self-review of the v2.1.10 bump): `ERROR: AI_FALLBACK_MODEL is required when AI_FALLBACK_BASE_URL is set`, `duration_ms=42` — fails before any model call.

## Test plan
- [ ] Next PR review run completes without the `AI_FALLBACK_MODEL is required` error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated pull request review workflow.
  * Configured a fallback model to improve review processing reliability.
  * Updated the review automation action to its latest version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->