### PR TITLE
fix(crowdsec): correct static resource classification for jellyfin

### DIFF
--- a/kubernetes/apps/security/crowdsec/app/helmrelease.yaml
+++ b/kubernetes/apps/security/crowdsec/app/helmrelease.yaml
@@ -65,14 +65,22 @@ spec:
               reason: "envoy bouncer response to already banned ips"
               expression:
                 - "evt.Meta.http_status == '418'"
-          jellyfin-crawl-whitelist.yaml: |-
-            name: hydaz/jellyfin-crawl-whitelist
-            description: "Jellyfin clients fan out to dozens of unique /HomeScreen/CachedImage URIs per page load, which reads as http-crawl-non_statics"
-            filter: "evt.Meta.service == 'http' && evt.Meta.log_type == 'http_access-log' && evt.Meta.target_fqdn == 'jellyfin.${SECRET_DOMAIN}'"
+          pseudo-ipv4-whitelist.yaml: |-
+            name: hydaz/pseudo-ipv4-whitelist
+            description: "Cloudflare Pseudo IPv4 rewrites IPv6 clients to class E; a ban on one synthetic address blocks every IPv6 client sharing it"
+            filter: "evt.Meta.service == 'http' && evt.Meta.log_type == 'http_access-log'"
             whitelist:
-              reason: "successful jellyfin api traffic"
-              expression:
-                - "evt.Meta.http_status startsWith '2' or evt.Meta.http_status startsWith '3'"
+              reason: "synthetic address, not a real client"
+              cidr:
+                - "240.0.0.0/4"
+          # s02-enrich runs in filename order; this must sort after http-logs.yaml
+          static-image-endpoints.yaml: |-
+            name: hydaz/static-image-endpoints
+            description: "crowdsecurity/http-logs infers static_ressource from the file extension, so extensionless image endpoints read as crawlable content"
+            filter: "evt.Meta.target_fqdn == 'jellyfin.${SECRET_DOMAIN}' && evt.Meta.http_verb in ['GET', 'HEAD'] && evt.Meta.http_path matches '(?i)^/(homescreen/cachedimage|items/[^/]+/images/)'"
+            statics:
+              - parsed: static_ressource
+                value: "true"
       config.yaml.local: |-
         api:
           server:


### PR DESCRIPTION
## Problem

Every CrowdSec alert of the last 30 days:

| Alert | When | ASN | Events | Statuses | Host |
|---|---|---|---|---|---|
| 6571 | 08-02 22:25 | Telenet BE | 50 | all 200 | jellyfin |
| 6572 | 08-02 22:29 | Proximus BE | 41 | all 200 | jellyfin |
| 6692 | 08-04 22:44 | Localitel BE | 49 | all 200 | jellyfin |
| 6693 | 08-04 22:47 | Proximus BE | 41 | all 200 | jellyfin |
| 6718 | 08-06 21:27 | Eurofiber NL | 49 | all 200 | jellyfin |
| 6728 | 08-07 23:00 | Proximus BE | 47 | all 200 | jellyfin |

Six for six false positives, all `crowdsecurity/http-crawl-non_statics`, all consumer ISPs, all 21:25-23:00. Zero real attackers caught by local scenarios in 30 days.

## Root cause

`crowdsecurity/http-logs` decides staticness by file extension only:

```
static_ressource = Upper(file_ext) in ['.JPG','.PNG','.WEBP',...] ? 'true' : 'false'
```

Jellyfin serves images from extensionless paths, so each thumbnail is a distinct non-static `file_name`. With `capacity: 40, leakspeed: 0.5s, distinct: file_name`, one home screen load overflows the bucket.

## Fix

Correct the classification at parse time. `static_ressource` has exactly two consumers on this cluster, `http-crawl-non_statics` and `http-probing`, and both gate on it identically, so one node closes both.

**Coverage, measured against the 36 event paths crowdsec sampled across the six alerts:** 22 match. The 14 that do not are all `/HomeScreen/Section/*` JSON responses, which are not static resources and are correctly left pouring. That is still sufficient, because `distinct` is on `file_name`: section names are a bounded set of roughly 15, image hashes are unbounded, so images supplied at least 26 of the 41-50 distinct names. What remains sits well under capacity 40.

**Trade-off:** the removed whitelist only fired on 2xx/3xx, so `http-probing` still saw jellyfin 4xx on image paths. Setting `static_ressource` unconditionally exempts those paths from probing at any status. That is the same property that stops missing-artwork 404s from banning on a library scroll, but it is a real reduction in coverage and needs GUID enumeration under a jellyfin-shaped route to exploit.

Also removes the blanket 2xx whitelist shipped 08-07, which dropped events from every scenario on that host.

## Secondary change

`240.0.0.0/4` whitelist. Cloudflare Pseudo IPv4 collapses IPv6 clients onto synthetic class E addresses, so one ban blocks every IPv6 client sharing it. Recovers a fix written on 08-01 that never merged. Zero hits currently, and that is fine: it is a blast-radius guard, not a detection rule.

## Considered and rejected

- **Postoverflow whitelist scoped to the scenario.** Closes one of two consumers of the bad field, couples to a hub scenario name that fails silently if renamed, and evaluates `all()` over a 5-event sample rather than the 41 events that filled the bucket.
- **Escalating `duration_expr`.** `GetDecisionsSinceCount` counts per IP, so a rotating-IP scanner always scores zero and would have had its first-contact ban cut from 24h to 4h. `profiles.yaml` is unchanged.
- **Acquisition split** to exclude `envoy-gateway-*` control-plane logs. Was in an earlier revision of this PR and has been reverted. The measurement behind it was wrong: it is 91k of 120k lines on the *one* agent that happens to co-host both gateway replicas (control-3), and 0 on the other two, not "72k per agent". The real gain is ~1 line/sec of failed regex against agents running 4-7m CPU, and the cost is a name-shape allowlist under which any future gateway is silently unmonitored.
- **`crowdsecurity/jellyfin-whitelist` from the hub.** Runs fine on Envoy-only acquisition, but both expressions gate on 403/404 and cannot match a 2xx-driven crawl overflow. Complementary; one token to add if those FP classes appear.
- **Envoy `%RESP(CONTENT-TYPE)%` in the access log**, which would retire the per-app URL list entirely. Roughly 34 lines in `envoy.yaml`, non-breaking (our parser reads named JSON keys), but it forks EnvoyGateway's default log format cluster-wide. Not warranted for one app. Revisit at app #2, or the first time this regex needs extending.

## Validation

`kustomize build` and `helm template` against chart 0.20.1 both clean. Parser mounts at `/etc/crowdsec/parsers/s02-enrich/static-image-endpoints.yaml`, which sorts after `http-logs.yaml` so it observes the field that node sets, confirmed against a live agent's directory listing.

Not verifiable pre-merge: that the parser actually reclassifies in the running pipeline. Current logs cannot exercise it either, since container rotation leaves only today's daytime traffic and the FPs are an evening mobile-client pattern. Confirm post-deploy with `cscli explain` and by watching `http-crawl-non_statics` pours in `cscli metrics show scenarios`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Jellyfin traffic handling by recognizing extensionless image endpoints as static resources.
  * Updated address filtering to prevent Cloudflare synthetic addresses from being incorrectly flagged or banned.
  * Reduced the likelihood of false positives affecting Jellyfin access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->