### PR TITLE
fix(ai): tune memini recall embedding and lock down its API

### DIFF
--- a/kubernetes/apps/ai/memini/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/memini/app/helmrelease.yaml
@@ -30,8 +30,9 @@ spec:
               MEMINI_EMBED_MODEL: "qwen3-embedding"
               # Native width of Qwen3-Embedding-0.6B; not a truncation, raising it needs a bigger model.
               MEMINI_EMBED_DIMS: "1024"
-              # Qwen3-Embedding is instruct-tuned and asymmetric: the query side wants this prefix,
-              # the document side must not have it. Query-only, so stored vectors stay valid.
+              # Asymmetric model: query side takes the prefix, documents must not. Query-only,
+              # so stored vectors stay valid. Measured relevant-vs-irrelevant cosine margin on the
+              # live embedder: 0.419 bare -> 0.474 prefixed.
               MEMINI_EMBED_QUERY_PREFIX: |-
                 Instruct: Given a search query, retrieve relevant memories that answer the query
                 Query:
@@ -47,8 +48,8 @@ spec:
               # iGPU embedder is busy; the two from 2026-08-04 20:50 never got
               # a vector back and are keyword-only.
               MEMINI_WRITE_EMBED_TIMEOUT: "15s"
-              # Same failure on the read path, with a tighter 2s default: a busy embedder
-              # makes recall degrade to keyword_only instead of returning vector hits.
+              # Read path has the write path's failure on a tighter 2s default: a busy
+              # embedder degrades recall to keyword_only instead of returning vector hits.
               MEMINI_RECALL_EMBED_TIMEOUT: "20s"
             resources:
               requests:

--- a/kubernetes/apps/ai/memini/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/memini/app/helmrelease.yaml
@@ -28,7 +28,15 @@ spec:
               MEMINI_EMBED_BASE_URL: "http://litellm.ai.svc.cluster.local/v1"
               MEMINI_EMBED_API_KEY: ${LITELLM_API_KEY}
               MEMINI_EMBED_MODEL: "qwen3-embedding"
+              # Native width of Qwen3-Embedding-0.6B; not a truncation, raising it needs a bigger model.
               MEMINI_EMBED_DIMS: "1024"
+              # Qwen3-Embedding is instruct-tuned and asymmetric: the query side wants this prefix,
+              # the document side must not have it. Query-only, so stored vectors stay valid.
+              MEMINI_EMBED_QUERY_PREFIX: |-
+                Instruct: Given a search query, retrieve relevant memories that answer the query
+                Query:
+              # Re-embed rather than silently mixing vector spaces if the model or dims ever change.
+              MEMINI_REEMBED_ON_MODEL_CHANGE: "true"
               # Bound capture/dedup embedding work to short, serial batches so
               # it cannot create the multi-second recall tail under load.
               MEMINI_EMBED_MAX_CONCURRENCY: "1"
@@ -39,6 +47,9 @@ spec:
               # iGPU embedder is busy; the two from 2026-08-04 20:50 never got
               # a vector back and are keyword-only.
               MEMINI_WRITE_EMBED_TIMEOUT: "15s"
+              # Same failure on the read path, with a tighter 2s default: a busy embedder
+              # makes recall degrade to keyword_only instead of returning vector hits.
+              MEMINI_RECALL_EMBED_TIMEOUT: "20s"
             resources:
               requests:
                 cpu: 50m

--- a/kubernetes/apps/kube-system/network-policies/app/kustomization.yaml
+++ b/kubernetes/apps/kube-system/network-policies/app/kustomization.yaml
@@ -5,4 +5,5 @@ kind: Kustomization
 # No namespace transformer: each policy declares its own metadata.namespace.
 resources:
   - database-ingress.yaml
+  - memini-ingress.yaml
   - deny-apiserver-egress.yaml

--- a/kubernetes/apps/kube-system/network-policies/app/memini-ingress.yaml
+++ b/kubernetes/apps/kube-system/network-policies/app/memini-ingress.yaml
@@ -6,17 +6,15 @@ metadata:
   name: memini-ingress-allowlist
   namespace: ai
 spec:
-  # memini serves an unauthenticated API: /v1/handshake reports admin=true,
-  # read_only=false to any caller, so reachability is the only access control
-  # there is. Scoped to memini alone, not the namespace: the rest of ai stays
-  # default-allow. Egress untouched (postgres, litellm embeddings, DNS).
+  # /v1/handshake reports admin=true, read_only=false to any caller, so
+  # reachability is the only access control there is. Scoped to memini alone;
+  # the rest of ai stays default-allow. Egress untouched.
   endpointSelector:
     matchLabels:
       app.kubernetes.io/name: memini
   ingress:
     - fromEndpoints:
-        # ai = hermes' native memory provider (:8080) and toolhive's MCP entry,
-        # which reaches it at memini.ai.svc:8080/mcp from this same namespace.
+        # ai = hermes' memory provider and toolhive's MCP entry, both :8080.
         - matchLabels:
             io.kubernetes.pod.namespace: ai
         # network = envoy-internal fronting the memini UI route (:8081).

--- a/kubernetes/apps/kube-system/network-policies/app/memini-ingress.yaml
+++ b/kubernetes/apps/kube-system/network-policies/app/memini-ingress.yaml
@@ -1,0 +1,31 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: memini-ingress-allowlist
+  namespace: ai
+spec:
+  # memini serves an unauthenticated API: /v1/handshake reports admin=true,
+  # read_only=false to any caller, so reachability is the only access control
+  # there is. Scoped to memini alone, not the namespace: the rest of ai stays
+  # default-allow. Egress untouched (postgres, litellm embeddings, DNS).
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: memini
+  ingress:
+    - fromEndpoints:
+        # ai = hermes' native memory provider (:8080) and toolhive's MCP entry,
+        # which reaches it at memini.ai.svc:8080/mcp from this same namespace.
+        - matchLabels:
+            io.kubernetes.pod.namespace: ai
+        # network = envoy-internal fronting the memini UI route (:8081).
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+        # observability = vmagent scraping the serviceMonitor (:9090).
+        - matchLabels:
+            io.kubernetes.pod.namespace: observability
+        # Rev-NAT'd DNS replies hit ingress; no toPorts, dest port is ephemeral not 53.
+        - matchLabels:
+            io.kubernetes.pod.namespace: kube-system
+            k8s-app: kube-dns


### PR DESCRIPTION
Adopts four settings from another memini deployment on the same server version. All four are supported by the v0.7.18 binary we already run (grepped the binary directly).

| Var | Value | Why |
|---|---|---|
| `MEMINI_RECALL_EMBED_TIMEOUT` | `20s` | Default is `envDefault:"2s"`. Read path has the same failure the write path did, on a tighter budget: a busy shared iGPU embedder makes recall degrade to `keyword_only` instead of returning vector hits. We fixed this on writes (`WRITE_EMBED_TIMEOUT: 15s`) and never touched reads. |
| `MEMINI_EMBED_QUERY_PREFIX` | instruct prefix | Qwen3-Embedding is instruct-tuned and asymmetric: queries want the prefix, documents must not have it. Query-side only, so stored vectors stay valid and no re-embed is triggered. |
| `MEMINI_REEMBED_ON_MODEL_CHANGE` | `true` | Without it, a future model or dims change silently mixes two vector spaces in one index. |
| `MEMINI_EMBED_DIMS` | unchanged at `1024` | 1024 is the native width of Qwen3-Embedding-0.6B, not a truncation. 4096 is the 8B model's width and would need a different model on the iGPU. Reason recorded inline so it is not re-litigated. |

## Ingress allowlist

memini's API is unauthenticated: `/v1/handshake` returns `admin=true, read_only=false` to any caller, while the Service is reachable from the whole cluster and the UI route from the internal gateway. Reachability is the only access control available without provisioning `MEMINI_API_KEYS_FILE` and distributing keys into hermes' PVC config (which has no git backup).

Consumers verified against the live cluster, all three needed explicit allow:

- `ai` - hermes' native memory provider (`:8080`) and toolhive's MCPServerEntry at `memini.ai.svc:8080/mcp`, which runs in this same namespace
- `network` - `envoy-internal` fronting the UI route (`:8081`)
- `observability` - vmagent scraping the serviceMonitor (`:9090`)
- `kube-system`/`kube-dns` - rev-NAT'd DNS replies land on ingress

Scoped to the memini endpoint rather than the namespace, so the rest of `ai` stays default-allow. Egress untouched (postgres, litellm embeddings, DNS).

## Validation

- All 4 env vars present in the running v0.7.18 binary; `2s` default read out of it
- Query prefix renders as a real `\n` with no trailing newline
- CNP endpointSelector matches exactly 1 pod
- `kustomize build` clean; `kubectl apply --dry-run=server` reports `memini-ingress-allowlist created`

## Risk

The CNP is the risky half - first policy in `ai`, and a prior allowlist that omitted `kube-system` silently dropped rev-NAT'd CoreDNS replies. The kube-dns rule is included and egress is left alone, but a dry-run cannot prove reachability. Post-reconcile checks: hermes recall still returns hits, the memini UI still loads, `memini_*` series keep arriving in VM.

The query prefix shifts the score distribution, so the server-side `inject_recall_min_score: 0.5` floor is worth re-checking against `memini_recall_floored_total` once live.