### PR TITLE
fix(monero-dashboard): repair the true-luck window label

### DIFF
--- a/kubernetes/apps/web3/monero/dashboard/resources/dashboard.js
+++ b/kubernetes/apps/web3/monero/dashboard/resources/dashboard.js
@@ -897,7 +897,7 @@ function updateTrueLuck(
         ? `${Math.round(timeWindow / 60)}m window`
         : displayHours < 24
           ? `${displayHours.toFixed(1)}h window`
-          : `${displayDays.toFixed(1)}d window`;
+          : `${cappedWindowDays.toFixed(1)}d window`;
     setTextContent("trueLuckWindow", windowText);
 
     setTooltipContent(


### PR DESCRIPTION
One-line fix on `main`. `displayDays` is not defined.

`dashboard.js:900`

```js
const cappedWindowDays = Math.min(timeWindowDays, MAX_WINDOW_DAYS);
const displayHours = cappedWindowDays * 24;
...
  : `${displayDays.toFixed(1)}d window`;   // <- undefined
```

#4378's simplify pass renamed `displayDays` to `cappedWindowDays` and updated two of the three references. Main before that pass was correct:

```js
const displayDays = Math.min(timeWindowDays, MAX_WINDOW_DAYS);
const displayHours = displayDays * 24;
```

## Why it matters

That branch is the `else` of `displayHours < 24`, so it fires whenever the mining window is at least a day, which is the normal case. The `ReferenceError` is caught by the enclosing `try`, which calls `reset()` and blanks the whole card:

```js
} catch (error) {
  console.error("Error updating Estimated True Luck card:", error);
  reset();
}
```

So "Estimated True Luck" shows `–` for both the factor and the window, with nothing visible except a console error. The luck factor is computed and set correctly one line earlier, then thrown away.

## Verification

`node --check` passes. Scope-checked every identifier in `updateWindowLuck` against its params, locals, and module-level declarations after stripping comments and string literals: `displayDays` was the only undefined one, and no other reference to it or to the other locals the rename removed survives anywhere in the file.