### PR TITLE
feat(vllm): nightly rocm + gfx1201 AITER, 16 GiB KV L2, reasoning_effort medium

### DIFF
--- a/kubernetes/apps/ai/litellm/instance/models.yaml
+++ b/kubernetes/apps/ai/litellm/instance/models.yaml
@@ -22,6 +22,12 @@ spec:
       timeout: 1800
       stream_timeout: 1800
       num_retries: 0
+      # Template default is xhigh; medium is the better quality/latency point for
+      # most turns. Only affects this alias -- qwen-3.8-fast sets enable_thinking
+      # false, and the template gates effort behind thinking.
+      extra_body:
+        chat_template_kwargs:
+          reasoning_effort: medium
   info:
     mode: chat
     # maxModelLen (221612) minus maxOutputTokens; re-derive if that changes,

--- a/kubernetes/apps/ai/llmkube/models/qwen38-27b-vllm.yaml
+++ b/kubernetes/apps/ai/llmkube/models/qwen38-27b-vllm.yaml
@@ -232,11 +232,13 @@ spec:
     - name: kv-offload
       persistentVolumeClaim:
         claimName: qwen38-27b-vllm-kv-offload
-    # The CPU offload tier mmaps 8Gi here; the 64M default EFAULTs on pre-fault.
+    # The CPU offload tier mmaps cpu_bytes_to_use here; the 64M default
+    # EFAULTs on pre-fault, and the connector needs this strictly larger
+    # than that value. 18Gi leaves 2Gi of margin over the 16Gi tier.
     - name: dshm
       emptyDir:
         medium: Memory
-        sizeLimit: 10Gi
+        sizeLimit: 18Gi
   extraVolumeMounts:
     - name: compile-cache
       mountPath: /cache
@@ -294,6 +296,11 @@ spec:
     # config: 2.81 GB.
     - --kv-cache-memory
     - "7516192768"
+    # CPU tier raised 8 -> 16 GiB: measured 8.0G of the 10Gi /dev/shm in use
+    # (80% full), i.e. the tier was saturated, not idle. At the ~33.7 B/token
+    # this config yields (7 GiB GPU pool = 223,172 tokens), 8 GiB held only
+    # ~1.1x the GPU pool; 16 GiB holds ~2.3x. Paid from the pod's own
+    # reservation -- it requests 32Gi and was measured using 14.8Gi total.
     # Hierarchical KV cache: CPU tier (matches SGLang's --hicache-ratio sizing
     # philosophy) + fs tier (SGLang's file backend analogue). Ported from
     # qwen36-27b-vllm.yaml, WITHOUT that config's --language-model-only —
@@ -301,7 +308,7 @@ spec:
     # so it must stay loaded even though that costs some context headroom.
     - --kv-transfer-config
     - >-
-      {"kv_connector":"OffloadingConnector","kv_role":"kv_both","kv_connector_extra_config":{"spec_name":"TieringOffloadingSpec","cpu_bytes_to_use":8589934592,"secondary_tiers":[{"type":"fs","root_dir":"/kvoffload","locality":"LOCAL"}]}}
+      {"kv_connector":"OffloadingConnector","kv_role":"kv_both","kv_connector_extra_config":{"spec_name":"TieringOffloadingSpec","cpu_bytes_to_use":17179869184,"secondary_tiers":[{"type":"fs","root_dir":"/kvoffload","locality":"LOCAL"}]}}
   nodeSelector:
     amd.com/gpu: "true"
   podSecurityContext:

--- a/kubernetes/apps/ai/llmkube/models/qwen38-27b-vllm.yaml
+++ b/kubernetes/apps/ai/llmkube/models/qwen38-27b-vllm.yaml
@@ -168,7 +168,10 @@ spec:
   # translates this to --max-num-seqs for the vllm runtime.
   parallelSlots: 16
   bindAddress: 0.0.0.0
-  image: vllm/vllm-openai-rocm:v0.27.1@sha256:bb44b39aea26798cce43030a98bf48efd0322ca7147367db86e38b96bd80f0e7
+  # Nightly, pinned to the commit-tagged build rather than the rolling
+  # `nightly` tag so the digest and the vLLM commit stay traceable to each
+  # other. v0.27.1 is the newest release and predates gfx1201 AITER support.
+  image: vllm/vllm-openai-rocm:nightly-aa9903490c616dc6871e5acc62cec7bb1e5e9434@sha256:d16558a215144a1a90f3ecfa377559fac4143e74424fa7c4fab2020dd947eb9e
   modelCache:
     claimName: qwen38-27b-vllm-model-cache
   vllmConfig:
@@ -202,8 +205,13 @@ spec:
     # sane value. The media-reserve math lives with that flag, not here.
     gpuMemoryUtilization: 0.875
   env:
+    # gfx1201 gained AITER Triton paths in vLLM #43615 (merged 2026-08-03);
+    # every release up to v0.27.1 gated them behind MI3xx and fell back to
+    # generic ROCm. The FP8 linear kernels it adds do not apply to this
+    # W4A16 checkpoint -- what applies is the gfx12 attention-backend
+    # reorder (ROCM_AITER_UNIFIED_ATTN first) and the GDN linear-attn path.
     - name: VLLM_ROCM_USE_AITER
-      value: "0"
+      value: "1"
     - name: HIP_VISIBLE_DEVICES
       value: "0"
     - name: ROCR_VISIBLE_DEVICES

--- a/kubernetes/apps/ai/llmkube/models/qwen38-27b-vllm.yaml
+++ b/kubernetes/apps/ai/llmkube/models/qwen38-27b-vllm.yaml
@@ -168,9 +168,8 @@ spec:
   # translates this to --max-num-seqs for the vllm runtime.
   parallelSlots: 16
   bindAddress: 0.0.0.0
-  # Nightly, pinned to the commit-tagged build rather than the rolling
-  # `nightly` tag so the digest and the vLLM commit stay traceable to each
-  # other. v0.27.1 is the newest release and predates gfx1201 AITER support.
+  # Commit-tagged nightly, not the rolling `nightly` tag.
+  # v0.27.1 is the newest release and predates gfx1201 AITER support.
   image: vllm/vllm-openai-rocm:nightly-aa9903490c616dc6871e5acc62cec7bb1e5e9434@sha256:d16558a215144a1a90f3ecfa377559fac4143e74424fa7c4fab2020dd947eb9e
   modelCache:
     claimName: qwen38-27b-vllm-model-cache
@@ -205,11 +204,9 @@ spec:
     # sane value. The media-reserve math lives with that flag, not here.
     gpuMemoryUtilization: 0.875
   env:
-    # gfx1201 gained AITER Triton paths in vLLM #43615 (merged 2026-08-03);
-    # every release up to v0.27.1 gated them behind MI3xx and fell back to
-    # generic ROCm. The FP8 linear kernels it adds do not apply to this
-    # W4A16 checkpoint -- what applies is the gfx12 attention-backend
-    # reorder (ROCM_AITER_UNIFIED_ATTN first) and the GDN linear-attn path.
+    # gfx1201 AITER Triton paths (vLLM #43615). Its FP8 linear kernels do
+    # not apply to this W4A16 checkpoint; the attention-backend reorder
+    # (ROCM_AITER_UNIFIED_ATTN first) and the GDN linear-attn path do.
     - name: VLLM_ROCM_USE_AITER
       value: "1"
     - name: HIP_VISIBLE_DEVICES
@@ -232,9 +229,8 @@ spec:
     - name: kv-offload
       persistentVolumeClaim:
         claimName: qwen38-27b-vllm-kv-offload
-    # The CPU offload tier mmaps cpu_bytes_to_use here; the 64M default
-    # EFAULTs on pre-fault, and the connector needs this strictly larger
-    # than that value. 18Gi leaves 2Gi of margin over the 16Gi tier.
+    # The CPU offload tier mmaps cpu_bytes_to_use (16Gi) here; the 64M
+    # default EFAULTs on pre-fault. 18Gi = 16Gi + 2Gi margin.
     - name: dshm
       emptyDir:
         medium: Memory
@@ -296,16 +292,12 @@ spec:
     # config: 2.81 GB.
     - --kv-cache-memory
     - "7516192768"
-    # CPU tier raised 8 -> 16 GiB: measured 8.0G of the 10Gi /dev/shm in use
-    # (80% full), i.e. the tier was saturated, not idle. At the ~33.7 B/token
-    # this config yields (7 GiB GPU pool = 223,172 tokens), 8 GiB held only
-    # ~1.1x the GPU pool; 16 GiB holds ~2.3x. Paid from the pod's own
-    # reservation -- it requests 32Gi and was measured using 14.8Gi total.
     # Hierarchical KV cache: CPU tier (matches SGLang's --hicache-ratio sizing
     # philosophy) + fs tier (SGLang's file backend analogue). Ported from
     # qwen36-27b-vllm.yaml, WITHOUT that config's --language-model-only —
     # Hermes' auxiliary.vision block actively uses this model's vision tower,
     # so it must stay loaded even though that costs some context headroom.
+    # CPU tier 16Gi: 8Gi measured 80% full in production, i.e. saturated.
     - --kv-transfer-config
     - >-
       {"kv_connector":"OffloadingConnector","kv_role":"kv_both","kv_connector_extra_config":{"spec_name":"TieringOffloadingSpec","cpu_bytes_to_use":17179869184,"secondary_tiers":[{"type":"fs","root_dir":"/kvoffload","locality":"LOCAL"}]}}
@@ -319,8 +311,8 @@ spec:
       type: Unconfined
   resources:
     cpu: "2"
-    # Measured steady state is 13.3Gi (8Gi of it the shm offload tier, which is
-    # tmpfs and so charged here). Kept at 32Gi for the model-load spike rather
+    # Steady state was 13.3Gi with an 8Gi shm offload tier (tmpfs, so charged
+    # here); the 16Gi tier projects ~21Gi. Kept at 32Gi for the load spike rather
     # than trimmed to the steady state -- an OOMKill mid-load throws away the
     # compile cache this node takes ~40min to rebuild.
     memory: 32Gi


### PR DESCRIPTION
Three independent changes on `qwen38-27b-vllm`, one commit each so any can be reverted alone.

## Image: v0.27.1 → nightly-aa99034

| | |
|---|---|
| digest | `sha256:d16558a215144a1a90f3ecfa377559fac4143e74424fa7c4fab2020dd947eb9e` |
| built | 2026-08-18T05:16:35Z |
| range | 630 commits since v0.27.1 |

v0.27.1 is the newest release tag; there is no v0.28. Pinned to the commit-tagged build, not the rolling `nightly`, so digest and vLLM commit stay traceable.

Relevant commits in range:

| PR | why it matters here |
|---|---|
| #43615 | first build exposing AITER Triton paths on gfx120x; adds tuned **gfx1201** shapes. Earlier builds gated these behind MI3xx and fell back to generic ROCm on the R9700 |
| #50068 | `[Model] Enable Qwen3.8 for AMD Rocm` — this exact model |
| #50607 | torch 2.12 / triton 3.7 — reaches the W4A16 kernels this config runs |

## AITER: 0 → 1

Enabled by #43615. Scope is narrower than the PR title suggests: most of it is **FP8** linear kernels, and this checkpoint is **W4A16 compressed-tensors**, so it does not touch `_triton_w4a16_skinny_fmt_kernel` — the measured decode bottleneck. What does apply is the gfx12 attention-backend reorder (`ROCM_AITER_UNIFIED_ATTN` first) and the GDN linear-attn path.

## KV L2: 8 → 16 GiB

The tier was **saturated, not idle** — `/dev/shm` measured 8.0G of 10Gi (80%) on the live pod.

| | 8 GiB | 16 GiB |
|---|---|---|
| tokens held (~33.7 B/tok) | ~255k | ~510k |
| vs 223,172-token GPU pool | 1.1x | 2.3x |

`dshm` 10Gi → 18Gi because the connector EFAULTs unless `/dev/shm` strictly exceeds `cpu_bytes_to_use`.

Costs no scheduling headroom: pod requests 32Gi, measured using 14.8Gi (6.8 RSS + 8.0 shm). control-1 sits at 52.3/59.3 Gi of requests — untouched.

## reasoning_effort: medium

Template default is `xhigh`. Only affects `qwen-3.8`; `qwen-3.8-fast` sets `enable_thinking: false` and the template gates effort behind thinking.

## Not measured

The arms harness aborted at its VRAM gate before reaching the nightly arms, so **none of the vLLM-side changes carry a benchmark**. Nightly + AITER land together, so a regression cannot be attributed between them without a follow-up A/B.

## Deliberately excluded

- **`maxNumBatchedTokens` 4096 → 8192** — doubles peak prefill activation memory against ~2 GB free VRAM shared with Jellyfin transcoding. Needs the VRAM gate, not a merge.
- **philbert gs128 quant swap** — pending the quality baseline currently running.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Improved Qwen 3.8 response reasoning by setting a medium reasoning effort.
  - Updated the vLLM runtime with performance enhancements for ROCm hardware.
  - Increased shared memory and CPU cache capacity to support larger workloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
