### PR TITLE
feat(vllm): raise qwen-3.8 context ceiling to 246944

### DIFF
--- a/kubernetes/apps/ai/litellm/instance/models.yaml
+++ b/kubernetes/apps/ai/litellm/instance/models.yaml
@@ -30,9 +30,9 @@ spec:
           reasoning_effort: medium
   info:
     mode: chat
-    # maxModelLen (221612) minus maxOutputTokens; re-derive if that changes,
+    # maxModelLen (246944) minus maxOutputTokens; re-derive if that changes,
     # nothing enforces it across the two CRDs.
-    maxInputTokens: 213420
+    maxInputTokens: 238752
     maxOutputTokens: 8192
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/litellm.home-operations.com/litellmmodel_v1alpha1.json
@@ -64,8 +64,8 @@ spec:
           enable_thinking: false
   info:
     mode: chat
-    # 221612 - 8192, as above.
-    maxInputTokens: 213420
+    # 246944 - 8192, as above.
+    maxInputTokens: 238752
     maxOutputTokens: 8192
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/litellm.home-operations.com/litellmmodel_v1alpha1.json

--- a/kubernetes/apps/ai/llmkube/models/qwen38-27b-vllm.yaml
+++ b/kubernetes/apps/ai/llmkube/models/qwen38-27b-vllm.yaml
@@ -188,18 +188,27 @@ spec:
     # 112K and p90 prompts are 20K, and normal concurrency is unaffected
     # because KV is paged and allocated on demand.
     #
-    # A decode-performance ceiling, NOT a pool-matching value: the pool is
-    # 287,159 tokens (1.30x this cap) and that margin is deliberate. DO NOT
-    # raise this toward the model's 262,144 limit -- 262,144 measured ~half the
-    # single-stream decode (15.8-17.1 vs 29.7-32.0 tok/s), confirmed by exact
-    # revert; mechanism unexplained. Production prompts are 47-56K anyway.
+    # A decode-performance ceiling, NOT a pool-matching value. Single-stream
+    # decode falls off a cliff once the pool/cap ratio drops below ~1.17x;
+    # bisected 2026-08-19, two concsweeps per point, run-after-restart discarded:
+    #
+    #   cap      pool     ratio  conc-1 tok/s  verdict
+    #   241,878  288,061  1.19x  31.46         fast
+    #   246,944  288,493  1.17x  31.65         fast   <- this value
+    #   249,477  288,702  1.16x  25.12 / 1.95  UNSTABLE, do not ship
+    #   252,011  288,012  1.14x  18.93         slow
+    #   262,144  --       1.10x  15.8-17.1     slow
+    #
+    # Mechanism unexplained; only conc-1 cliffs, conc-16 stays ~185 throughout.
+    # DO NOT raise past this without re-running the bisect -- the next step up
+    # measured unstable, not merely slower. Production prompts are 47-56K.
     #
     # If the pool ever shrinks below this cap the engine refuses to start
     # rather than silently truncating. Re-read "GPU KV cache size" from the
     # boot log after ANY of: --kv-cache-memory, the mamba cache dtypes, the
     # attention block size, or a vLLM image bump -- Renovate raises that last
     # one as a digest-bump PR, so re-check this value when reviewing it.
-    maxModelLen: 221612
+    maxModelLen: 246944
     kvCacheDtype: fp8_e4m3
     # Confirmed working on this hybrid Mamba/GDN model (~27% hit rate under
     # real traffic on the sibling qwen36 config).


### PR DESCRIPTION
Bisected the single-stream decode cliff between the shipped 221612 and the model's 262144 training limit. Two concsweeps per point; the run immediately after a pod restart is discarded.

| cap | pool | ratio | conc-1 tok/s | conc-8 | conc-16 | verdict |
|---|---|---|---|---|---|---|
| 221,612 | 287,159 | 1.30x | 29.7-32.0 | ~99 | ~184 | fast (was shipped) |
| 241,878 | 288,061 | 1.19x | 31.46 | 97.89 | 183.04 | fast |
| **246,944** | 288,493 | **1.17x** | **31.65** | 101.10 | 185.42 | **fast — shipped** |
| 249,477 | 288,702 | 1.16x | 25.12 / 1.95 | 88.86 | 184.53 | unstable, not shipped |
| 252,011 | 288,012 | 1.14x | 18.93 | 84.94 | 181.87 | slow |
| 262,144 | — | ~1.10x | 15.8-17.1 | — | — | slow |

+25,332 tokens of usable context (+11.4%) at no measured decode cost.

249477 is excluded deliberately: its two runs read 25.12 and 1.95, neither classifiable against the pre-set thresholds (>=27 fast, <=20 slow). Unstable, not merely slower.

Only conc-1 cliffs; conc-16 holds ~185 across the whole range. Mechanism unexplained.

litellm `maxInputTokens` re-derived on both qwen-3.8 entries to hold `maxInputTokens + maxOutputTokens == maxModelLen` (238752 + 8192 = 246944). Nothing enforces that across the two CRDs.

Live config already patched to 246944; `llmkube-models` Kustomization is suspended and needs `flux resume kustomization -n ai llmkube-models` after merge.