### PR TITLE
fix(nextcloud): right-size resources to prevent nginx OOMKill

### DIFF
--- a/kubernetes/apps/default/nextcloud/app/helmrelease.yaml
+++ b/kubernetes/apps/default/nextcloud/app/helmrelease.yaml
@@ -85,10 +85,10 @@ spec:
       resources:
         requests:
           cpu: 50m
-          memory: 64Mi
+          memory: 128Mi
         limits:
           cpu: 200m
-          memory: 128Mi
+          memory: 256Mi
 
     nextcloud:
       datadir: /var/www/data
@@ -169,7 +169,7 @@ spec:
           extension=exif
           extension=intl
           extension=gd
-          memory_limit = 8G
+          memory_limit = 512M
           opcache.memory_consumption = 512
           opcache.max_accelerated_files = 20000
           opcache.revalidate_freq = 60
@@ -457,6 +457,13 @@ spec:
           runAsUser: 33
           runAsGroup: 33
           runAsNonRoot: true
+        resources:
+          requests:
+            cpu: 100m
+            memory: 500Mi
+          limits:
+            cpu: "1"
+            memory: 2Gi
 
     startupProbe:
       enabled: true


### PR DESCRIPTION
Fix Nextcloud nginx sidecar OOMKill by increasing memory limits.

Changes:
- nginx sidecar: 128Mi -> 256Mi limit, 64Mi -> 128Mi request (was OOMKilled with 128Mi limit)
- PHP memory_limit: 8G -> 512M (matches pm.max_children=4 pool, well under 12Gi container limit)
- CronJob: added 100m/500Mi requests, 1cpu/2Gi limits (was BestEffort with no limits)

Verified against live cluster state (pod nextcloud-557c77f968-j5l76).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Nextcloud resource allocation for better reliability.
  * Added resource limits for scheduled background tasks.
  * Adjusted PHP memory usage to a more controlled limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->