### PR TITLE
chore(cnpg): drop the postgres-mcp ensure:absent stub

### DIFF
--- a/kubernetes/apps/database/cloudnative-pg/cluster/cluster.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/cluster.yaml
@@ -72,8 +72,6 @@ spec:
         login: true
         passwordSecret:
           name: crowdsec-db
-      - name: postgres-mcp
-        ensure: absent
       - name: ghostfolio
         login: true
         passwordSecret:


### PR DESCRIPTION
## Summary
Follow-up to #4423. The `ensure: absent` role reconciled — confirmed live (`pg_roles` query empty, role gone from postgres16). The transitional stub can now go; this is the last reference to `postgres-mcp` anywhere in the repo.

## Test plan
- [x] Confirmed live before this PR: role absent from `pg_roles`
- [x] `grep -rl postgres-mcp` across the whole repo returns nothing outside `.git`