### PR TITLE
fix(renovate): track the Talos release instead of the retired installer image

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -98,8 +98,8 @@
       minimumGroupSize: 2
     },
     {
-      // installer image (talosupgrade.yaml) + talosctl via github-releases (image-pull.yaml)
-      // all track the same Talos release — one PR instead of two
+      // talosupgrade.yaml, the flate workflow and the mise talosctl pin all track the
+      // same Talos release — one PR instead of three
       description: "Talos Group",
       groupName: "talos",
       matchDatasources: ["docker", "github-releases"],

--- a/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
@@ -6,8 +6,9 @@ metadata:
   name: talos
 spec:
   talos:
-    # Tracks the Talos release, not ghcr.io/siderolabs/installer: that image stopped being
-    # published with releases as of v1.14, so a docker datasource would silently freeze here.
+    # Tracks the Talos release, not ghcr.io/siderolabs/installer: publication of that image
+    # stopped partway through the v1.14 cycle (alpha.0 still had it) once Image Factory became
+    # the default, so a docker datasource would silently freeze at the last tag it ever saw.
     # renovate: datasource=github-releases depName=siderolabs/talos
     version: v1.13.9
   policy:

--- a/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
@@ -6,7 +6,9 @@ metadata:
   name: talos
 spec:
   talos:
-    # renovate: datasource=docker depName=ghcr.io/siderolabs/installer
+    # Tracks the Talos release, not ghcr.io/siderolabs/installer: that image stopped being
+    # published with releases as of v1.14, so a docker datasource would silently freeze here.
+    # renovate: datasource=github-releases depName=siderolabs/talos
     version: v1.13.9
   policy:
     rebootMode: powercycle


### PR DESCRIPTION
**Stack 1 of 3.** Independent of the rest — this is wrong today regardless of the Talos migration.

`talosupgrade.yaml` tracked `ghcr.io/siderolabs/installer` via a `docker` datasource. Publication of that image stopped partway through the v1.14 cycle (alpha.0 still had it) once Image Factory became the default, so the datasource would stop seeing new tags and **silently freeze the pin at the last tag it ever saw** — no error, no PR, just no more Talos updates.

Now tracks the GitHub release, matching what `.github/workflows/flate.yaml` already does. Both stay in the existing "Talos Group" Renovate rule, so it remains one grouped PR.

No version change. No live impact.

## Stack

| | PR | State |
|---|---|---|
| 1 | **this** — Renovate datasource | ready |
| 2 | #4580 — replace talhelper with talosctl render | ready, based on 1 |
| 3a | #4585 — custom-kernel installer | ready, branches off 2 |
| 3b | #4583 — Talos v1.14.0-rc.1 bump | blocked, branches off 2 |

#4585 and #4583 both branch from #4580 and are **independent of each other** — neither depends on the other, so the merge order between them is free. `gh stack` #4584 tracks the linear part (1 → 2 → 3b); a linear stack cannot express the fork, so #4585 sits alongside rather than inside it.
