### PR TITLE
perf(vmcp): cap find_tool results at 3 tools

### DIFF
--- a/kubernetes/apps/ai/toolhive/config/virtualmcpservers.yaml
+++ b/kubernetes/apps/ai/toolhive/config/virtualmcpservers.yaml
@@ -93,3 +93,8 @@ spec:
       embeddingService: http://litellm.ai.svc.cluster.local/v1
       embeddingModel: vmcp-embedding
       embeddingServiceTimeout: *embeddingTimeout
+      # find_tool returns each match's FULL json schema, re-prefilled every
+      # later turn: measured 7,721 tok/turn over 339 turns. Default 8 bound
+      # only 2 of 11 stored calls (mean 5.91 returned); top 3 drops 48.9% of
+      # schema bytes.
+      maxToolsToReturn: 3


### PR DESCRIPTION
`find_tool` returns each match's full json schema, and that result then lives in conversation history and is re-prefilled on every later turn.

| fact | value | source |
|---|---|---|
| turn-weighted cost of find_tool results | **7,721 tok/turn** over 339 turns | 11 calls, mean 22,885 chars, `state.db` |
| for comparison, the entire system prompt | 5,016 tok | vLLM `/tokenize` |
| tools actually returned per call | 4,8,8,7,5,6,6,6,5,6,4 — mean 5.91 | parsed from stored results |
| calls where the default 8 was binding | 2 of 11 | same |
| schema bytes dropped by keeping top 3 | 48.9% | same |
| tool results as share of non-user carried chars | ~86% | 7d, 276.5M carried chars |

The default bound on only 2 of 11 calls, so the win is truncating the typical call rather than the outlier. Results are returned ranked by relevance, so keeping the top 3 preserves the ranking.

Context: this vLLM instance has a 288,493-token KV pool shared across all consumers. Admission is gated on the full input sequence fitting alongside in-flight reservations, so per-request footprint decides how many requests run concurrently rather than queue.

Verified live before opening: a `find_tool` call returned 2 tools at 840 tokens, against 6-7 tools at 1,609-2,082 tokens on the same gateway earlier. The `unified` rollout came up clean with the embedder healthy.

Break-even is roughly one extra `find_tool` per two searches, since a re-search appends a new carried result. Watching call counts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Reduced the number of tool schemas returned by each `find_tool` search to three, making search results more focused and efficient.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->