### PR TITLE
feat(llmkube): cut over from qwen36-27b-vllm to muse-glimmer-30b

### DIFF
--- a/kubernetes/apps/ai/litellm/instance/models.yaml
+++ b/kubernetes/apps/ai/litellm/instance/models.yaml
@@ -8,8 +8,8 @@ spec:
   modelName: qwen-3.6
   proxyRef: litellm
   params:
-    model: openai/qwen-3.6
-    apiBase: http://qwen36-27b-vllm.ai.svc.cluster.local:8000/v1
+    model: openai/muse-glimmer-30b
+    apiBase: http://muse-glimmer-30b.ai.svc.cluster.local:8080/v1
     # Native vLLM/SGLang are unauthenticated internally, but LiteLLM's OpenAI provider
     # requires a non-empty api_key.
     apiKey: sk-sglang-noauth
@@ -19,8 +19,8 @@ spec:
       num_retries: 0
   info:
     mode: chat
-    # vLLM's 112000 ctx minus maxOutputTokens; SGLang served 171808, so 104K-172K prompts 400.
-    maxInputTokens: 103808
+    # llama.cpp's 262144 per-slot limit minus maxOutputTokens.
+    maxInputTokens: 253952
     maxOutputTokens: 8192
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/litellm.home-operations.com/litellmmodel_v1alpha1.json
@@ -32,8 +32,8 @@ spec:
   modelName: qwen-3.6-fast
   proxyRef: litellm
   params:
-    model: openai/qwen-3.6
-    apiBase: http://qwen36-27b-vllm.ai.svc.cluster.local:8000/v1
+    model: openai/muse-glimmer-30b
+    apiBase: http://muse-glimmer-30b.ai.svc.cluster.local:8080/v1
     apiKey: sk-sglang-noauth
     additional:
       # Hermes compression is a ~100K+ prefill on this alias; under GPU contention
@@ -41,17 +41,13 @@ spec:
       timeout: 900
       stream_timeout: 900
       num_retries: 0
-      # Vendor non-thinking sampling (Qwen3.6 model card) — generation_config ships thinking-mode
-      # values (1.0/0.95/presence 0). Defaults only: client-set params win (v1.91.0 router merge).
-      temperature: 0.7
-      top_p: 0.8
-      presence_penalty: 1.5
-      extra_body:
-        chat_template_kwargs:
-          enable_thinking: false
+      # Meta's defaults. enable_thinking dropped: that kwarg is Qwen's, and this model
+      # gates reasoning by effort level instead.
+      temperature: 1.0
+      top_p: 0.95
   info:
     mode: chat
-    maxInputTokens: 103808
+    maxInputTokens: 253952
     maxOutputTokens: 8192
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/litellm.home-operations.com/litellmmodel_v1alpha1.json

--- a/kubernetes/apps/ai/llmkube/ks.yaml
+++ b/kubernetes/apps/ai/llmkube/ks.yaml
@@ -34,19 +34,19 @@ spec:
     - name: llmkube
     - name: generic-device-plugin
       namespace: kube-system
-  # Deliberately gate only qwen36-27b: litellm and memini dependsOn this ks, and
-  # a wedged embedder (known vmcp-embedding affinity deadlock) must not block
-  # their reconciliation.
+  # Deliberately gate only the serving generation model: litellm and memini dependsOn
+  # this ks, and a wedged embedder (known vmcp-embedding affinity deadlock) must not
+  # block their reconciliation.
   healthChecks:
     - apiVersion: inference.llmkube.dev/v1alpha1
       kind: InferenceService
-      name: qwen36-27b
+      name: muse-glimmer-30b
       namespace: ai
   healthCheckExprs:
     - apiVersion: inference.llmkube.dev/v1alpha1
       kind: InferenceService
       failed: has(status.phase) && status.phase == 'Failed'
-      # Stopped only ever means spec.replicas=0, i.e. qwen36-27b was parked on purpose;
+      # Stopped only ever means spec.replicas=0, i.e. the model was parked on purpose;
       # a model that breaks lands in Failed above. The CRD tells readiness pollers to
       # treat Stopped as Pending, but this gate asks "has the Kustomization converged",
       # and a parked service has. Excluding it would hang llmkube-models forever, and

--- a/kubernetes/apps/ai/llmkube/ks.yaml
+++ b/kubernetes/apps/ai/llmkube/ks.yaml
@@ -34,24 +34,8 @@ spec:
     - name: llmkube
     - name: generic-device-plugin
       namespace: kube-system
-  # Deliberately gate only the serving generation model: litellm and memini dependsOn
-  # this ks, and a wedged embedder (known vmcp-embedding affinity deadlock) must not
-  # block their reconciliation.
-  healthChecks:
-    - apiVersion: inference.llmkube.dev/v1alpha1
-      kind: InferenceService
-      name: muse-glimmer-30b
-      namespace: ai
-  healthCheckExprs:
-    - apiVersion: inference.llmkube.dev/v1alpha1
-      kind: InferenceService
-      failed: has(status.phase) && status.phase == 'Failed'
-      # Stopped only ever means spec.replicas=0, i.e. the model was parked on purpose;
-      # a model that breaks lands in Failed above. The CRD tells readiness pollers to
-      # treat Stopped as Pending, but this gate asks "has the Kustomization converged",
-      # and a parked service has. Excluding it would hang llmkube-models forever, and
-      # litellm and memini behind it.
-      current: has(status.phase) && (status.phase == 'Stopped' || (status.phase == 'Ready' && has(status.conditions) && status.conditions.exists(e, e.type == 'Available' && e.status == 'True')))
+  # No healthChecks: litellm and memini dependsOn this ks, and a model that is slow to
+  # boot or wedged must not block their reconciliation.
   path: ./kubernetes/apps/ai/llmkube/models
   prune: true
   sourceRef:

--- a/kubernetes/apps/ai/llmkube/models/kustomization.yaml
+++ b/kubernetes/apps/ai/llmkube/models/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
   - qwen35-2b.yaml
   - vmcp-embedding.yaml
   - qwen36-27b-vllm.yaml
+  - muse-glimmer-30b.yaml

--- a/kubernetes/apps/ai/llmkube/models/muse-glimmer-30b.yaml
+++ b/kubernetes/apps/ai/llmkube/models/muse-glimmer-30b.yaml
@@ -31,8 +31,8 @@ metadata:
   name: muse-glimmer-30b
 spec:
   modelRef: muse-glimmer-30b
-  # Evaluation only: arch landed 2026-08-10 (#26841); scale up only with qwen36-27b-vllm at 0.
-  replicas: 0
+  # Owns the R9700 for the evaluation window; qwen36-27b-vllm drops to 0 in the same commit.
+  replicas: 1
   # Needs >= b10361 for muse_glimmer.
   image: ghcr.io/ggml-org/llama.cpp:server-rocm-b10362@sha256:2a078f50e40253167620f4b7002253db2254368e335149aa58e51a3cf2c09313
   # Operator default binds :: (IPv6-only on this IPv4 cluster); override to v4.

--- a/kubernetes/apps/ai/llmkube/models/muse-glimmer-30b.yaml
+++ b/kubernetes/apps/ai/llmkube/models/muse-glimmer-30b.yaml
@@ -60,7 +60,7 @@ spec:
     # speculativeDecoding can't express this: no CRD field names the drafter weights.
     - "--spec-type"
     - "draft-dflash"
-    # Path is sha256(Model.spec.source)[:16]; a Renovate sha bump changes it.
+    # Path is sha256(Model.spec.source)[:16]; recompute it if the source sha changes.
     - "--spec-draft-model"
     - "/models/28e769b306130581/dflash-kquant.gguf"
     # AMD's own published config for this drafter on this GPU.

--- a/kubernetes/apps/ai/llmkube/models/muse-glimmer-30b.yaml
+++ b/kubernetes/apps/ai/llmkube/models/muse-glimmer-30b.yaml
@@ -1,0 +1,102 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/inference.llmkube.dev/model_v1alpha1.json
+apiVersion: inference.llmkube.dev/v1alpha1
+kind: Model
+metadata:
+  name: muse-glimmer-30b
+spec:
+  # unsloth, not meta-models: the official GGUF crashes the DFlash drafter (llama.cpp #26894).
+  source: hf://unsloth/Muse-Glimmer-30B-GGUF@faa5b025c584459c13febfa5c59883516710ae39
+  quantization: Q4_K_XL
+  refreshPolicy: OnChange
+  # First entry is primary; mmproj omitted, it costs ~1000 tok/s of prefill (#26873).
+  files:
+    - Muse-Glimmer-30B-UD-Q4_K_XL.gguf
+    - dflash-kquant.gguf
+  hardware:
+    accelerator: rocm
+    memoryBudget: 30Gi
+    gpu:
+      enabled: true
+      count: 1
+      vendor: amd
+      runtime: rocm
+      layers: -1
+      resourceName: squat.ai/dri
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/inference.llmkube.dev/inferenceservice_v1alpha1.json
+apiVersion: inference.llmkube.dev/v1alpha1
+kind: InferenceService
+metadata:
+  name: muse-glimmer-30b
+spec:
+  modelRef: muse-glimmer-30b
+  # Evaluation only: arch landed 2026-08-10 (#26841); scale up only with qwen36-27b-vllm at 0.
+  replicas: 0
+  # Needs >= b10361 for muse_glimmer.
+  image: ghcr.io/ggml-org/llama.cpp:server-rocm-b10362@sha256:2a078f50e40253167620f4b7002253db2254368e335149aa58e51a3cf2c09313
+  # Operator default binds :: (IPv6-only on this IPv4 cluster); override to v4.
+  bindAddress: 0.0.0.0
+  # Under --kv-unified this is the pool AND each slot's limit: ~1.9 GiB KV at q8_0.
+  contextSize: 262144
+  parallelSlots: 4
+  flashAttention: true
+  # 13 KiB/token vs Qwen3.6's 64: KV is cheap enough to stop trading quality for bytes.
+  cacheTypeK: q8_0
+  cacheTypeV: q8_0
+  jinja: true
+  extraArgs:
+    - "--alias"
+    - "muse-glimmer-30b"
+    # Defaults to false once -np is set explicitly, which would hard-partition the pool.
+    - "--kv-unified"
+    # Meta's defaults; litellm's auto-registered alias carries no sampling params.
+    - "--temp"
+    - "1.0"
+    - "--top-p"
+    - "0.95"
+    - "--top-k"
+    - "64"
+    # speculativeDecoding can't express this: no CRD field names the drafter weights.
+    - "--spec-type"
+    - "draft-dflash"
+    # Path is sha256(Model.spec.source)[:16]; a Renovate sha bump changes it.
+    - "--spec-draft-model"
+    - "/models/28e769b306130581/dflash-kquant.gguf"
+    # AMD's own published config for this drafter on this GPU.
+    - "--spec-draft-n-max"
+    - "2"
+  env:
+    # HIP graph cache is unbounded and never evicted with parallel slots (llama.cpp #25082).
+    - name: GGML_CUDA_DISABLE_GRAPHS
+      value: "1"
+  nodeSelector:
+    amd.com/gpu: "true"
+  podSecurityContext:
+    runAsUser: 0
+    runAsGroup: 0
+    supplementalGroups: [44, 226]
+    seccompProfile:
+      type: Unconfined
+  probeOverrides:
+    startup:
+      httpGet:
+        path: /health
+        port: 8080
+      initialDelaySeconds: 60
+      periodSeconds: 15
+      failureThreshold: 240
+    # Inert by design: long model loads and transient GPU work must not restart the pod.
+    liveness:
+      exec:
+        command: ["true"]
+      periodSeconds: 3600
+    readiness:
+      tcpSocket:
+        port: 8080
+      periodSeconds: 30
+      timeoutSeconds: 5
+      failureThreshold: 6
+  resources:
+    cpu: "2"
+    memory: 8Gi

--- a/kubernetes/apps/ai/llmkube/models/qwen36-27b-vllm.yaml
+++ b/kubernetes/apps/ai/llmkube/models/qwen36-27b-vllm.yaml
@@ -158,8 +158,8 @@ spec:
   # v0.26.0 measured identical to the nightly on KV pool and throughput (2026-07-25).
   # The nightly self-reports a stale 0.23.1rc1 base tag; tags are not version-ordered.
   image: vllm/vllm-openai-rocm:v0.27.1@sha256:bb44b39aea26798cce43030a98bf48efd0322ca7147367db86e38b96bd80f0e7
-  # Validation window: SGLang is at replicas 0 so this owns the GPU. Revert both together.
-  replicas: 1
+  # Parked for the muse-glimmer-30b evaluation window; measured table in the PR that parked it.
+  replicas: 0
   # Above 16 the 125,041-token pool oversubscribes: TG 48 -> 35, TTFT 11s -> 85s.
   parallelSlots: 16
   vllmConfig:


### PR DESCRIPTION
Cuts the R9700 over from `qwen36-27b-vllm` to Muse-Glimmer-30B on llama.cpp/ROCm, and moves both litellm aliases and the Flux health gate with it.

## Switchover

| | before | after |
|---|---|---|
| qwen36-27b-vllm | 1 | **0** |
| muse-glimmer-30b | - | **1** |
| qwen-3.6 / qwen-3.6-fast apiBase | qwen36-27b-vllm:8000 | muse-glimmer-30b:8080 |
| maxInputTokens | 103808 | **253952** |
| llmkube-models health gate | qwen36-27b (parked, vacuous) | **removed** |

Only those two aliases referenced the vLLM service; karakeep, omniroute and Hermes reach the model through them, so they follow transitively. No app needs an explicit model change.

The health gate was pointing at the SGLang InferenceService, which has been at `replicas: 0` since the vLLM cutover - its `Stopped` phase counts as converged, so it passed unconditionally and gated nothing for the whole vLLM window. Rather than repoint it, it is removed: it demonstrably was not needed, and a gate on the serving model would block litellm and memini reconciliation during a slow first boot or a failed one, including blocking a revert.

## Why

| | qwen36-27b (parked) | muse-glimmer-30b |
|---|---|---|
| Attention | 48 DeltaNet + 16 full | 39 sliding (w=2048) + 13 full, dense |
| KV heads | 4 KV x 256 head_dim | 2 KV x 128 head_dim |
| KV/token (unbounded layers) | ~64 KiB | ~13 KiB |
| Recurrent state | ~150 MiB per request | none |

Weights are within 3% at Q4_K_M (17.31 vs 16.8 GB), so single-stream decode is not expected to win on bandwidth alone. The hypothesis is the kernel path: 48 of qwen36-27b's 64 layers are DeltaNet, and llama.cpp's fused GDN kernel is a CUDA kernel cross-compiled via HIP that performs like the CPU path on RDNA (#20354), plus ~271us/dispatch on the recurrent step (#20292). This model has zero recurrent layers, so all 52 hit the attention path that got #24668 (+8-15% FA, validated on gfx1201), #26046 and #26199.

### Baseline being replaced

vLLM v0.27.1, measured 2026-08-12 after tuning (4.37 GiB pool, 16 slots, 4096 batched tokens), warm pass, ~2K unique prompts, 128 gen:

| conc | PP tok/s | TG tok/s | TG/stream | TTFT s |
|---|---|---|---|---|
| 1 | 2904 | 5.25 | 5.39 | 0.81 |
| 8 | 3274 | 33.52 | 4.90 | 5.76 |
| 16 | 3200 | 54.80 | 4.39 | 11.79 |
| 32 | 1535 | 54.81 | 4.23 | 49.14 |

Per-stream decode ~4-5 tok/s with the GPU pinned at 100% util / 249W of a 250W cap. That is the number to beat.

## Config decisions

- **unsloth GGUF, not meta-models** - the official GGUF encodes `sliding_window_pattern` as a per-layer bool array and crashes the DFlash drafter (#26894).
- **No mmproj** - loading it costs ~1000 tok/s of prefill permanently (#26873); multimodal is unused.
- **ROCm, not Vulkan** - gfx1201 is in the official ROCm image's target list (#15994), so the old custom image is unnecessary. The only hard failure on this exact card is on the Vulkan image (#25520, load hangs), and that image ships RADV 26.0.3 while gfx1201 Vulkan results are measured on 26.1.x.
- **`--kv-unified` passed explicitly** - it defaults to false once `-np` is set (`common/common.h:563`). Without it `n_ctx_seq = n_ctx / n_seq_max` hard-partitions the pool; with it each slot may use the full 262144 while others idle, at identical total memory (`src/llama-context.cpp:290-303`).
- **`parallelSlots: 4`** - KV is only ~1.9 GiB at q8_0 and the base cache does not grow with slots (only the 2048 sliding ring does, ~0.16 GiB per 4 slots), so raising this later is nearly free. Starting low isolates the model question from the batching question, and over-subscription releases *every* active slot rather than the greediest.
- **`GGML_CUDA_DISABLE_GRAPHS=1`** - the HIP graph cache is an unbounded map, never evicted; an R9700 reporter saw RSS go 8 -> 13.7 GB under 3 slots and stay there (#25082).
- **DFlash via `extraArgs`** - the CRD's `speculativeDecoding` has a CEL rule rejecting `type: draft` for having no field to name drafter weights; `mtp` means self-speculation and is wrong here.
- **seccompProfile Unconfined** - matches both ROCm siblings. Not changed to RuntimeDefault in this PR: it cannot be boot-tested while the GPU is held by vLLM, and an untested tightening would fail the cutover rather than the test.

## Risks

- **The arch merged upstream 2026-08-10** with four open issues. Deliberate evaluation cutover, not a settled production choice.
- **`qwen-3.6-fast` changes behaviour.** It loses `enable_thinking: false` and the Qwen sampling triple. Muse-Glimmer gates reasoning by effort level (low/medium/high/xhigh) instead, and the equivalent kwarg is unverified - if Hermes aux calls come back verbose or slow, check that first.
- **First start pays a 17.5 GB download** plus the ROCm image pull; weights are not fetched until scale-up.
- **No cross-request prefix sharing** in llama.cpp - two requests with the same system prompt each store their own copy (`seq_cp` is only used for `n_cmpl > 1`). For agentic traffic with a long shared prefix this uses several times the KV vLLM would.
- **`--spec-draft-model` path is `sha256(Model.spec.source)[:16]`** (verified: reproduces qwen36-27b-vllm's `1ad954900d52a84d`). Recompute it if the source sha ever changes. Note no Renovate manager currently matches `hf://` sources - the custom manager only matches the `https://huggingface.co/.../resolve/<sha>/` form - so nothing auto-bumps it.

## Revert

Flip both `replicas` back and point the two litellm aliases at `qwen36-27b-vllm:8000`. No health gate stands in the way.

## Validation

`kustomize build` passes for the models and litellm kustomizations; `ks.yaml` parses. Not booted - the GPU is held by vLLM until this merges.

After merge, re-run the same harness that produced the table above and compare PP and TG at matched concurrency.
