### PR TITLE
fix(ai): restore omniroute failover and alert on gateway failures

### DIFF
--- a/kubernetes/apps/ai/litellm/instance/kustomization.yaml
+++ b/kubernetes/apps/ai/litellm/instance/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
   - models.yaml
   - servicemonitor.yaml
   - grafanadashboard.yaml
+  - prometheusrule.yaml

--- a/kubernetes/apps/ai/litellm/instance/prometheusrule.yaml
+++ b/kubernetes/apps/ai/litellm/instance/prometheusrule.yaml
@@ -7,23 +7,15 @@ metadata:
 spec:
   groups:
     - name: litellm.rules
-      # Nothing watched this gateway until 2026-08-17, when omniroute's free tier
-      # went dry, its fallback turned out to point at a deployment scaled to 0,
-      # and the first symptom anyone saw was PR review jobs failing ~6h later.
-      # The counter-based rules below read litellm's own metrics, scraped every
-      # 60s by the sibling ServiceMonitor; increase() is deliberate over rate()
-      # because traffic is
-      # bursty and tiny (7 requests overnight, dozens during a Renovate burst),
-      # so a per-second rate rounds to noise. increase() also rides out the
-      # counter resets that come with litellm's frequent pod rolls.
-      # The window is the debounce — a blip stays in view for its full duration —
-      # so `for` only has to survive one bad evaluation. Setting it to something
-      # comparable to the window just adds the two together (a 30m window with
-      # for: 30m took an hour to fire) and hides the real latency from anyone
-      # reading the threshold.
+      # increase() over rate(): traffic is bursty and tiny (single digits
+      # overnight, dozens during a Renovate burst), so a per-second rate rounds
+      # to noise. It also rides out the counter resets from litellm's pod rolls.
+      # The window is the debounce, so `for` only has to survive one bad
+      # evaluation -- setting it comparable to the window adds the two together
+      # and hides the real firing delay from anyone reading the threshold.
       rules:
-        # The one that matters: a caller got an error back. Everything else here
-        # is early warning, this is the outage itself.
+        # A caller got an error back. Everything else here is early warning;
+        # this is the outage itself.
         - alert: LiteLLMRequestsFailing
           expr: |-
             sum by (requested_model, exception_status) (
@@ -37,18 +29,16 @@ spec:
           labels:
             severity: critical
 
-        # Structural, not traffic-derived: the other rules here need a real
-        # request to fail before they see anything, which at 7-requests-overnight
-        # volume is the same multi-hour lag that let the 2026-08-17 outage run
-        # ~6h. This fires at 3am on zero traffic. It watches the one invariant
-        # proxy.yaml's fallback chain leans on -- qwen-3.8-fast must point at a
-        # live deployment -- and covers the actual cause (scaled to 0) plus
-        # crashloop, unschedulable, and the deployment being retired out from
-        # under the chain (absent(), the earlier qwen-3.6-fast case).
-        # The deployment name is hardcoded because it is the fallback target
-        # named in proxy.yaml; nothing derives one from the other, so both move
-        # together or this goes quiet. qwen-3.8 (hermes' primary) shares this
-        # same backend, so a hit here means no local model at all, not degraded.
+        # The only structural rule here: every other one needs a real request to
+        # fail first, which at this traffic volume means hours of lag. This
+        # fires on zero traffic and enforces the invariant proxy.yaml's chain
+        # depends on -- qwen-3.8-fast must point at a live deployment. absent()
+        # covers the target being retired out from under the chain, == 0 covers
+        # scaled-to-0, crashloop and unschedulable.
+        # Deployment name is hardcoded: nothing derives it from proxy.yaml's
+        # fallback target, so the two move together or this silently stops
+        # watching. Critical, not warning -- qwen-3.8 shares this backend, so a
+        # hit means hermes has no local model either.
         - alert: LiteLLMFallbackBackendDown
           expr: |-
             kube_deployment_status_replicas_available{namespace="ai", deployment="qwen38-27b-vllm"} == 0
@@ -63,10 +53,9 @@ spec:
           labels:
             severity: critical
 
-        # Complements the structural rule above, which cannot see a target that
-        # is up but rejects the payload -- qwen35-2b's 16384-token window turning
-        # review-sized 503s into 400s was exactly that. > 0 because the chain is
-        # one deep (see proxy.yaml): a single failed fallback is the whole net.
+        # Catches what the structural rule cannot: a target that is up but
+        # rejects the payload. > 0 because the chain is one deep (see
+        # proxy.yaml) -- a single failed fallback is the whole safety net.
         - alert: LiteLLMFallbackTargetUnavailable
           expr: |-
             sum by (requested_model, fallback_model) (
@@ -80,10 +69,10 @@ spec:
           labels:
             severity: warning
 
-        # omniroute dropping to fallback for a minute is normal: its free tier
-        # cycles quota roughly every 5m and recovers on its own. Sustained use
+        # omniroute briefly dropping to fallback is normal -- its free tier
+        # cycles quota every few minutes and recovers itself. Sustained use
         # means it is not recovering and the self-hosted models are carrying
-        # production traffic they were never sized for.
+        # traffic they were never sized for.
         - alert: LiteLLMPrimaryDegraded
           expr: |-
             sum by (requested_model, fallback_model) (

--- a/kubernetes/apps/ai/litellm/instance/prometheusrule.yaml
+++ b/kubernetes/apps/ai/litellm/instance/prometheusrule.yaml
@@ -15,6 +15,11 @@ spec:
       # bursty and tiny (7 requests overnight, dozens during a Renovate burst),
       # so a per-second rate rounds to noise. increase() also rides out the
       # counter resets that come with litellm's frequent pod rolls.
+      # The window is the debounce — a blip stays in view for its full duration —
+      # so `for` only has to survive one bad evaluation. Setting it to something
+      # comparable to the window just adds the two together (a 30m window with
+      # for: 30m took an hour to fire) and hides the real latency from anyone
+      # reading the threshold.
       rules:
         # The one that matters: a caller got an error back. Everything else here
         # is early warning, this is the outage itself.
@@ -32,17 +37,16 @@ spec:
             severity: critical
 
         # Fires while requests still succeed, so it is the one that buys time: a
-        # configured fallback target that is itself broken. Both real instances of
-        # this were invisible until they mattered — qwen-3.6-fast pointing at a
-        # retired deployment, then qwen35-2b rejecting every review-sized payload
-        # on a 16384-token window. Chain depth silently drops to zero and nothing
-        # else reports it.
+        # configured fallback target that is itself broken drops the chain's real
+        # depth to zero, and nothing else reports that. > 0 because the chain is
+        # one deep (see proxy.yaml) — a single failed fallback is already the
+        # whole safety net.
         - alert: LiteLLMFallbackTargetUnavailable
           expr: |-
             sum by (requested_model, fallback_model) (
               increase(litellm_deployment_failed_fallbacks_total[30m])
             ) > 0
-          for: 15m
+          for: 5m
           annotations:
             summary: >-
               Fallback {{ $labels.fallback_model }} for {{ $labels.requested_model }}
@@ -59,10 +63,10 @@ spec:
             sum by (requested_model, fallback_model) (
               increase(litellm_deployment_successful_fallbacks_total[30m])
             ) > 5
-          for: 30m
+          for: 5m
           annotations:
             summary: >-
-              {{ $labels.requested_model }} has been served by fallback
-              {{ $labels.fallback_model }} for 30m — the primary is not recovering
+              {{ $labels.requested_model }} has leaned on fallback
+              {{ $labels.fallback_model }} repeatedly — the primary is not recovering
           labels:
             severity: warning

--- a/kubernetes/apps/ai/litellm/instance/prometheusrule.yaml
+++ b/kubernetes/apps/ai/litellm/instance/prometheusrule.yaml
@@ -1,0 +1,68 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: litellm-rules
+spec:
+  groups:
+    - name: litellm.rules
+      # Nothing watched this gateway until 2026-08-17, when omniroute's free tier
+      # went dry, its fallback turned out to point at a deployment scaled to 0,
+      # and the first symptom anyone saw was PR review jobs failing ~6h later.
+      # All three rules below are counters scraped every 60s by the sibling
+      # ServiceMonitor; increase() is deliberate over rate() because traffic is
+      # bursty and tiny (7 requests overnight, dozens during a Renovate burst),
+      # so a per-second rate rounds to noise. increase() also rides out the
+      # counter resets that come with litellm's frequent pod rolls.
+      rules:
+        # The one that matters: a caller got an error back. Everything else here
+        # is early warning, this is the outage itself.
+        - alert: LiteLLMRequestsFailing
+          expr: |-
+            sum by (requested_model, exception_status) (
+              increase(litellm_proxy_failed_requests_metric_total[15m])
+            ) > 2
+          for: 10m
+          annotations:
+            summary: >-
+              litellm is returning {{ $labels.exception_status }} for
+              {{ $labels.requested_model }} — the fallback chain is not covering it
+          labels:
+            severity: critical
+
+        # Fires while requests still succeed, so it is the one that buys time: a
+        # configured fallback target that is itself broken. Both real instances of
+        # this were invisible until they mattered — qwen-3.6-fast pointing at a
+        # retired deployment, then qwen35-2b rejecting every review-sized payload
+        # on a 16384-token window. Chain depth silently drops to zero and nothing
+        # else reports it.
+        - alert: LiteLLMFallbackTargetUnavailable
+          expr: |-
+            sum by (requested_model, fallback_model) (
+              increase(litellm_deployment_failed_fallbacks_total[30m])
+            ) > 0
+          for: 15m
+          annotations:
+            summary: >-
+              Fallback {{ $labels.fallback_model }} for {{ $labels.requested_model }}
+              is failing — the chain is shorter than it looks
+          labels:
+            severity: warning
+
+        # omniroute dropping to fallback for a minute is normal: its free tier
+        # cycles quota roughly every 5m and recovers on its own. Sustained use
+        # means it is not recovering and the self-hosted models are carrying
+        # production traffic they were never sized for.
+        - alert: LiteLLMPrimaryDegraded
+          expr: |-
+            sum by (requested_model, fallback_model) (
+              increase(litellm_deployment_successful_fallbacks_total[30m])
+            ) > 5
+          for: 30m
+          annotations:
+            summary: >-
+              {{ $labels.requested_model }} has been served by fallback
+              {{ $labels.fallback_model }} for 30m — the primary is not recovering
+          labels:
+            severity: warning

--- a/kubernetes/apps/ai/litellm/instance/prometheusrule.yaml
+++ b/kubernetes/apps/ai/litellm/instance/prometheusrule.yaml
@@ -10,8 +10,9 @@ spec:
       # Nothing watched this gateway until 2026-08-17, when omniroute's free tier
       # went dry, its fallback turned out to point at a deployment scaled to 0,
       # and the first symptom anyone saw was PR review jobs failing ~6h later.
-      # All three rules below are counters scraped every 60s by the sibling
-      # ServiceMonitor; increase() is deliberate over rate() because traffic is
+      # The counter-based rules below read litellm's own metrics, scraped every
+      # 60s by the sibling ServiceMonitor; increase() is deliberate over rate()
+      # because traffic is
       # bursty and tiny (7 requests overnight, dozens during a Renovate burst),
       # so a per-second rate rounds to noise. increase() also rides out the
       # counter resets that come with litellm's frequent pod rolls.
@@ -36,11 +37,36 @@ spec:
           labels:
             severity: critical
 
-        # Fires while requests still succeed, so it is the one that buys time: a
-        # configured fallback target that is itself broken drops the chain's real
-        # depth to zero, and nothing else reports that. > 0 because the chain is
-        # one deep (see proxy.yaml) — a single failed fallback is already the
-        # whole safety net.
+        # Structural, not traffic-derived: the other rules here need a real
+        # request to fail before they see anything, which at 7-requests-overnight
+        # volume is the same multi-hour lag that let the 2026-08-17 outage run
+        # ~6h. This fires at 3am on zero traffic. It watches the one invariant
+        # proxy.yaml's fallback chain leans on -- qwen-3.8-fast must point at a
+        # live deployment -- and covers the actual cause (scaled to 0) plus
+        # crashloop, unschedulable, and the deployment being retired out from
+        # under the chain (absent(), the earlier qwen-3.6-fast case).
+        # The deployment name is hardcoded because it is the fallback target
+        # named in proxy.yaml; nothing derives one from the other, so both move
+        # together or this goes quiet. qwen-3.8 (hermes' primary) shares this
+        # same backend, so a hit here means no local model at all, not degraded.
+        - alert: LiteLLMFallbackBackendDown
+          expr: |-
+            kube_deployment_status_replicas_available{namespace="ai", deployment="qwen38-27b-vllm"} == 0
+            or
+            absent(kube_deployment_status_replicas_available{namespace="ai", deployment="qwen38-27b-vllm"})
+          # replicas: 1 on a single dGPU node, so every pod roll dips to 0.
+          for: 10m
+          annotations:
+            summary: >-
+              qwen38-27b-vllm has no available replica — litellm's only fallback
+              target is gone and hermes has no local model
+          labels:
+            severity: critical
+
+        # Complements the structural rule above, which cannot see a target that
+        # is up but rejects the payload -- qwen35-2b's 16384-token window turning
+        # review-sized 503s into 400s was exactly that. > 0 because the chain is
+        # one deep (see proxy.yaml): a single failed fallback is the whole net.
         - alert: LiteLLMFallbackTargetUnavailable
           expr: |-
             sum by (requested_model, fallback_model) (

--- a/kubernetes/apps/ai/litellm/instance/proxy.yaml
+++ b/kubernetes/apps/ai/litellm/instance/proxy.yaml
@@ -55,7 +55,8 @@ spec:
     retry_policy:
       InternalServerErrorRetries: 2
     # omniroute's free providers have no SLA; qwen-3.8-fast catches that.
-    # qwen35-2b was briefly a second tier and is deliberately gone: llama.cpp
+    # qwen35-2b was briefly a second tier and is deliberately not one now (the
+    # model still runs — karakeep uses it — it is just not a fallback): llama.cpp
     # splits contextSize across parallelSlots, so it served a 16384-token window
     # and rejected every review-sized payload that reached it -- turning a 503
     # into a 400. Widening it costs iGPU-node RAM that is not worth spending on

--- a/kubernetes/apps/ai/litellm/instance/proxy.yaml
+++ b/kubernetes/apps/ai/litellm/instance/proxy.yaml
@@ -55,14 +55,12 @@ spec:
     retry_policy:
       InternalServerErrorRetries: 2
     # omniroute's free providers have no SLA; qwen-3.8-fast catches that.
-    # qwen35-2b was briefly a second tier and is deliberately not one now (the
-    # model still runs — karakeep uses it — it is just not a fallback): llama.cpp
-    # splits contextSize across parallelSlots, so it served a 16384-token window
-    # and rejected every review-sized payload that reached it -- turning a 503
-    # into a 400. Widening it costs iGPU-node RAM that is not worth spending on
-    # a last resort, so the chain is one deep. That is only safe while
-    # qwen-3.8-fast points at a live deployment: the 2026-08-17 outage was this
-    # same single-entry chain aimed at a deployment scaled to 0.
+    # Deliberately one deep. qwen35-2b is not a second tier: llama.cpp splits
+    # contextSize across parallelSlots, so it serves a 16384-token window and
+    # rejects review-sized payloads, turning a 503 into a 400. Widening it costs
+    # iGPU-node RAM not worth spending on a last resort. (The model itself still
+    # runs -- karakeep uses it.) A one-deep chain is only safe while its target
+    # is live, which LiteLLMFallbackBackendDown enforces.
     fallbacks:
       - omniroute: ["qwen-3.8-fast"]
   route:

--- a/kubernetes/apps/ai/litellm/instance/proxy.yaml
+++ b/kubernetes/apps/ai/litellm/instance/proxy.yaml
@@ -55,11 +55,15 @@ spec:
     retry_policy:
       InternalServerErrorRetries: 2
     # omniroute's free providers have no SLA; qwen-3.8-fast catches that.
-    # qwen35-2b is the last resort because a single-entry chain went hard-down
-    # on 2026-08-17 when the 27B was scaled to 0 -- it is iGPU-pinned, so it
-    # never shares control-1's dGPU. Degraded, not down.
+    # qwen35-2b was briefly a second tier and is deliberately gone: llama.cpp
+    # splits contextSize across parallelSlots, so it served a 16384-token window
+    # and rejected every review-sized payload that reached it -- turning a 503
+    # into a 400. Widening it costs iGPU-node RAM that is not worth spending on
+    # a last resort, so the chain is one deep. That is only safe while
+    # qwen-3.8-fast points at a live deployment: the 2026-08-17 outage was this
+    # same single-entry chain aimed at a deployment scaled to 0.
     fallbacks:
-      - omniroute: ["qwen-3.8-fast", "qwen35-2b"]
+      - omniroute: ["qwen-3.8-fast"]
   route:
     hostnames:
       - "litellm.${SECRET_DOMAIN}"

--- a/kubernetes/apps/ai/omniroute/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/omniroute/app/helmrelease.yaml
@@ -22,10 +22,17 @@ spec:
           app:
             image:
               repository: docker.io/diegosouzapw/omniroute
-              # Tried main@digest 2026-08-11 and reverted: main is only dependabot
-              # bumps ahead of this tag (provider work lives on the `next` image,
-              # which has no public branch to audit) and its CI run was cancelled.
-              tag: 3.8.49@sha256:92c768c56e2de32c51a0621ef182835018b00b288c9bb235c5c5e4514658c1a1
+              # On `next` for a specific upstream fix, not for novelty: 3.8.49
+              # never clears the last-known-good-provider pin when its target
+              # starts failing, so every request re-selects the same exhausted
+              # model instead of failing over (upstream #10034, merged
+              # 2026-08-13 -- observed here as omniroute re-picking a dry
+              # antigravity model until it 503'd). No tagged release carries it;
+              # `main` was built 04:05Z that day, three hours before the merge.
+              # Source is public (github.com/diegosouzapw/OmniRoute, default
+              # branch release/v3.8.50) so this is auditable -- move to the
+              # v3.8.50 tag once it ships. Digest-pinned so Flux re-pulls.
+              tag: next@sha256:2dd8dee4c5247c372af2ebbdfb98d72b4abacca77a07dd41aa6de6aa77e527cc
             env:
               TZ: ${TIMEZONE}
               DATA_DIR: /app/data

--- a/kubernetes/apps/ai/omniroute/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/omniroute/app/helmrelease.yaml
@@ -22,19 +22,15 @@ spec:
           app:
             image:
               repository: docker.io/diegosouzapw/omniroute
-              # On `next` for a specific upstream fix, not for novelty: 3.8.49
-              # never clears the last-known-good-provider pin when its target
-              # starts failing, so every request re-selects the same exhausted
-              # model instead of failing over (upstream #10034, merged
-              # 2026-08-13 -- observed here as omniroute re-picking a dry
-              # antigravity model until it 503'd). No tagged release carries it;
-              # `main` was built 04:05Z that day, three hours before the merge.
-              # Source is public (github.com/diegosouzapw/OmniRoute, default
-              # branch release/v3.8.50) so this is auditable -- move to the
-              # v3.8.50 tag once it ships -- Renovate cannot prompt that, since
-              # `next` is not a version it can compute an update from; it will
-              # only offer digest bumps that walk this further along the branch.
-              # Digest-pinned so the branch moving does not silently move us.
+              # On `next` for one upstream fix, not for novelty: 3.8.49 never
+              # clears the last-known-good-provider pin when its target starts
+              # failing, so every request re-selects the same exhausted model
+              # instead of failing over (upstream #10034). No tagged release
+              # carries it yet; move to the v3.8.50 tag once it ships.
+              # Renovate cannot prompt that move -- `next` is not a version it
+              # can diff against, so it will only ever offer digest bumps that
+              # walk this further along the branch. Digest-pinned so the branch
+              # moving does not silently move us.
               tag: next@sha256:2dd8dee4c5247c372af2ebbdfb98d72b4abacca77a07dd41aa6de6aa77e527cc
             env:
               TZ: ${TIMEZONE}

--- a/kubernetes/apps/ai/omniroute/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/omniroute/app/helmrelease.yaml
@@ -31,7 +31,10 @@ spec:
               # `main` was built 04:05Z that day, three hours before the merge.
               # Source is public (github.com/diegosouzapw/OmniRoute, default
               # branch release/v3.8.50) so this is auditable -- move to the
-              # v3.8.50 tag once it ships. Digest-pinned so Flux re-pulls.
+              # v3.8.50 tag once it ships -- Renovate cannot prompt that, since
+              # `next` is not a version it can compute an update from; it will
+              # only offer digest bumps that walk this further along the branch.
+              # Digest-pinned so the branch moving does not silently move us.
               tag: next@sha256:2dd8dee4c5247c372af2ebbdfb98d72b4abacca77a07dd41aa6de6aa77e527cc
             env:
               TZ: ${TIMEZONE}


### PR DESCRIPTION
The 2026-08-17 AI-gateway outage had three independent causes. All three are addressed here, and all three are **already live-patched on the cluster** (`ks/litellm` and `ks/omniroute` are suspended) — merging this makes the running state match git.

## What broke

1. omniroute 3.8.49 never cleared its last-known-good-provider pin when the pinned target started failing, so every request re-selected the same exhausted free-tier model instead of failing over.
2. litellm's fallback chain pointed at `qwen-3.6-fast`, whose backing deployment was scaled to 0 — a single-entry chain aimed at nothing.
3. Nothing alerted. Measured ~60% failure rate over 6h (64 distinct failures / 107 requests) before it was noticed by hand.

## Changes

- **omniroute → `next` (v3.8.50), digest-pinned.** Carries upstream #10034, the LKGP-clear fix; no tagged release has it yet. Live result: candidate pool went from 2 candidates / 7 models / 14 targets to **4 candidates / 21 models / 19 targets**, and two previously-errored accounts cleared themselves.
- **Fallback chain trimmed to one deep** (`omniroute: ["qwen-3.8-fast"]`). A second `qwen35-2b` tier was tried and removed: llama.cpp splits `contextSize` across `parallelSlots`, so it served a 16384-token window and rejected every review-sized payload — converting a 503 into a 400. Widening it costs iGPU-node RAM not worth spending on a last resort.
- **New `PrometheusRule`** with three rules, metric names taken from litellm's live `/metrics`:
  - `LiteLLMRequestsFailing` (critical, 10m) — requests failing outright
  - `LiteLLMFallbackTargetUnavailable` (warning, 15m) — the fallback itself is failing, i.e. no tier left
  - `LiteLLMPrimaryDegraded` (warning, 30m) — fallbacks succeeding often, so the primary is quietly sick

## Verification (live)

- vmalert has all 3 rules loaded, `health=ok`
- `x-omniroute-version: 3.8.50`
- 0 litellm errors post-cutover; 3/3 end-to-end requests OK
- All 4 PR reviews that had been failing (#4515–#4518) now SUCCESS

## Note

3.8.50 changed `/v1/models` to require auth (`sk-omniroute-noauth` now gets `invalid_api_key` there). `/v1/chat/completions` still accepts it, so litellm is unaffected — but anything enumerating models against omniroute would need a real key.

## After merge

    flux resume kustomization litellm -n ai
    flux resume kustomization omniroute -n ai

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added monitoring alerts for critical request failures, fallback-backend unavailability, fallback-target failures, and sustained primary-model degradation.
* **Bug Fixes**
  * Updated Omniroute with an upstream provider failover fix.
  * Removed an incompatible fallback model to improve fallback reliability.
* **Operations**
  * Documented the requirement for the remaining fallback deployment to stay available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->