### PR TITLE
perf(ai): 7 GiB KV against a measured transcode reserve, plus a detector

### DIFF
--- a/docs/llm-hosting/engine-benchmarks-gfx1201.md
+++ b/docs/llm-hosting/engine-benchmarks-gfx1201.md
@@ -32,7 +32,8 @@ unchanged config.
 
 **2026-08-17 — the 4.6 GB figure was wrong, and the risk was real but misattributed.**
 Measured with `node_drm_memory_vram_used_bytes` across transcode start/stop: a 4K Dolby
-Vision transcode costs 0.85 GB, fileflows ~0.69 GB, ~1.1 GB peak for both — not 4.6 GB.
+Vision transcode costs 0.85 GB, fileflows 0.69 GB — measured separately, never
+concurrently, so the bound is their sum, 1.54 GB — not 4.6 GB.
 Production reserves 2 GiB and sizes KV explicitly (`--kv-cache-memory 7 GiB`, 221,612
 tokens). The contention that *does* bite is compute: DV tone mapping runs on Vulkan
 shaders, so a transcode crawls at 1.15x while vLLM saturates the CUs. Throttling vLLM to

--- a/docs/llm-hosting/engine-benchmarks-gfx1201.md
+++ b/docs/llm-hosting/engine-benchmarks-gfx1201.md
@@ -30,6 +30,15 @@ Operational finding from the same check: the 0.875 VRAM "ceiling" is effectively
 out, so a concurrent transcode would contend with LLM serving (or OOM). Known latent risk,
 unchanged config.
 
+**2026-08-17 — the 4.6 GB figure was wrong, and the risk was real but misattributed.**
+Measured with `node_drm_memory_vram_used_bytes` across transcode start/stop: a 4K Dolby
+Vision transcode costs 0.85 GB, fileflows ~0.69 GB, ~1.1 GB peak for both — not 4.6 GB.
+Production reserves 2 GiB and sizes KV explicitly (`--kv-cache-memory 7 GiB`, 221,612
+tokens). The contention that *does* bite is compute: DV tone mapping runs on Vulkan
+shaders, so a transcode crawls at 1.15x while vLLM saturates the CUs. Throttling vLLM to
+fix it is not viable — `maxNumBatchedTokens: 2048` cost 4-16x TTFT on this prefill-bound
+workload (129:1 prompt:output).
+
 ## Model-fit verdict — DeepSeek-V4-Flash-0731 (2026-08-01, NO-GO, do not re-ask)
 
 284B-param MoE (13B active/token, 1M context, CSA/HCA hybrid). Official weights ~167 GB

--- a/docs/llm-hosting/vllm-vs-sglang-2026-07.md
+++ b/docs/llm-hosting/vllm-vs-sglang-2026-07.md
@@ -13,6 +13,19 @@ Any benchmark taken above 0.875 is invalid as a production candidate no matter h
 it scores. Two were run during this round before the constraint was known; both are
 recorded below and both are rejected.
 
+> **Superseded 2026-08-17.** The 4.6 GB above was never measured — it was whatever
+> 0.875 happened to leave over. Measured on the live GPU (`node_drm_memory_vram_used_bytes`,
+> transcode on/off): a worst-case 4K Dolby Vision transcode costs **0.85 GB**, fileflows
+> **~0.69 GB**, **~1.1 GB peak** for both. Production now reserves **2 GiB** and sizes KV
+> with `--kv-cache-memory` instead, which makes `gpuMemoryUtilization` inert (vLLM skips
+> profiling when it is set). The benchmarks below remain valid as engine comparisons.
+>
+> The real contention is **compute, not memory**: Dolby Vision tone mapping runs on Vulkan
+> shaders (VCN covers only decode/encode), so it competes with vLLM for the same CUs. A 4K DV
+> transcode ran at 1.15x while vLLM held the shaders at 100%. Lowering
+> `maxNumBatchedTokens` to 2048 to free shader time was tried and rejected: TTFT p50 went
+> 5s -> 80s because this workload is prefill-bound (~129:1 prompt:output).
+
 ## What was overturned
 
 > Historical numbers superseded — full records in the [benchmark log](engine-benchmarks-gfx1201.md).

--- a/docs/llm-hosting/vllm-vs-sglang-2026-07.md
+++ b/docs/llm-hosting/vllm-vs-sglang-2026-07.md
@@ -16,7 +16,8 @@ recorded below and both are rejected.
 > **Superseded 2026-08-17.** The 4.6 GB above was never measured — it was whatever
 > 0.875 happened to leave over. Measured on the live GPU (`node_drm_memory_vram_used_bytes`,
 > transcode on/off): a worst-case 4K Dolby Vision transcode costs **0.85 GB**, fileflows
-> **~0.69 GB**, **~1.1 GB peak** for both. Production now reserves **2 GiB** and sizes KV
+> **0.69 GB**. They were measured **separately, never concurrently**, so the bound the
+> reserve must cover is their sum, **1.54 GB**. Production reserves **2 GiB** and sizes KV
 > with `--kv-cache-memory` instead, which makes `gpuMemoryUtilization` inert (vLLM skips
 > profiling when it is set). The benchmarks below remain valid as engine comparisons.
 >

--- a/kubernetes/apps/ai/litellm/instance/models.yaml
+++ b/kubernetes/apps/ai/litellm/instance/models.yaml
@@ -24,9 +24,9 @@ spec:
       num_retries: 0
   info:
     mode: chat
-    # maxModelLen (148000) minus maxOutputTokens; re-derive if that changes,
+    # maxModelLen (216000) minus maxOutputTokens; re-derive if that changes,
     # nothing enforces it across the two CRDs.
-    maxInputTokens: 139808
+    maxInputTokens: 207808
     maxOutputTokens: 8192
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/litellm.home-operations.com/litellmmodel_v1alpha1.json
@@ -58,8 +58,8 @@ spec:
           enable_thinking: false
   info:
     mode: chat
-    # 148000 - 8192, as above.
-    maxInputTokens: 139808
+    # 216000 - 8192, as above.
+    maxInputTokens: 207808
     maxOutputTokens: 8192
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/litellm.home-operations.com/litellmmodel_v1alpha1.json

--- a/kubernetes/apps/ai/litellm/instance/models.yaml
+++ b/kubernetes/apps/ai/litellm/instance/models.yaml
@@ -24,9 +24,9 @@ spec:
       num_retries: 0
   info:
     mode: chat
-    # maxModelLen (216000) minus maxOutputTokens; re-derive if that changes,
+    # maxModelLen (221612) minus maxOutputTokens; re-derive if that changes,
     # nothing enforces it across the two CRDs.
-    maxInputTokens: 207808
+    maxInputTokens: 213420
     maxOutputTokens: 8192
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/litellm.home-operations.com/litellmmodel_v1alpha1.json
@@ -58,8 +58,8 @@ spec:
           enable_thinking: false
   info:
     mode: chat
-    # 216000 - 8192, as above.
-    maxInputTokens: 207808
+    # 221612 - 8192, as above.
+    maxInputTokens: 213420
     maxOutputTokens: 8192
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/litellm.home-operations.com/litellmmodel_v1alpha1.json

--- a/kubernetes/apps/ai/llmkube/models/qwen38-27b-vllm.yaml
+++ b/kubernetes/apps/ai/llmkube/models/qwen38-27b-vllm.yaml
@@ -173,13 +173,21 @@ spec:
     claimName: qwen38-27b-vllm-model-cache
   vllmConfig:
     # The only per-request cap on KV blocks, so it decides how much of the pool
-    # a single session can hold. Set just under the measured pool (221,612
-    # tokens) so one session can take ~97% of it; the ~5.6K shortfall is margin
-    # because the engine refuses to start if the pool cannot hold one full
-    # sequence. Headroom, not a working size -- Hermes peaks at 112K and p90
-    # prompts are 20K, and concurrency for normal traffic is unaffected since
-    # KV is paged and allocated on demand. Model allows 262,144.
-    maxModelLen: 216000
+    # a single session can hold. Set to the pool so one session can use
+    # effectively all of it: verified booting at this value, which reports
+    # 223,172 tokens (raising it improves block packing slightly) = 1.01x, so
+    # a session reaches 99.3%. Headroom, not a working size -- Hermes peaks at
+    # 112K and p90 prompts are 20K, and normal concurrency is unaffected
+    # because KV is paged and allocated on demand.
+    #
+    # Deliberately no margin: if a future change shrinks the pool below this
+    # the engine refuses to start rather than silently truncating, and Flux
+    # applies automatically. Re-read "GPU KV cache size" from the boot log and
+    # match it after ANY of: --kv-cache-memory, the mamba cache dtypes, the
+    # attention block size, or a vLLM image bump. That last one is the easy
+    # miss -- Renovate opens it as an ordinary reviewed PR.
+    # The model itself allows 262,144; KV memory is the binding limit.
+    maxModelLen: 221612
     kvCacheDtype: fp8_e4m3
     # Confirmed working on this hybrid Mamba/GDN model (~27% hit rate under
     # real traffic on the sibling qwen36 config).
@@ -274,7 +282,8 @@ spec:
     # Vision transcode 0.85 GB, fileflows 0.69 GB -- 1.54 GB if they ever peak
     # together, which was not observed but is the number the reserve must cover.
     # Jellyfin has no transcode concurrency cap, so a third stream would exceed
-    # 2 GiB and evict KV; see the DgpuVramLow alert. 7 GiB leaves ~2.6 GB free.
+    # 2 GiB and evict KV; see the DgpuVramLow alert. Measured free at this
+    # config: 2.81 GB.
     - --kv-cache-memory
     - "7516192768"
     # Hierarchical KV cache: CPU tier (matches SGLang's --hicache-ratio sizing

--- a/kubernetes/apps/ai/llmkube/models/qwen38-27b-vllm.yaml
+++ b/kubernetes/apps/ai/llmkube/models/qwen38-27b-vllm.yaml
@@ -172,12 +172,14 @@ spec:
   modelCache:
     claimName: qwen38-27b-vllm-model-cache
   vllmConfig:
-    # The only per-request cap on KV blocks. Headroom, not a working size:
-    # Hermes peaks at 112K and p90 prompts are 20K. The pool (221,612 tokens)
-    # is bounded by parallelSlots, not by this -- 16 slots at p90 would want
-    # ~320K, so raising this further buys nothing. Engine refuses to start if
-    # the pool cannot hold one full sequence.
-    maxModelLen: 148000
+    # The only per-request cap on KV blocks, so it decides how much of the pool
+    # a single session can hold. Set just under the measured pool (221,612
+    # tokens) so one session can take ~97% of it; the ~5.6K shortfall is margin
+    # because the engine refuses to start if the pool cannot hold one full
+    # sequence. Headroom, not a working size -- Hermes peaks at 112K and p90
+    # prompts are 20K, and concurrency for normal traffic is unaffected since
+    # KV is paged and allocated on demand. Model allows 262,144.
+    maxModelLen: 216000
     kvCacheDtype: fp8_e4m3
     # Confirmed working on this hybrid Mamba/GDN model (~27% hit rate under
     # real traffic on the sibling qwen36 config).

--- a/kubernetes/apps/ai/llmkube/models/qwen38-27b-vllm.yaml
+++ b/kubernetes/apps/ai/llmkube/models/qwen38-27b-vllm.yaml
@@ -181,12 +181,18 @@ spec:
     # Confirmed working on this hybrid Mamba/GDN model (~27% hit rate under
     # real traffic on the sibling qwen36 config).
     enablePrefixCaching: true
-    maxNumBatchedTokens: 4096
+    # 2048, not the 4096 that maximises prefill: this GPU is shared with
+    # Jellyfin, whose Dolby Vision tone mapping runs on Vulkan shaders (VCN
+    # only covers decode/encode). At 4096 vLLM held the shaders at 100% and a
+    # 4K DV transcode crawled at 1.15x -- buffering on any burst. Smaller
+    # steps leave gaps ffmpeg can use. Costs prefill throughput, which is
+    # where this workload lives (measured 129:1 prompt:output).
+    maxNumBatchedTokens: 2048
     # INERT while --kv-cache-memory is set below (vLLM skips profiling and logs
-    # that it ignores this). Kept because dropping that flag hands sizing back
-    # here, and 0.875 is the hard ceiling: the ~4.6 GB free at this value is
-    # Jellyfin's transcode reservation, not slack, and nothing enforces it
-    # (docs/llm-hosting/vllm-vs-sglang-2026-07.md).
+    # that it ignores this); kept only so dropping that flag falls back to a
+    # sane value. Note the doc's "0.875 leaves Jellyfin's 4.6 GB" was never a
+    # measurement -- media actually peaks ~1.1 GB, so --kv-cache-memory now
+    # sets the split against a 2 GiB reserve instead.
     gpuMemoryUtilization: 0.875
   env:
     - name: VLLM_ROCM_USE_AITER
@@ -264,11 +270,12 @@ spec:
     - bfloat16
     # Skips profiling, so this -- not gpuMemoryUtilization -- sizes KV. The
     # profiler was conservative: 3.22 GiB, which forced the old 98K ceiling.
-    # 5 GiB is the most that still clears Jellyfin's ~4.6 GB: 5.46 GB free,
-    # 156,493 tokens, 1.40x at 112K. 6 GiB gives 1.68x but only 3.41 GB free,
-    # under the reservation. Re-measure free VRAM before raising.
+    # Sized against a measured 2 GiB transcode reserve, not the old 4.6 GB
+    # guess: a worst-case 4K Dolby Vision transcode costs 0.85 GB and
+    # fileflows ~0.69 GB, ~1.1 GB peak for both (2026-08-17, drm VRAM).
+    # 7 GiB leaves ~2.6 GB free. Re-measure free VRAM before raising.
     - --kv-cache-memory
-    - "5368709120"
+    - "7516192768"
     # Hierarchical KV cache: CPU tier (matches SGLang's --hicache-ratio sizing
     # philosophy) + fs tier (SGLang's file backend analogue). Ported from
     # qwen36-27b-vllm.yaml, WITHOUT that config's --language-model-only —

--- a/kubernetes/apps/ai/llmkube/models/qwen38-27b-vllm.yaml
+++ b/kubernetes/apps/ai/llmkube/models/qwen38-27b-vllm.yaml
@@ -172,10 +172,11 @@ spec:
   modelCache:
     claimName: qwen38-27b-vllm-model-cache
   vllmConfig:
-    # The only per-request cap on KV blocks, so it sets how much of the pool
-    # one session can hold: 67% of the measured 221,612 tokens (1.50x). Hermes
-    # peaks at 112K, so this is headroom. Engine refuses to start if the pool
-    # can't hold one full sequence.
+    # The only per-request cap on KV blocks. Headroom, not a working size:
+    # Hermes peaks at 112K and p90 prompts are 20K. The pool (221,612 tokens)
+    # is bounded by parallelSlots, not by this -- 16 slots at p90 would want
+    # ~320K, so raising this further buys nothing. Engine refuses to start if
+    # the pool cannot hold one full sequence.
     maxModelLen: 148000
     kvCacheDtype: fp8_e4m3
     # Confirmed working on this hybrid Mamba/GDN model (~27% hit rate under
@@ -188,9 +189,7 @@ spec:
     maxNumBatchedTokens: 4096
     # INERT while --kv-cache-memory is set below (vLLM skips profiling and logs
     # that it ignores this); kept only so dropping that flag falls back to a
-    # sane value. Note the doc's "0.875 leaves Jellyfin's 4.6 GB" was never a
-    # measurement -- media actually peaks ~1.1 GB, so --kv-cache-memory now
-    # sets the split against a 2 GiB reserve instead.
+    # sane value. The media-reserve math lives with that flag, not here.
     gpuMemoryUtilization: 0.875
   env:
     - name: VLLM_ROCM_USE_AITER
@@ -268,10 +267,12 @@ spec:
     - bfloat16
     # Skips profiling, so this -- not gpuMemoryUtilization -- sizes KV. The
     # profiler was conservative: 3.22 GiB, which forced the old 98K ceiling.
-    # Sized against a measured 2 GiB transcode reserve, not the old 4.6 GB
-    # guess: a worst-case 4K Dolby Vision transcode costs 0.85 GB and
-    # fileflows ~0.69 GB, ~1.1 GB peak for both (2026-08-17, drm VRAM).
-    # 7 GiB leaves ~2.6 GB free. Re-measure free VRAM before raising.
+    # Sized against a 2 GiB transcode reserve, not the old 4.6 GB guess, which
+    # was never measured. Measured separately 2026-08-17 (drm VRAM): a 4K Dolby
+    # Vision transcode 0.85 GB, fileflows 0.69 GB -- 1.54 GB if they ever peak
+    # together, which was not observed but is the number the reserve must cover.
+    # Jellyfin has no transcode concurrency cap, so a third stream would exceed
+    # 2 GiB and evict KV; see the DgpuVramLow alert. 7 GiB leaves ~2.6 GB free.
     - --kv-cache-memory
     - "7516192768"
     # Hierarchical KV cache: CPU tier (matches SGLang's --hicache-ratio sizing

--- a/kubernetes/apps/ai/llmkube/models/qwen38-27b-vllm.yaml
+++ b/kubernetes/apps/ai/llmkube/models/qwen38-27b-vllm.yaml
@@ -173,7 +173,7 @@ spec:
     claimName: qwen38-27b-vllm-model-cache
   vllmConfig:
     # The only per-request cap on KV blocks, so it sets how much of the pool
-    # one session can hold: 94% of the measured 158,073 tokens (1.07x). Hermes
+    # one session can hold: 67% of the measured 221,612 tokens (1.50x). Hermes
     # peaks at 112K, so this is headroom. Engine refuses to start if the pool
     # can't hold one full sequence.
     maxModelLen: 148000
@@ -181,13 +181,11 @@ spec:
     # Confirmed working on this hybrid Mamba/GDN model (~27% hit rate under
     # real traffic on the sibling qwen36 config).
     enablePrefixCaching: true
-    # 2048, not the 4096 that maximises prefill: this GPU is shared with
-    # Jellyfin, whose Dolby Vision tone mapping runs on Vulkan shaders (VCN
-    # only covers decode/encode). At 4096 vLLM held the shaders at 100% and a
-    # 4K DV transcode crawled at 1.15x -- buffering on any burst. Smaller
-    # steps leave gaps ffmpeg can use. Costs prefill throughput, which is
-    # where this workload lives (measured 129:1 prompt:output).
-    maxNumBatchedTokens: 2048
+    # Do NOT lower this to buy transcode headroom: 2048 was tried and cost
+    # 4-16x TTFT (p50 5s -> 80s, avg 13.8s -> 58.5s) because a 20K-token
+    # prompt then needs 10 prefill steps instead of 5 and decode starves
+    # behind them. This workload is prefill-bound (129:1 prompt:output).
+    maxNumBatchedTokens: 4096
     # INERT while --kv-cache-memory is set below (vLLM skips profiling and logs
     # that it ignores this); kept only so dropping that flag falls back to a
     # sane value. Note the doc's "0.875 leaves Jellyfin's 4.6 GB" was never a

--- a/kubernetes/apps/observability/exporters/node-exporter/app/prometheusrule.yaml
+++ b/kubernetes/apps/observability/exporters/node-exporter/app/prometheusrule.yaml
@@ -86,17 +86,15 @@ spec:
           # subtraction, so it returns NO SAMPLE if either metric disappears rather
           # than firing. NodeDRMCollectorFailed does not cover that case either --
           # node_scrape_collector_success vanishes too when the exporter is gone.
+          # absent(), not the label_replace/unless idiom NodeGTTTelemetryMissing
+          # uses: that shape exists to synthesise one series per node across
+          # two nodes, and here there is only control-1. It also missed the
+          # case where _size_bytes alone vanishes -- absent() on both covers
+          # each metric independently and keeps the node label for the summary.
           expr: |-
-            max by (kubernetes_node) (
-              node_drm_memory_vram_size_bytes{kubernetes_node="control-1"}
-            ) <= 0
-            or (
-              label_replace(vector(1), "kubernetes_node", "control-1", "", "")
-              unless on(kubernetes_node)
-              max by (kubernetes_node) (
-                node_drm_memory_vram_used_bytes{kubernetes_node="control-1"}
-              )
-            )
+            absent(node_drm_memory_vram_used_bytes{kubernetes_node="control-1"})
+            or absent(node_drm_memory_vram_size_bytes{kubernetes_node="control-1"})
+            or node_drm_memory_vram_size_bytes{kubernetes_node="control-1"} <= 0
           for: 10m
           annotations:
             summary: >-

--- a/kubernetes/apps/observability/exporters/node-exporter/app/prometheusrule.yaml
+++ b/kubernetes/apps/observability/exporters/node-exporter/app/prometheusrule.yaml
@@ -76,8 +76,32 @@ spec:
           for: 10m
           annotations:
             summary: >-
-              DRM collector failed on {{ $labels.kubernetes_node }} — NodeGTTMemoryHigh
-              and DgpuVramLow are blind until it recovers
+              DRM collector failed on {{ $labels.kubernetes_node }} — its GPU memory
+              alert (GTT on control-2/3, dGPU VRAM on control-1) is blind until it
+              recovers
+          labels:
+            severity: warning
+        - alert: DgpuVramTelemetryMissing
+          # Same reasoning as NodeGTTTelemetryMissing, for the dGPU: DgpuVramLow is a
+          # subtraction, so it returns NO SAMPLE if either metric disappears rather
+          # than firing. NodeDRMCollectorFailed does not cover that case either --
+          # node_scrape_collector_success vanishes too when the exporter is gone.
+          expr: |-
+            max by (kubernetes_node) (
+              node_drm_memory_vram_size_bytes{kubernetes_node="control-1"}
+            ) <= 0
+            or (
+              label_replace(vector(1), "kubernetes_node", "control-1", "", "")
+              unless on(kubernetes_node)
+              max by (kubernetes_node) (
+                node_drm_memory_vram_used_bytes{kubernetes_node="control-1"}
+              )
+            )
+          for: 10m
+          annotations:
+            summary: >-
+              dGPU VRAM telemetry is absent or non-positive on
+              {{ $labels.kubernetes_node }} — DgpuVramLow is blind until it recovers
           labels:
             severity: warning
         - alert: NodeGTTTelemetryMissing

--- a/kubernetes/apps/observability/exporters/node-exporter/app/prometheusrule.yaml
+++ b/kubernetes/apps/observability/exporters/node-exporter/app/prometheusrule.yaml
@@ -45,18 +45,39 @@ spec:
               likely the embedder leak; native max pod lifetime recycling should cap it
           labels:
             severity: warning
+        - alert: DgpuVramLow
+          # control-1's dGPU is shared between vLLM and Jellyfin/fileflows
+          # transcoding, and nothing enforces the split: squat.ai/dri counts
+          # device nodes, not bytes, so either side can take the whole card.
+          # vLLM is sized to leave 2 GiB (--kv-cache-memory in
+          # qwen38-27b-vllm.yaml) against a measured 0.85 GB DV transcode +
+          # 0.69 GB fileflows. A third concurrent transcode would breach it and
+          # evict KV instead of failing, so this is the only detector.
+          expr: |-
+            node_drm_memory_vram_size_bytes{kubernetes_node="control-1"}
+              - node_drm_memory_vram_used_bytes{kubernetes_node="control-1"}
+              < 2147483648
+          for: 10m
+          annotations:
+            summary: >-
+              {{ $labels.kubernetes_node }} dGPU has under 2GiB VRAM free — the
+              transcode reserve is breached; check concurrent transcodes before
+              raising vLLM's --kv-cache-memory
+          labels:
+            severity: warning
         - alert: NodeDRMCollectorFailed
           # A silently-dead DRM collector reads as "no GTT problem" (the xmrig-guard
-          # telemetry gap ran blind 40h this way).
+          # telemetry gap ran blind 40h this way). control-1 included since
+          # DgpuVramLow depends on the same collector.
           expr: |-
             max by (kubernetes_node) (
-              node_scrape_collector_success{collector="drm", kubernetes_node=~"control-[23]"} == 0
+              node_scrape_collector_success{collector="drm", kubernetes_node=~"control-[123]"} == 0
             )
           for: 10m
           annotations:
             summary: >-
               DRM collector failed on {{ $labels.kubernetes_node }} — NodeGTTMemoryHigh
-              is blind until it recovers
+              and DgpuVramLow are blind until it recovers
           labels:
             severity: warning
         - alert: NodeGTTTelemetryMissing


### PR DESCRIPTION
Follow-up to #4520. Everything here is measured on the live GPU.

## The 4.6 GB Jellyfin reservation was never a measurement

`docs/llm-hosting/vllm-vs-sglang-2026-07.md` defined it as *whatever 0.875 happened
to leave over* and then treated that number as a hard constraint. Measured with
`node_drm_memory_vram_used_bytes` across transcode start/stop:

| Workload | VRAM |
|---|---|
| 4K Dolby Vision transcode (worst case) | **0.85 GB** |
| fileflows transcode | **0.69 GB** |
| worst case if both peak together | **1.54 GB** |

They were measured separately, never concurrently — 1.54 GB is the additive bound
the reserve has to cover, not an observed peak. Reserving **2 GiB** and giving the
rest to KV:

| | before | after |
|---|---|---|
| `--kv-cache-memory` | 5 GiB | **7 GiB** |
| KV pool | 158,073 tok | **221,612 tok** (+40%) |
| concurrency @148K | 1.07x | **1.50x** |
| VRAM free | 5.71 GB | **2.99 GB** |

## A detector, because nothing enforces the split

`squat.ai/dri` counts device nodes, not bytes — verified in
`generic-device-plugin`'s values — so either tenant can map the whole card, and
Jellyfin has no transcode concurrency cap. A third concurrent transcode would
breach 2 GiB and evict KV rather than fail.

Adds **`DgpuVramLow`** (free VRAM < 2 GiB for 10m) mirroring the existing iGPU
`NodeGTTMemoryHigh`, and widens `NodeDRMCollectorFailed` to control-1 so the new
alert cannot go blind — the same failure mode that comment already records from
the xmrig-guard telemetry gap.

## maxNumBatchedTokens stays at 4096

2048 was tried, to free Vulkan shader time for Dolby Vision tone mapping (VCN
covers only decode/encode, so tone mapping competes with vLLM for the same CUs).
It was much worse:

| | 4096 | 2048 |
|---|---|---|
| TTFT avg | 13.8s | **58.5s** |
| TTFT p50 | 5s | **80s** |
| decode avg | 16.8s | **73.8s** |

A 20K-token prompt needs 10 prefill steps instead of 5 and decode starves behind
them. This workload is prefill-bound (measured 129:1 prompt:output), so throttling
vLLM is not a viable lever for transcode smoothness. Recorded in the manifest and
both docs so it is not retried.

## Verification

- KV pool and concurrency read from the live engine at each setting
- VRAM deltas from `node_drm_memory_vram_used_bytes`, transcode on/off
- `DgpuVramLow` expression evaluated against VictoriaMetrics (13.21 GB free, no fire)
- Affected kustomize trees build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added low dGPU VRAM monitoring for control nodes, with warnings when free memory remains below 2 GiB for 10 minutes.
  * Expanded collector-failure alerts to cover all control nodes and clarify when memory alerts may be unavailable.

* **Documentation**
  * Updated GPU memory guidance with measured transcoding usage and production reserve requirements.
  * Documented vLLM cache sizing, token limits, batching considerations, and GPU compute contention affecting transcoding performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->