### PR TITLE
chore(coderabbit): skip auto-review on routine Renovate bumps

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,11 @@
+---
+# yaml-language-server: $schema=https://storage.googleapis.com/coderabbit_public_assets/schema.v2.json
+reviews:
+  auto_review:
+    # Renovate applies exactly one of these per PR (.renovaterc.json5 addLabels).
+    # type/major still auto-reviews; skipping minor/patch/digest keeps CodeRabbit's
+    # quota for PRs that actually need judgment instead of routine bumps.
+    labels:
+      - "!type/patch"
+      - "!type/minor"
+      - "!type/digest"

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -3,9 +3,9 @@
 reviews:
   auto_review:
     # Renovate applies exactly one of these per PR (.renovaterc.json5 addLabels).
-    # type/major still auto-reviews; skipping minor/patch/digest keeps CodeRabbit's
-    # quota for PRs that actually need judgment instead of routine bumps.
+    # type/major and type/minor still auto-review; skipping patch/digest keeps
+    # CodeRabbit's quota for PRs that actually need judgment. Add type/minor here
+    # too if patch/digest alone doesn't clear the quota pressure.
     labels:
       - "!type/patch"
-      - "!type/minor"
       - "!type/digest"


### PR DESCRIPTION
## Summary
- Adds `.coderabbit.yaml` excluding `type/patch`/`type/digest`-labeled PRs from CodeRabbit's auto-review (labels applied by `.renovaterc.json5`).
- `type/major` and `type/minor` Renovate PRs still auto-review, as do all manually-authored PRs — minor bumps can carry real risk worth a look.
- Fixes CodeRabbit's Pro Plus review quota getting exhausted by routine Renovate bumps, which rate-limited review on real PRs (observed on #4419).
- Starting narrow (patch + digest only); widen to `type/minor` too if this alone doesn't relieve the quota pressure.

## Caveat
This is label-based, not author-based — if a human pushes to a Renovate PR's branch, the Renovate-applied label stays and the PR keeps being skipped. Force a review on it with a `@coderabbitai review` comment; there's no CodeRabbit setting to auto-detect a takeover.

## Test plan
- [ ] Confirm a `type/patch`/`type/digest` Renovate PR opened after merge shows CodeRabbit skipped
- [ ] Confirm a `type/minor` or `type/major` Renovate PR still gets reviewed