### PR TITLE
feat(network): add eep error pages

### DIFF
--- a/kubernetes/apps/network/envoy-gateway/app/eep.yaml
+++ b/kubernetes/apps/network/envoy-gateway/app/eep.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/gateway.envoyproxy.io/envoyextensionpolicy_v1alpha1.json
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: EnvoyExtensionPolicy
+metadata:
+  name: eep
+spec:
+  targetSelectors:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+  wasm:
+    - name: eep
+      rootID: eep
+      code:
+        type: Image
+        image:
+          url: oci://ghcr.io/ishioni/eep:0.2.1@sha256:0d5b4e3f6fb16b82c05e03c5cce88dd6c283221ca4bb8e1f58ba4b47f0fdffeb
+      config:
+        theme: connection
+        showDetails: false
+        locale: auto
+        logLevel: warn
+        filterCodes: [404, "500-599"]
+      failOpen: true

--- a/kubernetes/apps/network/envoy-gateway/app/envoy.yaml
+++ b/kubernetes/apps/network/envoy-gateway/app/envoy.yaml
@@ -228,6 +228,8 @@ spec:
   http2:
     onInvalidMessage: TerminateStream
   http3: {}
+  connection:
+    bufferLimit: 1Mi
   targetSelectors:
     - group: gateway.networking.k8s.io
       kind: Gateway

--- a/kubernetes/apps/network/envoy-gateway/app/kustomization.yaml
+++ b/kubernetes/apps/network/envoy-gateway/app/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 
 resources:
   - certificate.yaml
+  - eep.yaml
   - envoy.yaml
   - grafanadashboard.yaml
   - helmrelease.yaml


### PR DESCRIPTION
## Summary

- add EEP 0.2.1 as an Envoy Gateway Wasm extension for internal and external HTTP gateways
- replace 404 and 5xx responses with localized connection-themed error pages
- raise the shared Envoy response buffer to 1 MiB and fail open to preserve ingress availability

## Validation

- `mise exec -- kustomize build kubernetes/apps/network/envoy-gateway/app/` with targeted policy assertions
- `mise exec -- flate test all` (284 resources passed; one unrelated existing external-dns values warning)
- `mise exec -- bash .agents/skills/pr-review/scripts/validate-pr.sh`
- independent spec-compliance and quality reviews

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added connection-focused display enhancements with automatic locale detection.
  * Added warnings for unsuccessful requests, including not-found and server-error responses.
  * Configured the extension to continue operating when it cannot be loaded.
* **Improvements**
  * Increased the HTTP connection buffer limit to 1 MiB for improved handling of larger requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->