### PR TITLE
fix(renovate): bump renovate-presets to v7, opt into app presets

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -2,7 +2,18 @@
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   extends: [
     "abandonments:recommended",
-    "github>home-operations/renovate-presets#5.0.0",
+    // v6 flattened every config/managers/overrides/policies file into default.json and moved
+    // app-specific presets to apps/, opt-in only — the old config/baseConfig.json5 etc. paths
+    // this repo's default.json used to extend no longer exist past 5.0.0, which is why pinning
+    // "github>home-operations/renovate-presets#5.0.0" started failing to resolve: nested extends
+    // in their default.json carry no ref of their own, so Renovate re-resolves them against the
+    // default branch (now v7's flat layout) instead of inheriting the #5.0.0 pin.
+    "github>home-operations/renovate-presets#7.0.0",
+    "github>home-operations/renovate-presets//apps/cnpg.json5#7.0.0",
+    "github>home-operations/renovate-presets//apps/grafanaDashboards.json5#7.0.0",
+    "github>home-operations/renovate-presets//apps/llamacpp.json5#7.0.0",
+    "github>home-operations/renovate-presets//apps/searxng.json5#7.0.0",
+    "github>home-operations/renovate-presets//apps/talosFactory.json5#7.0.0",
     ":timezone(Europe/Brussels)"
   ],
   ignorePaths: ["**/*.sops.*", "**/resources/**"],


### PR DESCRIPTION
## Summary
- Renovate stopped opening PRs (#4395: "Cannot find preset's package (github>home-operations/renovate-presets//config/baseConfig.json5)")
- `home-operations/renovate-presets` v6/v7 flattened `config/`, `managers/`, `overrides/`, `policies/` into a single `default.json`, and moved app-specific presets under `apps/` as opt-in
- Nested extends inside their `default.json` carry no `#ref` of their own, so pinning our top-level extend to `#5.0.0` still resolved those nested paths against the *default branch* (now v7's flat layout, missing `config/baseConfig.json5`) instead of inheriting our pin

## Changes
- Bump `github>home-operations/renovate-presets#5.0.0` → `#7.0.0`
- Explicitly opt into the app presets this repo actually uses (previously pulled in automatically by the old `default.json`): `apps/cnpg.json5`, `apps/grafanaDashboards.json5` (needed for the `grafanaCom: {id, revision}` dashboards in cert-manager/nextcloud/rook-ceph/etc.), `apps/llamacpp.json5`, `apps/searxng.json5`, `apps/talosFactory.json5`

## Test plan
- [x] Verified `apps/*.json5` presets exist at tag `7.0.0` and are self-contained (no further nested cross-repo extends)
- [x] Verified all 5 opted-in app presets are actually used in-repo (grep for cnpg/grafanaCom/llama.cpp/searxng/talos)
- [ ] Confirm issue #4395 auto-closes and the dependency dashboard resumes opening PRs after merge