### PR TITLE
fix(ai): floor memini auto-injection recall score at 0.5

### DIFF
--- a/kubernetes/apps/ai/hermes/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/hermes/app/helmrelease.yaml
@@ -53,6 +53,8 @@ spec:
               # own bypass detection doesn't recognise a containerd pod. Value matches the one
               # it injects itself.
               AGENT_BROWSER_ARGS: "--no-sandbox,--disable-dev-shm-usage"
+              # Floor for memini auto-injection: sub-0.5 composite scores are fragment noise (measured 2026-08-20).
+              MEMINI_INJECT_RECALL_MIN_SCORE: "0.5"
             envFrom:
               - secretRef:
                   name: hermes-secret


### PR DESCRIPTION
Adds MEMINI_INJECT_RECALL_MIN_SCORE 0.5 to the hermes HelmRelease env block (+2 lines, 1 file).

Why: measured 2026-08-20 across 14 representative queries (112 hits) - about 25% of auto-injected memories score below 0.5 (fragment noise: raw turn echoes) while useful memories sit at 0.7-1.0 (median 0.71). A 0.5 floor on the composite recall score trims the bottom quartile of injected context with no useful-recall loss. Recall latency is unaffected (p50=5ms, p90=35ms).

The plugin reads MEMINI_INJECT_RECALL_MIN_SCORE (env wins over the server default; the server enforces it via min_rank_score). The other MEMINI_* vars live in the SOPS-encrypted hermes-secret; putting this one in the HelmRelease env block keeps the tuning visible and reversible without touching the secret.

Validation: validate-pr.sh passes (exit 0, no new warnings from this diff); YAML parses and the entry reads back as 0.5.

Card: hermes-memini-recall-floor