### PR TITLE
fix(ai): restore mamba SSM dtype, raise context to 148K, add fallback tier

### DIFF
--- a/kubernetes/apps/ai/litellm/instance/models.yaml
+++ b/kubernetes/apps/ai/litellm/instance/models.yaml
@@ -24,11 +24,10 @@ spec:
       num_retries: 0
   info:
     mode: chat
-    # vLLM's maxModelLen (112000) minus maxOutputTokens; covers Hermes' measured
-    # p100 (112K), so routine sessions never truncate. Takes both the
-    # OffloadingConnector and an explicit --kv-cache-memory to reach — see
-    # qwen38-27b-vllm.yaml.
-    maxInputTokens: 103808
+    # vLLM's maxModelLen (148000) minus maxOutputTokens. Must be re-derived
+    # whenever that changes -- nothing enforces the subtraction across the two
+    # CRDs. Comfortably over Hermes' measured p100 of 112K.
+    maxInputTokens: 139808
     maxOutputTokens: 8192
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/litellm.home-operations.com/litellmmodel_v1alpha1.json
@@ -60,8 +59,8 @@ spec:
           enable_thinking: false
   info:
     mode: chat
-    # 112000 - 8192, as above.
-    maxInputTokens: 103808
+    # 148000 - 8192, as above.
+    maxInputTokens: 139808
     maxOutputTokens: 8192
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/litellm.home-operations.com/litellmmodel_v1alpha1.json

--- a/kubernetes/apps/ai/litellm/instance/models.yaml
+++ b/kubernetes/apps/ai/litellm/instance/models.yaml
@@ -24,9 +24,8 @@ spec:
       num_retries: 0
   info:
     mode: chat
-    # vLLM's maxModelLen (148000) minus maxOutputTokens. Must be re-derived
-    # whenever that changes -- nothing enforces the subtraction across the two
-    # CRDs. Comfortably over Hermes' measured p100 of 112K.
+    # maxModelLen (148000) minus maxOutputTokens; re-derive if that changes,
+    # nothing enforces it across the two CRDs.
     maxInputTokens: 139808
     maxOutputTokens: 8192
 ---

--- a/kubernetes/apps/ai/litellm/instance/proxy.yaml
+++ b/kubernetes/apps/ai/litellm/instance/proxy.yaml
@@ -57,9 +57,13 @@ spec:
     # omniroute's free providers have no SLA and can fail/time out without
     # warning; fall back to the self-hosted (slower but always-available)
     # qwen-3.8-fast alias so a flaky free provider doesn't take out the PR
-    # review action.
+    # review action. qwen35-2b is the last resort: a single-entry chain went
+    # hard-down on 2026-08-17 when qwen36-27b was scaled to 0 for this cutover
+    # while the alias still pointed at it, so keep a tier that does not share
+    # qwen-3.8-fast's node or GPU (2b runs on control-2's dri device, the 27B
+    # on control-1). Quality drops a lot at 2B — this is "degraded, not down".
     fallbacks:
-      - omniroute: ["qwen-3.8-fast"]
+      - omniroute: ["qwen-3.8-fast", "qwen35-2b"]
   route:
     hostnames:
       - "litellm.${SECRET_DOMAIN}"

--- a/kubernetes/apps/ai/litellm/instance/proxy.yaml
+++ b/kubernetes/apps/ai/litellm/instance/proxy.yaml
@@ -54,14 +54,10 @@ spec:
     # already burned 900s only deepens the contention that caused it.
     retry_policy:
       InternalServerErrorRetries: 2
-    # omniroute's free providers have no SLA and can fail/time out without
-    # warning; fall back to the self-hosted (slower but always-available)
-    # qwen-3.8-fast alias so a flaky free provider doesn't take out the PR
-    # review action. qwen35-2b is the last resort: a single-entry chain went
-    # hard-down on 2026-08-17 when qwen36-27b was scaled to 0 for this cutover
-    # while the alias still pointed at it, so keep a tier that does not share
-    # qwen-3.8-fast's node or GPU (2b runs on control-2's dri device, the 27B
-    # on control-1). Quality drops a lot at 2B — this is "degraded, not down".
+    # omniroute's free providers have no SLA; qwen-3.8-fast catches that.
+    # qwen35-2b is the last resort because a single-entry chain went hard-down
+    # on 2026-08-17 when the 27B was scaled to 0 -- it is iGPU-pinned, so it
+    # never shares control-1's dGPU. Degraded, not down.
     fallbacks:
       - omniroute: ["qwen-3.8-fast", "qwen35-2b"]
   route:

--- a/kubernetes/apps/ai/llmkube/models/qwen38-27b-vllm.yaml
+++ b/kubernetes/apps/ai/llmkube/models/qwen38-27b-vllm.yaml
@@ -172,11 +172,14 @@ spec:
   modelCache:
     claimName: qwen38-27b-vllm-model-cache
   vllmConfig:
-    # Hermes hard-requires >=64K context (refuses to start below it); its
-    # measured percentiles are p90 94K, p95 106K, p100 112K, so this covers
-    # p100 and routine sessions never truncate. Reachable only with the
-    # explicit --kv-cache-memory below.
-    maxModelLen: 112000
+    # This is the ONLY per-request cap on KV blocks (max-num-seqs reserves
+    # nothing, max-num-batched-tokens is a compute budget), so it decides how
+    # much of the pool one session can hold. Sized just under the pool so a
+    # single stream can take ~94% of it: measured 158,073 tokens, 1.07x.
+    # Hermes needs >=64K to start and peaks at p100 112K, so this is headroom
+    # over its real traffic, not a routine working size. The model itself
+    # allows 262,144 (max_position_embeddings); KV is the binding limit.
+    maxModelLen: 148000
     kvCacheDtype: fp8_e4m3
     # Confirmed working on this hybrid Mamba/GDN model (~27% hit rate under
     # real traffic on the sibling qwen36 config).

--- a/kubernetes/apps/ai/llmkube/models/qwen38-27b-vllm.yaml
+++ b/kubernetes/apps/ai/llmkube/models/qwen38-27b-vllm.yaml
@@ -224,8 +224,14 @@ spec:
     - name: dshm
       mountPath: /dev/shm
   extraArgs:
+    # First name is what vLLM reports back as `model`, so qwen-3.8 stays
+    # primary. The second is an alias: the operator derives a LiteLLMModel from
+    # this InferenceService's own name and has no field to override it, so
+    # without the alias that generated model group sends model=qwen38-27b-vllm
+    # and vLLM 404s it (verified 2026-08-17). Keep it in sync with metadata.name.
     - --served-model-name
     - qwen-3.8
+    - qwen38-27b-vllm
     - --trust-remote-code
     - --reasoning-parser
     - qwen3

--- a/kubernetes/apps/ai/llmkube/models/qwen38-27b-vllm.yaml
+++ b/kubernetes/apps/ai/llmkube/models/qwen38-27b-vllm.yaml
@@ -172,13 +172,10 @@ spec:
   modelCache:
     claimName: qwen38-27b-vllm-model-cache
   vllmConfig:
-    # This is the ONLY per-request cap on KV blocks (max-num-seqs reserves
-    # nothing, max-num-batched-tokens is a compute budget), so it decides how
-    # much of the pool one session can hold. Sized just under the pool so a
-    # single stream can take ~94% of it: measured 158,073 tokens, 1.07x.
-    # Hermes needs >=64K to start and peaks at p100 112K, so this is headroom
-    # over its real traffic, not a routine working size. The model itself
-    # allows 262,144 (max_position_embeddings); KV is the binding limit.
+    # The only per-request cap on KV blocks, so it sets how much of the pool
+    # one session can hold: 94% of the measured 158,073 tokens (1.07x). Hermes
+    # peaks at 112K, so this is headroom. Engine refuses to start if the pool
+    # can't hold one full sequence.
     maxModelLen: 148000
     kvCacheDtype: fp8_e4m3
     # Confirmed working on this hybrid Mamba/GDN model (~27% hit rate under
@@ -258,11 +255,9 @@ spec:
     # hardware, MTP + tool-calling grammar wedges to ~0.2 tok/s (100x
     # regression) under concurrent tool traffic. Re-test that wedge before
     # re-adding.
-    # Two separate pools, both needed: --mamba-cache-dtype is the conv-state
-    # cache, --mamba-ssm-cache-dtype the SSM-state cache. Dropping the ssm one
-    # on the theory that it inherits from the other cost 7,160 KV tokens
-    # (156,493 -> 149,333) and halved the CPU offload tier (327 -> 167 blocks),
-    # measured 2026-08-17. bfloat16 is the smallest vLLM accepts for either.
+    # Separate pools, both needed -- ssm does NOT inherit from the other on
+    # Qwen3.5 (its config forces auto to fp32). Dropping it cost 7,160 KV
+    # tokens and halved the CPU tier. bfloat16 is vLLM's floor for either.
     - --mamba-cache-dtype
     - bfloat16
     - --mamba-ssm-cache-dtype

--- a/kubernetes/apps/ai/llmkube/models/qwen38-27b-vllm.yaml
+++ b/kubernetes/apps/ai/llmkube/models/qwen38-27b-vllm.yaml
@@ -255,9 +255,14 @@ spec:
     # hardware, MTP + tool-calling grammar wedges to ~0.2 tok/s (100x
     # regression) under concurrent tool traffic. Re-test that wedge before
     # re-adding.
-    # Covers the conv-state and SSM pools both (--mamba-ssm-cache-dtype
-    # defaults to following this), and bfloat16 is the smallest vLLM accepts.
+    # Two separate pools, both needed: --mamba-cache-dtype is the conv-state
+    # cache, --mamba-ssm-cache-dtype the SSM-state cache. Dropping the ssm one
+    # on the theory that it inherits from the other cost 7,160 KV tokens
+    # (156,493 -> 149,333) and halved the CPU offload tier (327 -> 167 blocks),
+    # measured 2026-08-17. bfloat16 is the smallest vLLM accepts for either.
     - --mamba-cache-dtype
+    - bfloat16
+    - --mamba-ssm-cache-dtype
     - bfloat16
     # Skips profiling, so this -- not gpuMemoryUtilization -- sizes KV. The
     # profiler was conservative: 3.22 GiB, which forced the old 98K ceiling.


### PR DESCRIPTION
Follow-ups to #4509, found while reconciling it into production. All four
changes measured on the live engine.

## `--mamba-ssm-cache-dtype` is a separate pool (regression fix)

The simplify pass on #4509 dropped this flag on the theory that it inherits from
`--mamba-cache-dtype`. It does not, and the mechanism is model-specific:
`vllm/model_executor/models/config.py` has a Qwen3.5 override that rewrites
`auto` to the checkpoint's `mamba_ssm_dtype`, which is **float32**. The generic
"follow the conv-state dtype" path never applies here.

fp32 SSM state forces the attention `block_size` from 800 up to 1568, and the
coarser block wastes more pool:

| | KV tokens | concurrency @112K | CPU offload tier |
|---|---|---|---|
| with the flag | 156,493 | 1.40x | 327 blocks |
| without | 149,333 | 1.33x | 167 blocks |

Restoring it recovered exactly the 7,160 tokens. It is silently load-bearing —
the comment now says so.

## Context 112K -> 148K, so one session can use the whole pool

`maxModelLen` is the only per-request cap on KV blocks (`max_num_seqs` reserves
nothing; `max_num_batched_tokens` is a compute budget), so at 112000 a single
stream could hold at most 72% of the pool.

Measured at 148000: pool **158,073 tokens** (+1,580 from better block rounding),
1.07x concurrency, 28.50 GB VRAM used leaving **5.71 GB free** — still above
Jellyfin's ~4.6 GB reservation. One stream now reaches 94% of the pool.

The engine refuses to start if the pool cannot hold one full sequence, so an
over-large value fails fast rather than at runtime. The model allows 262,144
(`max_position_embeddings`); KV memory is the binding limit.

litellm `maxInputTokens` follows at `148000 - 8192`.

## Second fallback tier

`omniroute` fell back only to `qwen-3.8-fast` — a single-entry chain on the same
node and GPU. That went hard-down on 2026-08-17 when the 27B was scaled to 0
during the cutover. `qwen35-2b` runs on a different node's dri device, so it
degrades instead of dropping.

## Served-model-name alias

llmkube auto-registers a `LiteLLMModel` under the InferenceService name, but vLLM
only served `qwen-3.8`, so that route 404'd at the vLLM hop.

## Considered and rejected

- **`--language-model-only`** (+31,000 KV tokens, ~1.0 GiB reclaimed): it never
  loads the vision tower, and karakeep's `INFERENCE_IMAGE_MODEL` plus hermes'
  `auxiliary.vision` both use it. Product regression traded for context.
- **`--prefix-match-unit 100`**: proposed on a 0.0% prefix-hit reading that turned
  out to be a cold-start artifact — real traffic runs 30-58%. It also hard-couples
  to `block_size: 800`, so it would turn a future mamba-flag change into a startup
  failure.
- **int4/int8 `per_token_head` KV** (potentially ~2.7x concurrency): the backend
  advertises support, but correctness/perf on gfx1201 is unverified and int4 KV is
  a real quality risk with tool-calling grammar. Needs an eval, not a config edit.

## Verification

- Hermes end-to-end through litellm, no overrides: `PIPELINE OK`
- KV numbers above read from the live engine at each setting
- All affected kustomize trees build