### PR TITLE
fix(alerts): clear four standing false-positive and blocked alerts

### DIFF
--- a/kubernetes/apps/ai/hermes/app/prometheusrule.yaml
+++ b/kubernetes/apps/ai/hermes/app/prometheusrule.yaml
@@ -16,9 +16,12 @@ spec:
       rules:
         # The scheduler already records per-job status in cron/jobs.json; nothing read
         # it, so a dead cron stayed dark 40h.
+        # A paused job's last status is frozen history, not a live failure: it will never
+        # re-run, so the alert would never clear (kanban-actualizer, paused 2026-08-05).
         - alert: HermesCronJobFailed
           expr: |-
             last_over_time(hermes_cron_last_status_ok[30m]) == 0
+              unless on (id) last_over_time(hermes_cron_paused[30m]) == 1
           for: 15m
           annotations:
             summary: >-
@@ -32,6 +35,7 @@ spec:
         - alert: HermesCronDeliveryFailed
           expr: |-
             last_over_time(hermes_cron_delivery_failed[30m]) == 1
+              unless on (id) last_over_time(hermes_cron_paused[30m]) == 1
           for: 15m
           annotations:
             summary: >-

--- a/kubernetes/apps/ai/llmkube/models/qwen36-27b-sglang.yaml
+++ b/kubernetes/apps/ai/llmkube/models/qwen36-27b-sglang.yaml
@@ -229,8 +229,10 @@ spec:
       value: 192Gi
     # MAX_SIZE is blind to the other tenants of control-1's shared root, so hold a floor
     # above kubelet's nodefs eviction threshold: refuse writes rather than fill the disk.
+    # 160Gi, not 100Gi: rook-ceph's mon-c store shares this 500G filesystem and MON_DISK_LOW
+    # fires below 30% avail (150Gi), which a 100Gi floor guarantees (2026-08-06).
     - name: SGLANG_HICACHE_FILE_BACKEND_MIN_FREE_SPACE
-      value: 100Gi
+      value: 160Gi
     # Not the eviction trigger despite the log's wording: eviction fires at MAX_SIZE and
     # this is the low-water mark it drains to. Higher = warmer cache, more frequent passes.
     - name: SGLANG_HICACHE_FILE_BACKEND_EVICTION_RATIO

--- a/kubernetes/apps/network/external-dns/app/prometheusrule.yaml
+++ b/kubernetes/apps/network/external-dns/app/prometheusrule.yaml
@@ -10,7 +10,8 @@ spec:
       rules:
         - alert: ExternalDNSStale
           expr: |-
-            time() - external_dns_controller_last_sync_timestamp_seconds > 60
+            # 300s, not 60s: the sync interval is itself 1m, so a 60s threshold trips every cycle.
+            time() - external_dns_controller_last_sync_timestamp_seconds > 300
           for: 5m
           annotations:
             summary: >-

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -58,6 +58,11 @@ spec:
           mon_cluster_log_level: info
       cleanupPolicy:
         wipeDevicesFromOtherClusters: true
+      # Off: the sidecar duplicates to host disk what daemons already write to stdout and
+      # victoria-logs already collects. It also costs a 100Mi request on every ceph daemon
+      # pod, which is what left rook-ceph-exporter-control-2 unschedulable (2026-08-06).
+      logCollector:
+        enabled: false
       csi:
         readAffinity:
           enabled: true


### PR DESCRIPTION
Four alerts firing continuously; each traced to a root cause, not silenced.

| Alert | Root cause | Fix |
|---|---|---|
| `HermesCronJobFailed` | `kanban-actualizer` is paused (superseded by `homelab-infra-kanban-daily`). A paused job's last status is frozen at `error`, so the rule can never clear. | `unless on(id) hermes_cron_paused == 1` on the failed + delivery rules |
| `ExternalDNSStale` | threshold 60s equals external-dns's own 1m sync interval, so it trips every cycle | 300s, matching the annotation's "five minutes" |
| `CephMonDiskspaceLow` | mon-c shares control-1's 500G root with SGLang HiCache, whose `MIN_FREE_SPACE` floor of 100Gi sits below ceph's 30%-avail warn (150Gi) | floor 100Gi -> 160Gi |
| `KubePodNotReady` + `KubeDeploymentReplicasMismatch` | control-2 at 99% memory requests; `rook-ceph-exporter-control-2` (150Mi) unschedulable 2d5h | `logCollector.enabled: false` frees 100Mi x 4 ceph daemon pods on control-2 |

Evidence:

- control-2 allocatable 21.75Gi, allocated 22784036Ki (99%), ~21Mi free; exporter needs 150Mi. Log-collector sidecars on control-2: `rook-ceph-{mds-ceph-filesystem-a,mgr-a,mon-b,osd-0}` = 400Mi reclaimed. Daemons log to stdout regardless; victoria-logs already collects them.
- `ceph health detail`: `mon.c has 26% avail`; mon-c runs on control-1, whose nodefs is 362.5G/499.6G used. `machine-kubelet.yaml` already sets `imageGCHighThresholdPercent: 70` for this threshold, but HiCache is not images.
- Hermes rule verified against VM: new expression returns `"result":[]` where the old one returns the paused job.

Not included, deliberately:

- `CephPoolGrowthWarning` is a false positive from the mgr failover 23h ago: the new instance's `ceph_pool_percent_used` steps 0 -> 30.4%, which `predict_linear[2d]` reads as 140%. The standby's series gives 0.31 and real 2d growth is 0.3 points. Ages out of the window on its own.
- `BLUESTORE_SLOW_OP` on osd.3, the other half of `CephHealthWarning`: known control-3 NVMe thermal, not a config fix.
- `KubeMemoryOvercommit`, `CPUThrottlingHigh`, `InfoInhibitor`: capacity reality on 3 nodes and info-level noise.

Separately, `qbitrr`'s Kustomization was failing because its Deployment had been deleted out-of-band while the HelmRelease still read `Ready`. Fixed live with a forced HR reconcile; no manifest change needed.

Rollout note: `logCollector` is a CephCluster spec change, so every ceph daemon pod restarts on merge.