### PR TITLE
perf(talos): reclaim reserved memory the scheduler never gets

### DIFF
--- a/talos/patches/global/machine-kubelet.yaml
+++ b/talos/patches/global/machine-kubelet.yaml
@@ -7,7 +7,10 @@ machine:
       enableSystemLogQuery: true
       mergeDefaultEvictionSettings: true
       evictionHard:
-        memory.available: "7%"
+        # Flat, not a percentage: 7% cost 2.04Gi on the 29GB nodes and 4.39Gi on the 64GB one,
+        # so the big node set aside twice the reserve the small ones got. Still 10x the k8s
+        # default of 100Mi, against 8.7-10GB of reclaimable page cache per node.
+        memory.available: 1Gi
       evictionMinimumReclaim:
         memory.available: 1Gi
       # Trigger image GC before Ceph's mon_data_avail_warn default (30% free) fires.
@@ -15,6 +18,9 @@ machine:
       imageGCLowThresholdPercent: 55
       # Reap images unused for 7d regardless of disk pressure.
       imageMaximumGCAge: 168h
+      # Left at 2Gi despite being under-reserved: measured /podruntime is 2.89GB steady-state on
+      # control-2 and peaked at 14.1GB on control-3. Raising it to the truth costs allocatable on
+      # nodes that have none to spare, so the under-reservation is accepted deliberately.
       kubeReserved:
         cpu: 500m
         memory: 2Gi
@@ -22,7 +28,8 @@ machine:
       serializeImagePulls: false
       systemReserved:
         cpu: 500m
-        memory: 1Gi
+        # Measured /system + /init peak is 391MB on control-3, 203MB on control-2.
+        memory: 512Mi
     nodeIP:
       validSubnets:
         - 192.168.0.0/24


### PR DESCRIPTION
Stacked on #4385, which is based on `main`. Both are independent of the #4378/#4379 stack.

The two are separated because this one's headline gain only holds once #4385 removes the hugepages reservation; merge #4385 first.

Talos sets no `systemReserved`/`kubeReserved` by default. Every byte withheld below is this repo's own choice, and `talos/patches/global/` applies it identically to the 64GB node and the two 29GB ones.

## The accounting

Capacity minus these four predicts reported allocatable to within 9 bytes on control-2 and 20 on control-1, so nothing here is unexplained:

| withheld on control-2 | GiB |
|---|---|
| `vm.nr_hugepages: 1184` (removed in #4385) | 2.31 |
| `kubeReserved.memory: 2Gi` | 2.00 |
| `evictionHard: memory.available 7%` | 2.04 |
| `systemReserved.memory: 1Gi` | 1.00 |
| | **7.35** |

## Changes

**`evictionHard: 7%` -> `1Gi`.** A percentage made the 64GB node reserve 4.39Gi against the small nodes' 2.04Gi, so the node with the most headroom set aside the most. Flat is still 10x the k8s default of 100Mi, against 8.7-10GB of reclaimable page cache per node.

**`systemReserved: 1Gi` -> `512Mi`.** Measured `/system` + `/init` peak is 391MB on control-3, 203MB on control-2.

**`kubeReserved` unchanged at 2Gi**, now commented. Measured `/podruntime` is 2.89GB steady-state on control-2 and peaked at 14.1GB on control-3, so it is already under-reserved. Raising it to the truth is honest but costs allocatable on nodes that have none to spare. Cutting it would be actively dangerous. Left alone deliberately.

## Result, combined with the hugepages removal in #4385

| node | alloc now | alloc after | gain | booked now | after |
|---|---|---|---|---|---|
| control-1 | 54335Mi | 60690Mi | +6355Mi | 83% | 74% |
| control-2 | 22271Mi | 26213Mi | +3942Mi | 100% | 85% |
| control-3 | 22271Mi | 26213Mi | +3942Mi | 100% | 85% |

Unblocks `rook-ceph-exporter-control-2` and gives the 2Gi xmrig request from #4385 somewhere to land.

## Applying

Takes effect on next reboot; nothing was applied to the cluster.

`enforceNodeAllocatable` is unset and so defaults to `["pods"]`, meaning system/kubeReserved are pure accounting rather than cgroup limits. Lowering them does not make the daemons OOM directly; it lets the scheduler book memory they will then compete for. That is why kubeReserved is left alone.

`evictionHard` is the one with real risk: it is genuine OOM headroom on swapless nodes. `1Gi` is my judgement (10x the k8s default, roughly half the current 7%), not a measured figure. Roll one node at a time and watch `MemAvailable` and NPD before doing the next.

## Verification

`talhelper genconfig` renders all three nodes; rendered `machine.kubelet.extraConfig` confirmed to carry `evictionHard: 1Gi`, `systemReserved: 512Mi`, `kubeReserved: 2Gi`, and `vm.nr_hugepages` confirmed absent.

## Not done

The `nvme1` Micron 7450 480GB still runs ~10C hotter than the 980 PRO beside it and sets the thermal gate on both nodes. Cooling it is worth more mining hours than any config change in this stack.
