### PR TITLE
fix(network): pin eep module digest

### DIFF
--- a/kubernetes/apps/network/envoy-gateway/app/eep.yaml
+++ b/kubernetes/apps/network/envoy-gateway/app/eep.yaml
@@ -14,7 +14,7 @@ spec:
       code:
         type: Image
         image:
-          url: oci://ghcr.io/ishioni/eep:0.2.1@sha256:0d5b4e3f6fb16b82c05e03c5cce88dd6c283221ca4bb8e1f58ba4b47f0fdffeb
+          url: oci://ghcr.io/ishioni/eep:0.2.1@sha256:ca0a10167c543203acefa196e9e9123ec8bca8529e872b9301249824f28b33a0
       config:
         theme: connection
         showDetails: false


### PR DESCRIPTION
## Summary

- pin EEP to the AMD64 module digest reported by Envoy Gateway
- replace the OCI index digest that causes `EnvoyExtensionPolicy/eep` to be rejected

## Root cause

Envoy Gateway downloads the AMD64 Wasm module and validates its checksum (`sha256:ca0a…`) against the digest in the URL. The original manifest used the multi-platform OCI index digest (`sha256:0d5b…`), producing a deterministic checksum mismatch on every Gateway.

## Validation

- live policy status reproduced `Accepted=False`, reason `Invalid`, with expected module checksum `ca0a101…`
- targeted Kustomize render assertion passed
- `mise exec -- bash .agents/skills/pr-review/scripts/validate-pr.sh` passed Flux/flate and shellcheck phases