### PR TITLE
feat(litellm): cap per-deployment concurrency on the shared GPU aliases

### DIFF
--- a/kubernetes/apps/ai/litellm/instance/models.yaml
+++ b/kubernetes/apps/ai/litellm/instance/models.yaml
@@ -21,6 +21,11 @@ spec:
     additional:
       timeout: 1800
       stream_timeout: 1800
+      # Tail guard against a runaway client, not a tuning knob: the pool holds
+      # 288,493 KV tokens against 47-56K prompts, i.e. ~5 concurrent full-size
+      # requests. Queues, does not reject. PER-DEPLOYMENT -- the semaphore keys
+      # on model_info.id, so this and qwen-3.8-fast's 5 let the GPU see 10.
+      max_parallel_requests: 5
       num_retries: 0
       # Template default is xhigh; medium is the better quality/latency point for
       # most turns. Only affects this alias -- qwen-3.8-fast sets enable_thinking
@@ -52,6 +57,8 @@ spec:
       # the shared prefill rate drops below what 600s covers (2026-07-07).
       timeout: 900
       stream_timeout: 900
+      # Second half of the per-deployment cap; rationale on qwen-3.8 above.
+      max_parallel_requests: 5
       num_retries: 0
       # Non-thinking instruct-mode sampling — matches Qwen3.8's model card
       # exactly (temperature/top_p/presence_penalty), same as Qwen3.6's.


### PR DESCRIPTION
`qwen-3.8` and `qwen-3.8-fast` both route to `qwen38-27b-vllm`. hermes is the only consumer with a self-imposed limit; nothing bounds the tail.

| fact | value | source |
|---|---|---|
| KV pool | 288,493 tokens | `--kv-cache-memory 9663676416` |
| production prompt size | 47-56K | measured |
| implied concurrency ceiling | ~5 full-size requests | pool / prompt |
| preemptions after capping hermes at 5 sessions | 5, then flat | `vllm:num_preemptions_total` |
| semaphore scope | per-deployment | `client_initalization_utils.py:18` keys on `model_info.id` |

litellm cannot cap tokens, so this caps requests as a proxy. `max_parallel_requests` is an `asyncio.Semaphore` used via `async with` — it queues, it does not reject.

Per-deployment, not per model group: both aliases carry 5, so the GPU can still see 10. Raising either without re-deriving against the pool reintroduces the thrash.

Applied live and verified: `max_parallel_requests = 5` on both deployments via `/model/info`, operator `Reconciled`, no pod restart required.

Baseline at apply time: `num_preemptions_total` 0, `num_requests_running` 0, `num_requests_waiting` 0.
Revert criterion: queueing latency rises without a matching drop in preemptions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Added concurrency limits for the qwen-3.8 and qwen-3.8-fast models.
  * Requests are now capped at five simultaneous requests per deployment for improved stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->