### PR TITLE
feat(talos): upgrade to v1.14.0-rc.1

### DIFF
--- a/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
@@ -10,7 +10,7 @@ spec:
     # stopped partway through the v1.14 cycle (alpha.0 still had it) once Image Factory became
     # the default, so a docker datasource would silently freeze at the last tag it ever saw.
     # renovate: datasource=github-releases depName=siderolabs/talos
-    version: v1.13.9
+    version: v1.14.0-rc.1
   policy:
     rebootMode: powercycle
   healthChecks:


### PR DESCRIPTION
> **DO NOT MERGE YET.** Preconditions below are not met. Merging rolls Talos across the control plane.

**Stack 3b of 4.** One line, but it carries the entire live blast radius of the Talos work — everything else in the stack is inert.

| | PR | State |
|---|---|---|
| 1 | #4582 — Renovate datasource | **merged** |
| 2 | #4580 — replace talhelper with talosctl render | ready |
| 3 | #4585 — custom-kernel installer | ready, based on 2 |
| 4 | **this** — Talos v1.14.0-rc.1 bump | blocked, based on 3 |

Merge bottom-up. This PR now sits on top of #4585 rather than beside it, because #4585 carries the control-2 fix that stops this PR reverting its kernel (blocker 1).

## Blockers

**1. It would silently revert control-2's custom kernel.** control-2 was upgraded out-of-band to `ghcr.io/tanguille/installer:v1.13.9-k7.1.9` (Linux 7.1.9 + rebuilt amdgpu). `talosctl upgrade` does not rewrite the machine config, so control-2 still advertises `factory.talos.dev/installer/1fd419…:v1.13.9`. Traced through tuppr 0.5.0 `buildTalosUpgradeImage`:

```go
if ext.Schematic != "" && !strings.HasSuffix(repo, "/"+ext.Schematic) { ... }  // skipped: custom imager emits no schematic
if ext.Schematic == "" && len(ext.Extensions) > 0 && looksLikeGenericInstaller(repo) { ... }  // skipped: a factory ref is not the generic repo
targetImage := fmt.Sprintf("%s:%s", repo, targetVersion)   // bare tag swap -> stock image, kernel gone
```

No error is raised. Confirmed against the node: control-2 reports `amdgpu`/`amd-ucode`/`nfsrahead` **plus `modules.dep 7.1.9-talos`**, which control-3 does not have.

**It is not "might" — merging this PR is the trigger.** tuppr currently reports all nodes up to date only because `findNextNodes` skips anything in `Status.CompletedNodes` *before* comparing versions. Changing the target version restarts the campaign and clears that list (`statusCompletedNodes: []string{}` on "New node detected, restarting upgrade"), so control-2 is re-evaluated, mismatches, and gets the tag swap. Verified against tuppr 0.5.0 source and the live cluster by two sessions independently.

**RESOLVED in #4585**, which is why this PR is now stacked on top of it rather than beside it. control-2's node file points at `ghcr.io/tanguille/installer/shared` with a matching `machine.nodeAnnotations` pin, so the tag swap yields a *custom* 1.14 image instead of the stock one. Both pieces are required: `getTargetVersion` prefers the node annotation over the CR, and without it the swap would request a tag that is never published. control-1 and control-3 are untouched and still resolve against the Factory.

Merging this PR **before** #4585 would reintroduce the silent revert, which is the reason for the stacking order.

**1b. The replacement image is PRIVATE — a separate blocker from "the tag exists".** GHCR treats a nested path as a distinct package from the parent repo, and it defaults to private on first push, inheriting nothing:

```
installer:v1.13.9-k7.1.9        anon: OK    ← public (what control-2 booted from)
installer/<nested>:<tag>        anon: FAIL  ← private
```

Our machine config carries **no registry credentials** (verified on the live node: zero entries), so a node cannot pull it. Pointing `.machine.install.image` at that ref means a failed pull at upgrade time.

The package needing the flip is **`ghcr.io/tanguille/installer/shared`**, which must be public before #4585 merges. It was originally named after the schematic *id*; that was abandoned because a content-addressed id moves whenever a schematic is edited, and each new id is a fresh package that starts private — the hazard documented in `talos/README.md`, but unfixable rather than merely documented. Naming by schematic *name* (`shared`, or the node name for a per-node override) keeps the package stable across schematic edits.

Still recurs per schematic: cutting control-1 over creates `installer/control-1`, private by default, needing its own flip.

> Method note, because it produced a false all-clear here: `crane manifest` and `crane digest` are **not** anonymity tests. They use the ambient `~/.docker/config.json`, which on this machine holds ghcr credentials. Test with `DOCKER_CONFIG` pointed at an empty directory, or request a token for the exact repository scope.

**2. control-1 has no out-of-band recovery — so upgrade it during the BMC recovery window.** The BMC on the hypervisor (192.168.0.27) is stuck in firmware flash mode: in-band KCS returns `0xD5`, and cold reset, web login and firmware upload are all refused. Recovery needs an AC power cycle, which gracefully shuts down TrueNAS and all three VMs, control-1 included. That host also sits at ~90C with a PROCHOT history.

Rather than treating those as two separate control-1 outages, **combine them**. The power cycle already requires someone physically at the machine, which is precisely the condition that makes upgrading control-1 safe — the objection was never the reboot itself, it was rebooting a thermally fragile node with no recovery path if it fails to come back. Hands-on presence removes that.

Sequence: upgrade control-2 and control-3 first (both are standalone Chuwi boxes, unaffected by the hypervisor), confirm the cluster is healthy on two upgraded nodes, then remove control-1's `tuppr.home-operations.com/version=v1.13.9` hold as part of the same maintenance window as the AC power cycle. One control-1 outage instead of two, and the riskiest node is upgraded with someone standing next to it.

**3. etcd quorum margin is zero.** 3-node etcd tolerates exactly one node down. Rebooting any node while control-1 is thermally fragile and remotely unrecoverable risks losing quorum with no recovery path.

**4. The OSD on the hypervisor makes any control-1 reboot a storage event.** `SSD_Pool/vm/ceph/osd` lives on 192.168.0.27, so control-1 carries both `osd.3` and `mon-c`. Measured exposure:

```
pools: size 2, min_size 1, failure domain host, 81 pgs all active+clean
ceph pg ls-by-osd 3  →  45 of 81 PGs
```

`min_size 1` means I/O does **not** block. But 45 PGs — 56% of the cluster — drop to a **single replica** for the duration. A fault on control-2's or control-3's OSD during that window is data loss, not a degraded-but-recoverable event. This is a property of `size=2` and is true of *any* control-1 reboot, including a routine Talos upgrade; it is not specific to the BMC window.

## Worth knowing before merging

Talos `v1.14.0-rc.1` ships **Linux 6.18.44** — exactly what control-1 and control-3 already run. This upgrade buys no kernel version. The 1.14 wins are config-level (`SecurityProfileConfig`, `FilesystemTrimConfig`, `CRICustomizationConfig`, …), which land in a later PR on top of the new render pipeline.

`control-1` currently carries `tuppr.home-operations.com/version=v1.13.9`, holding it back. Remove that annotation only once the BMC is recovered.

**5. Rook's control plane is wedged.** `rook-ceph-cluster` has been a failed HelmRelease since 2026-08-19T21:59Z with `failures: 76`, still looping a 5-minute rollback. The CephCluster states the cause verbatim: *"failed the ceph version check: ceph status in namespace rook-ceph is not healthy, refusing to upgrade."* So the CVE-2025-30156 auth warnings → `HEALTH_ERR` → Rook refuses its version gate → Helm upgrade and rollback both time out. Rebooting nodes while Rook cannot reconcile or self-remediate is the wrong order.

Side effect to clear at the same time: the looping rollback re-applies the older chart, so the live CR carries `ceph:v20.2.3` while git pins `v20.2.4`. Nothing has downgraded (Rook refuses), but the HelmRelease should be driven back to the git-desired state deliberately rather than left to race once health clears.

**6. control-1's disk pressure is a deliberate equilibrium, NOT a blocker.** Investigated rather than assumed, because `ImageGCFailed` at 82% looked alarming:

| | |
| --- | --- |
| imageFs used | **76 GB** — images are not the problem |
| `/var/openebs` | **323 GB**, of which `ai/qwen38-27b-vllm-kv-offload` alone is **278 GB** |
| PVC capacity | 128Gi — `openebs-hostpath` does not enforce it, so the store grew to 2.17× |
| free space | **90 GiB** |

The `kv-offload-guard` cronjob is free-space based, not size based: it holds a hard floor of 80Gi free and lets the KV store occupy everything above it, evicting oldest-first only when the floor is breached. Last run: `avail: 94594740K (floor: 83886080K) / above floor, nothing to do`. Working exactly as designed.

So the node sits at 82% *on purpose*, and `imageGCHighThresholdPercent: 70` can never be satisfied — the `ImageGCFailed` events are structural noise, not a warning, and image GC "freeing 0 bytes" is expected because only 76 GB of the 440 GB is images. Reclaiming below the GC threshold would mean destroying the prefix cache the guard exists to preserve.

90 GiB free against a ~162 MB installer image is ~570× headroom. `mon-c` does run on control-1 and shares the filesystem, so `MON_DISK_LOW` has the same root cause and is equally structural. Ceph's data plane is fine: 27/27 pods Running, all PVCs Bound, no `PG_DEGRADED`, no `OSD_DOWN`.

## Merge checklist

**Before merge**
- [x] ~~control-1 disk reclaimed~~ — not required, see blocker 6: 90 GiB free against a ~162 MB installer, and the 82% is a deliberate KV-guard equilibrium
- [ ] `rook-ceph-cluster` HelmRelease reconciling again, at the git-pinned `ceph:v20.2.4`
- [ ] Decision made on control-2: hold at `v1.13.9-k7.1.9`, or allow revert to stock
- [ ] `ghcr.io/tanguille/installer/shared` GHCR package flipped to **public** (separate from the tag existing — verify with `DOCKER_CONFIG` empty, not plain `crane`)
- [ ] Ceph shows no new PG/OSD degradation vs the recorded baseline
- [ ] #4580 and #4585 merged first

**Rollout, in order**
- [ ] control-2 and control-3 upgrade (independent of the hypervisor); verify each before the next
- [ ] control-1 hold annotation removed **during the BMC AC-power-cycle window**, with someone physically present

control-1's `tuppr.home-operations.com/version=v1.13.9` annotation stays until that window. Merging this PR with the annotation in place upgrades only control-2 and control-3, which is the intended first step.
