### PR TITLE
fix(network): raise envoy HTTP/2 stream window

### DIFF
--- a/kubernetes/apps/network/envoy-gateway/app/envoy.yaml
+++ b/kubernetes/apps/network/envoy-gateway/app/envoy.yaml
@@ -226,6 +226,7 @@ spec:
       trustedCIDRs:
         - ${POD_CIDR}
   http2:
+    initialStreamWindowSize: 1Mi
     onInvalidMessage: TerminateStream
   http3: {}
   connection:


### PR DESCRIPTION
## Summary

- set Envoy HTTP/2 initial stream window to 1 MiB
- allow EEP’s 67 KiB error page to be delivered to HTTP/2 clients

## Root cause

EEP worked over HTTP/1.1, but HTTP/2 streams reset with `INTERNAL_ERROR`. Envoy access logs reported `response_payload_too_large`: the generated 67,043-byte page exceeded the default 64 KiB HTTP/2 stream window. `connection.bufferLimit` only controls socket-level buffering. Current EEP guidance also requires `http2.initialStreamWindowSize`.

## Validation

- reproduced HTTP/2 failure and `response_payload_too_large` in live Envoy access logs
- targeted Kustomize render assertion for `initialStreamWindowSize: 1Mi`
- `mise exec -- bash .agents/skills/pr-review/scripts/validate-pr.sh` passed Flux/flate and shellcheck phases