### PR TITLE
fix(vllm): correct qwen-3.8 spec.files for the philbert layout

### DIFF
--- a/kubernetes/apps/ai/llmkube/models/qwen38-27b-vllm.yaml
+++ b/kubernetes/apps/ai/llmkube/models/qwen38-27b-vllm.yaml
@@ -131,20 +131,18 @@ spec:
   format: safetensors
   quantization: compressed-tensors
   refreshPolicy: OnChange
+  # MUST match the layout of `source` above -- the init container fetches exactly
+  # these names and exits 1 on a 404. philbert ships one model.safetensors, not
+  # cyankiwi's 5 shards, and folds merges/vocab into tokenizer.json.
   files:
-    - model-00001-of-00005.safetensors
-    - model-00002-of-00005.safetensors
-    - model-00003-of-00005.safetensors
-    - model-00004-of-00005.safetensors
-    - model-00005-of-00005.safetensors
+    - model.safetensors
+    - model-mtp.safetensors
     - model.safetensors.index.json
     - config.json
     - generation_config.json
     - tokenizer.json
     - tokenizer_config.json
     - chat_template.jinja
-    - merges.txt
-    - vocab.json
     - preprocessor_config.json
     - video_preprocessor_config.json
   hardware:


### PR DESCRIPTION
#4551 moved `source` to philbert440 but left `spec.files` listing cyankiwi's layout. The `model-downloader` init container fetches exactly those names and `exit 1`s on a 404, so the pod crashlooped (`Init:Error`, 5 restarts) as soon as the Deployment was regenerated.

Latent until now: the running Deployment carried a correct `MODEL_FILES` env from an earlier resolution, and the old cyankiwi weights on disk let the downloader's "kept cached copy" branch mask the wrong list. Resuming the Kustomization regenerated the Deployment and removing the stale weights took away the fallback.

Verified against the pinned revision `7908d42a`:

| file | content-length |
|---|---|
| model.safetensors | 18,698,467,264 |
| model-mtp.safetensors | 849,400,424 |
| model.safetensors.index.json | 205,894 |
| config.json | 20,883 |
| generation_config.json | 214 |
| tokenizer.json | 12,809,320 |
| tokenizer_config.json | 17,928 |
| chat_template.jinja | 8,952 |
| preprocessor_config.json | 390 |
| video_preprocessor_config.json | 385 |

Removed, all 404 at that revision: `model-0000{1..5}-of-00005.safetensors`, `merges.txt`, `vocab.json` (philbert folds merges/vocab into `tokenizer.json`).

Deleting and recreating the Model CR does not help — the operator reproduces the list straight from `spec.files`, so the fix has to be in git.