### PR TITLE
fix(ghostfolio): switch mcp server to stdio transport

### DIFF
--- a/kubernetes/apps/ai/toolhive/config/ghostfolio.yaml
+++ b/kubernetes/apps/ai/toolhive/config/ghostfolio.yaml
@@ -5,8 +5,11 @@ metadata:
   name: ghostfolio
 spec:
   image: ghcr.io/mhajder/ghostfolio-mcp:1.5.0@sha256:4436268d0a1604e5bc1c9080f0005e7b5e0b80163803f95519b7a4537cd6660c
-  transport: streamable-http
-  mcpPort: 8000
+  # ghostfolio-mcp's own transport selection only recognizes "http"/"sse" as literal
+  # values (src/ghostfolio_mcp/server.py); toolhive injects spec.transport verbatim as
+  # MCP_TRANSPORT, so "streamable-http" silently falls through to its stdio default
+  # while the proxy still expects a network listener on mcpPort — crash loop.
+  transport: stdio
   proxyPort: 8080
   groupRef:
     name: all


### PR DESCRIPTION
## Summary
- The `ghostfolio` MCPServer was crash-looping in the cluster after #4419 merged: `ghostfolio-mcp` only recognizes `MCP_TRANSPORT` literal `http`/`sse` for network transports ([src/ghostfolio_mcp/server.py](https://github.com/mhajder/ghostfolio-mcp/blob/main/src/ghostfolio_mcp/server.py)); toolhive injects `spec.transport` verbatim as that env var, so `streamable-http` silently fell through to the app's stdio default while toolhive's proxy still expected a network listener on `mcpPort` — mismatch, crash loop.
- Switched to `transport: stdio`, matching the app's actual behavior and the working `karakeep`/`grafana` MCPServer pattern already in this cluster.

## Verification
Observed in-cluster before the fix: pod `ghostfolio-0` restarted repeatedly, logs showed `Using STDIO transport` on every start despite `streamable-http` configured, `MCPServer` stuck in `Pending`/`NotReady`.

## Test plan
- [ ] Confirm `ghostfolio` MCPServer reaches `Ready`/`Running` after this merges
- [ ] Confirm no pod restarts after the fix lands