### PR TITLE
fix(memini): raise write-path embed timeout to 15s

### DIFF
--- a/kubernetes/apps/ai/memini/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/memini/app/helmrelease.yaml
@@ -35,6 +35,10 @@ spec:
               MEMINI_EMBED_MAX_BATCH: "8"
               MEMINI_EMBED_MAX_BATCH_CHARS: "12000"
               MEMINI_EMBED_MAX_ITEM_CHARS: "4000"
+              # The 5s default drops writes to vectorless whenever the shared
+              # iGPU embedder is busy; the two from 2026-08-04 20:50 never got
+              # a vector back and are keyword-only.
+              MEMINI_WRITE_EMBED_TIMEOUT: "15s"
             resources:
               requests:
                 cpu: 50m


### PR DESCRIPTION
`MEMINI_WRITE_EMBED_TIMEOUT` is unset, so writes embed with the 5s default against the shared iGPU embedder. On timeout memini stores the memory **vectorless** — keyword-searchable, invisible to vector search — and reports the write as successful.

```
20:50:35 WARN remember: content embed failed, storing without vector
         namespace=tanguille reason=embed_timeout err="embed: context deadline exceeded"
```

Both affected memories are still vectorless 1.5h later. A keyword-loaded query finds them; a paraphrase with no shared words does not, while a semantically similar memory tops the same search:

| query | `f1680ff9` (has vector) | `5503034b` / `46dc5cf8` (vectorless) |
|---|---|---|
| keyword-loaded | 0.833 / 0.696 | returned |
| paraphrase, no shared words | 0.864 | absent |

The documented repair/backfill loop logged nothing in that window, and the startup banner announces dedup and promotion but no repair loop. The binary supports the knob (`strings` confirms `MEMINI_WRITE_EMBED_TIMEOUT`), it was simply never set.

Deployed: memini v0.7.17. `flate test all` and shellcheck pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a 15-second timeout for embedding writes, reducing the chance of data being stored without vector embeddings when the shared embedder is busy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->