### PR TITLE
fix(llmkube): disable llama.cpp prompt cache on the iGPU embedders

### DIFF
--- a/kubernetes/apps/ai/llmkube/models/qwen3-embedding.yaml
+++ b/kubernetes/apps/ai/llmkube/models/qwen3-embedding.yaml
@@ -53,6 +53,10 @@ spec:
   extraArgs:
     - "--alias"
     - "qwen3-embedding" # served model name memini sends in /v1/embeddings
+    # Host prompt cache (default 8192 MiB) is never released: 100 distinct
+    # embedding requests took anon 0.08 -> 8.06 GiB. One-shot embeddings never hit it.
+    - "--cache-ram"
+    - "0"
 
   # Pin to the iGPU node; without this the scheduler could place it on the dGPU
   # node (which also advertises squat.ai/dri) and steal a dGPU slot from sglang.

--- a/kubernetes/apps/ai/llmkube/models/vmcp-embedding.yaml
+++ b/kubernetes/apps/ai/llmkube/models/vmcp-embedding.yaml
@@ -57,6 +57,9 @@ spec:
   extraArgs:
     - "--alias"
     - "vmcp-embedding" # served model name litellm/vmcp-unified send in /v1/embeddings
+    # Same as qwen3-embedding: 8192 MiB host prompt cache, never hit, never released.
+    - "--cache-ram"
+    - "0"
 
   # Defense-in-depth: keeps the iGPU pin even if qwen3-embedding's own pin is
   # ever loosened (the podAffinity below would otherwise follow it anywhere).


### PR DESCRIPTION
llama.cpp's host prompt cache defaults to 8192 MiB and is never released. Both iGPU embedders inherit it, and neither can ever hit it: embeddings are one-shot.

## Evidence

Measured on the live `qwen3-embedding` pod (control-3), image `sha256:a26d0488`, the same digest this PR targets. Values are cgroup `memory.stat` `anon`.

| requests sent | anon |
|---|---|
| fresh pod, model loaded | 0.08 GiB |
| 100 distinct single-input (~200 tok) | 7.95 GiB |
| 200 | 8.06 GiB |
| 300 | 8.06 GiB (saturated) |

- Growth tracks the **number of distinct prompts**, not batch size or token count. A single 4000-token input moves nothing.
- Never released: a tiny follow-up request plus idle leaves it at 8.06 GiB. Only pod deletion resets it.
- Saturation point matches the documented default exactly: `-cram, --cache-ram N ... (default: 8192)` = 8192 MiB.
- It is **host** memory, not GPU. GTT used was 1.34 GiB of a 14.55 GiB aperture while anon was 8.13 GiB. This is why the nightly GTT recycle never relieved control-3.

## Impact

| control-3 | memory |
|---|---|
| embedder idle | 12438 Mi (55%) |
| cache filled | 23722 Mi (106% of allocatable) |

Deleting the pod dropped the node from 88% to 55% immediately. The node's chronic pressure is this one allocation, held ~20h/day until `maxPodLifetimeSeconds` recycles it.

## Not done here

- `resources.memory: 4Gi` and its "~3.1 GiB peak working set" comment are both stale (measured peak 8.22 GiB working set). Re-sizing needs a post-merge measurement, so it is deliberately left alone rather than replaced with another number that goes stale.
- `qwen35-2b` shows the same 7.57 GiB profile, but prompt cache is genuinely useful for a generative model, so it needs a separate size/benefit call.
- No upstream issue filed yet.

## Verification

Rendered with `kustomize build`; both InferenceServices emit `--cache-ram 0`. **Not yet verified live**: patching the running InferenceService required suspending Flux, which was declined. Post-merge check: a fresh embedder pod should stay near 0.1 GiB after 100+ distinct requests instead of climbing to 8 GiB.
