### PR TITLE
feat(talos): adopt the 1.14 filesystem and CRI documents

### DIFF
--- a/talos/README.md
+++ b/talos/README.md
@@ -119,12 +119,17 @@ only after tuppr has rolled every node, and re-run `diff-node` on all three befo
 | Document | Replaces / adds |
 | --- | --- |
 | `CRICustomizationConfig` | the `machine.files` drop-in at `/etc/cri/conf.d/20-customization.part`. Editing it restarts CRI instead of needing a reboot |
-| `FilesystemTrimConfig` | fstrim, weekly. Absent means no automatic trimming at all, and every node is NVMe |
+| `FilesystemTrimConfig` | fstrim, weekly. Absent means no automatic trimming at all |
 | `FilesystemScrubConfig` | `xfs_scrub`, weekly, off by default. Closes #4289 |
+| `SysctlConfig` | `machine.sysctls`, which 1.14 deprecates. All 16 keys verified identical |
 
 Both filesystem documents pick a stable hash-derived slot per volume per node, so the fleet does
 not scrub or trim in lockstep. That is what makes weekly safe on control-3 despite its
 thermal-shutdown history: it never runs at the same moment as its peers.
+
+Trim reaches only what the node can discard. control-2 and control-3 install to real NVMe; control-1
+is the TrueNAS VM, installs to `/dev/vda`, and has no NVMe device at all (`talosctl get disks` shows
+only virtio and rbd), so its discards pass through to whatever the hypervisor does with them.
 
 ### Deliberately not adopted
 
@@ -132,9 +137,10 @@ thermal-shutdown history: it never runs at the same moment as its peers.
 | --- | --- |
 | `OOMConfig` | a PSI-expression OOM handler. Real potential here given this cluster's OOM cascades, but it changes which cgroup dies under pressure. Needs a baseline first, not a blind default |
 | `SecurityProfileConfig` | `workloadIsolation: true` (sandboxd) is a runtime change for every workload; wants its own change and its own rollback |
-| `KubeletConfig` + `KubeNodeConfig` | would restate a working kubelet block with no functional gain |
-| `SysctlConfig` / `SysfsConfig` / `KernelModuleConfig` / `UdevRulesConfig` | mechanical renames of `machine.*` fields that still work; churn without benefit until they are actually removed |
-| `EtcFileConfig`, `RAIDArrayConfig`, `LVM*Config`, `BGPInstanceConfig`, `VethConfig` | new capabilities, none currently needed |
+| `KubeletConfig` + `KubeNodeConfig` | **blocked, not deferred.** `machine.kubelet.extraMounts` has no equivalent (`ExtraMounts()` is `return nil` in v1.14.0-rc.1) and we bind-mount `/var/openebs/local` through it. Mutually exclusive with `machine.kubelet`, so there is no partial migration: the key fails to decode, and removing it silently drops the mount |
+| `SysfsConfig` / `CRIBaseRuntimeSpecConfig` | the other two v1alpha1 fields 1.14 deprecates; neither is used in this repo |
+| `RAIDArrayConfig`, `LVM*Config`, `BGPInstanceConfig`, `VethConfig` | new capabilities, none currently needed |
+| `EtcFileConfig` | not needed *yet*, but upstream uses it for `nfsmount.conf` (nconnect 8, 1MiB rsize/wsize). Our five NFS mounts run at kernel defaults; worth its own change |
 
 `VolumeConfig`'s `filesystem.xfs.minAllocationGroupSize` only affects volumes Talos formats, so it
 is a wipe-time decision rather than a live one.

--- a/talos/README.md
+++ b/talos/README.md
@@ -101,18 +101,39 @@ fails to pull. Check which nodes use a non-Factory installer before changing a s
 
 ## Talos 1.14 adoption
 
-The version lives in the tuppr CR, not here. Once the cluster is on 1.14, these documents become
-available and each should land as its own change with a `diff-node` review. Swept and confirmed
-renderable against this pipeline:
+The version lives in the tuppr CR, not here.
+
+**These documents cannot be applied before the nodes are on 1.14.** Not a style rule, a hard
+gate: a 1.13.9 node rejects the config outright rather than ignoring what it does not know.
+
+```text
+error decoding document v1alpha1/CRICustomizationConfig/keep-unpacked-layers:
+  "CRICustomizationConfig" "v1alpha1": not registered
+```
+
+So `apply-node` and `diff-node` both fail against a node that has not been upgraded yet. Adopt
+only after tuppr has rolled every node, and re-run `diff-node` on all three before applying.
+
+### Adopted
 
 | Document | Replaces / adds |
 | --- | --- |
-| `CRICustomizationConfig` | `machine.files` CRI drop-in; no reboot needed to change CRI config |
-| `FilesystemTrimConfig` | absent on upgraded clusters, so trimming is off by default |
-| `SecurityProfileConfig` | `workloadIsolation: true` (sandboxd). Check first: no in-tree iSCSI volume plugin. Ceph CSI is unaffected |
-| `SysctlConfig` / `SysfsConfig` / `KernelModuleConfig` / `UdevRulesConfig` | the deprecated `machine.*` equivalents |
-| `KubeletConfig` + `KubeNodeConfig` | most of the kubelet block and the node labels |
-| `FilesystemScrubConfig` | XFS scrub; note control-3's XFS shutdown history |
+| `CRICustomizationConfig` | the `machine.files` drop-in at `/etc/cri/conf.d/20-customization.part`. Editing it restarts CRI instead of needing a reboot |
+| `FilesystemTrimConfig` | fstrim, weekly. Absent means no automatic trimming at all, and every node is NVMe |
+| `FilesystemScrubConfig` | `xfs_scrub`, weekly, off by default. Closes #4289 |
+
+Both filesystem documents pick a stable hash-derived slot per volume per node, so the fleet does
+not scrub or trim in lockstep. That is what makes weekly safe on control-3 despite its
+thermal-shutdown history: it never runs at the same moment as its peers.
+
+### Deliberately not adopted
+
+| Document | Why not |
+| --- | --- |
+| `OOMConfig` | a PSI-expression OOM handler. Real potential here given this cluster's OOM cascades, but it changes which cgroup dies under pressure. Needs a baseline first, not a blind default |
+| `SecurityProfileConfig` | `workloadIsolation: true` (sandboxd) is a runtime change for every workload; wants its own change and its own rollback |
+| `KubeletConfig` + `KubeNodeConfig` | would restate a working kubelet block with no functional gain |
+| `SysctlConfig` / `SysfsConfig` / `KernelModuleConfig` / `UdevRulesConfig` | mechanical renames of `machine.*` fields that still work; churn without benefit until they are actually removed |
 | `EtcFileConfig`, `RAIDArrayConfig`, `LVM*Config`, `BGPInstanceConfig`, `VethConfig` | new capabilities, none currently needed |
 
 `VolumeConfig`'s `filesystem.xfs.minAllocationGroupSize` only affects volumes Talos formats, so it

--- a/talos/cluster.yaml.j2
+++ b/talos/cluster.yaml.j2
@@ -67,23 +67,6 @@ machine:
   time:
     disabled: false
     servers: [{{ gateway }}]
-  sysctls:
-    fs.inotify.max_user_watches: "1048576" # Watchdog
-    fs.inotify.max_user_instances: "8192" # Watchdog
-    net.core.default_qdisc: "fq" # Fair Queuing - improves network fairness and reduces latency
-    net.core.rmem_max: "67108864" # Maximum TCP receive window (64MB) - improves throughput
-    net.core.wmem_max: "67108864" # Maximum TCP send window (64MB) - improves throughput
-    net.ipv4.tcp_congestion_control: "bbr" # BBR congestion control - better performance than cubic
-    net.ipv4.tcp_fastopen: "3" # Enables TCP Fast Open for both client and server
-    net.ipv4.tcp_mtu_probing: "1" # Enables automatic MTU probing for optimal packet size
-    net.ipv4.tcp_rmem: "4096 87380 33554432" # TCP receive buffer sizes (min, default, max)
-    net.ipv4.tcp_wmem: "4096 65536 33554432" # TCP send buffer sizes (min, default, max)
-    net.ipv4.tcp_window_scaling: "1" # Enables TCP window scaling for better throughput
-    net.ipv4.neigh.default.gc_thresh1: "4096" # Prevent ARP cache overflows
-    net.ipv4.neigh.default.gc_thresh2: "8192" # Prevent ARP cache overflows
-    net.ipv4.neigh.default.gc_thresh3: "16384" # Prevent ARP cache overflows
-    net.ipv4.tcp_slow_start_after_idle: "0" # Preserve congestion window after idle
-    user.max_user_namespaces: "11255" # User Namespaces
   features:
     diskQuotaSupport: true
     kubePrism:
@@ -142,3 +125,26 @@ interval: 168h0m0s
 apiVersion: v1alpha1
 kind: FilesystemScrubConfig
 interval: 168h0m0s
+---
+# Was machine.sysctls, which Talos 1.14 deprecates (the marker is in this document's own schema
+# description, not the v1alpha1 one). Same keys and values; the field is `params`, not `sysctls`.
+# The two merge with this document winning on conflicts, so keeping both would only hide drift.
+apiVersion: v1alpha1
+kind: SysctlConfig
+params:
+  fs.inotify.max_user_watches: "1048576" # Watchdog
+  fs.inotify.max_user_instances: "8192" # Watchdog
+  net.core.default_qdisc: "fq" # Fair Queuing - improves network fairness and reduces latency
+  net.core.rmem_max: "67108864" # Maximum TCP receive window (64MB) - improves throughput
+  net.core.wmem_max: "67108864" # Maximum TCP send window (64MB) - improves throughput
+  net.ipv4.tcp_congestion_control: "bbr" # BBR congestion control - better performance than cubic
+  net.ipv4.tcp_fastopen: "3" # Enables TCP Fast Open for both client and server
+  net.ipv4.tcp_mtu_probing: "1" # Enables automatic MTU probing for optimal packet size
+  net.ipv4.tcp_rmem: "4096 87380 33554432" # TCP receive buffer sizes (min, default, max)
+  net.ipv4.tcp_wmem: "4096 65536 33554432" # TCP send buffer sizes (min, default, max)
+  net.ipv4.tcp_window_scaling: "1" # Enables TCP window scaling for better throughput
+  net.ipv4.neigh.default.gc_thresh1: "4096" # Prevent ARP cache overflows
+  net.ipv4.neigh.default.gc_thresh2: "8192" # Prevent ARP cache overflows
+  net.ipv4.neigh.default.gc_thresh3: "16384" # Prevent ARP cache overflows
+  net.ipv4.tcp_slow_start_after_idle: "0" # Preserve congestion window after idle
+  user.max_user_namespaces: "11255" # User Namespaces

--- a/talos/cluster.yaml.j2
+++ b/talos/cluster.yaml.j2
@@ -110,9 +110,9 @@ content: |
   [plugins."io.containerd.cri.v1.images"]
     discard_unpacked_layers = false
 ---
-# fstrim. Absent on an upgraded cluster means no automatic trimming at all, and every node here
-# is NVMe. Talos picks a stable hash-derived slot per volume per node, so the fleet does not trim
-# in lockstep.
+# fstrim. Absent on an upgraded cluster means no automatic trimming at all. Talos picks a stable
+# hash-derived slot per volume per node, so the fleet does not trim in lockstep. control-1 is the
+# TrueNAS VM with no NVMe device, so its discards pass through to the hypervisor.
 # Interval is stated rather than defaulted: talosctl accepts 0s while rejecting 1s against its own
 # 10s minimum, so zero is an unset sentinel and an omitted field lands on it.
 apiVersion: v1alpha1

--- a/talos/cluster.yaml.j2
+++ b/talos/cluster.yaml.j2
@@ -130,13 +130,15 @@ content: |
 # fstrim. Absent on an upgraded cluster means no automatic trimming at all, and every node here
 # is NVMe. Talos picks a stable hash-derived slot per volume per node, so the fleet does not trim
 # in lockstep.
+# Interval is stated rather than defaulted: talosctl accepts 0s while rejecting 1s against its own
+# 10s minimum, so zero is an unset sentinel and an omitted field lands on it.
 apiVersion: v1alpha1
 kind: FilesystemTrimConfig
 interval: 168h0m0s
 ---
-# xfs_scrub, off by default. Closes #4289. Weekly is the Talos default and the scrub slot is
-# hash-derived per volume per node, so control-3 (Micron 7450, thermal-shutdown history) never
-# scrubs at the same moment as its peers.
+# xfs_scrub, off until this document exists. Closes #4289. The scrub slot is hash-derived per
+# volume per node, so control-3 (Micron 7450, thermal-shutdown history) never scrubs at the same
+# moment as its peers. Interval stated for the same reason as the trim document above.
 apiVersion: v1alpha1
 kind: FilesystemScrubConfig
 interval: 168h0m0s

--- a/talos/cluster.yaml.j2
+++ b/talos/cluster.yaml.j2
@@ -64,13 +64,6 @@ machine:
     grubUseUKICmdline: true
     # Identical for every node; the schematic id is resolved per node and passed in.
     image: factory.talos.dev/installer/{{ schematic }}:{{ talosVersion }}
-  files:
-    - op: create
-      path: /etc/cri/conf.d/20-customization.part
-      permissions: 0o0
-      content: |
-        [plugins."io.containerd.cri.v1.images"]
-          discard_unpacked_layers = false
   time:
     disabled: false
     servers: [{{ gateway }}]
@@ -123,3 +116,27 @@ cluster:
       kubernetes:
         disabled: true
       service: {}
+---
+# Was a machine.files drop-in at /etc/cri/conf.d/20-customization.part, which needed a reboot to
+# change. As a document, applying or editing it restarts CRI on its own.
+# Keeps unpacked layers so Talos can serve them without re-unpacking after an image GC.
+apiVersion: v1alpha1
+kind: CRICustomizationConfig
+name: keep-unpacked-layers
+content: |
+  [plugins."io.containerd.cri.v1.images"]
+    discard_unpacked_layers = false
+---
+# fstrim. Absent on an upgraded cluster means no automatic trimming at all, and every node here
+# is NVMe. Talos picks a stable hash-derived slot per volume per node, so the fleet does not trim
+# in lockstep.
+apiVersion: v1alpha1
+kind: FilesystemTrimConfig
+interval: 168h0m0s
+---
+# xfs_scrub, off by default. Closes #4289. Weekly is the Talos default and the scrub slot is
+# hash-derived per volume per node, so control-3 (Micron 7450, thermal-shutdown history) never
+# scrubs at the same moment as its peers.
+apiVersion: v1alpha1
+kind: FilesystemScrubConfig
+interval: 168h0m0s


### PR DESCRIPTION
Closes #4289.

Adopts four Talos 1.14 configuration documents. Stacked on #4583.

> **Gate: every node on 1.14 — which is NOT the same as "the roll finished".**
>
> Merging #4583 moves exactly one node. `getTargetVersion` prefers a node's
> `tuppr.home-operations.com/version` annotation over `spec.talos.version`, and two nodes carry one:
>
> | Node | Annotation | On merge of #4583 |
> | --- | --- | --- |
> | control-1 | `v1.13.9` | pinned — hold exists for the BMC, not for this stack |
> | control-2 | `v1.13.9-k7.1.9` | pinned until its config is re-applied at the new version |
> | control-3 | none | rolls to `v1.14.0-rc.1` |
>
> control-1 therefore stays on 1.13.9 **indefinitely**, until the TrueNAS hypervisor is fixed and its
> hold is cleared. Because a 1.13 node rejects the whole config, this PR stays blocked that entire
> time. The real gate is *control-1 released from its hold*, and the roll will look finished long
> before that happens.

## Hard ordering gate, verified against the live cluster

A 1.13.9 node rejects the whole config rather than ignoring documents it does not know:

```
192.168.0.12: error applying configuration: rpc error: code = InvalidArgument
desc = error decoding document v1alpha1/CRICustomizationConfig/keep-unpacked-layers
(line 169): "CRICustomizationConfig" "v1alpha1": not registered
```

`cluster.yaml.j2` is the every-node layer, so one such document breaks `diff-node` and `apply-node` for the **whole fleet** until the last node is upgraded. That is why this is a separate PR rather than part of #4583.

## What is adopted

| Document | Replaces / adds |
| --- | --- |
| `FilesystemScrubConfig` | `xfs_scrub`, weekly. Off by default in Talos. Closes #4289 |
| `FilesystemTrimConfig` | `fstrim`, weekly. Absent means no automatic trimming at all |
| `CRICustomizationConfig` | the `machine.files` drop-in at `/etc/cri/conf.d/20-customization.part`, byte-identical containerd fragment |
| `SysctlConfig` | `machine.sysctls`, which 1.14 **deprecates**. All 16 keys verified identical |

`CRICustomizationConfig` has a behavioural gain beyond the feature itself: editing the containerd fragment now restarts CRI automatically instead of requiring a reboot.

Both filesystem documents pick a stable hash-derived slot per volume per node, so the fleet does not scrub or trim in lockstep — that is what makes weekly safe on control-3 despite its thermal-shutdown history.

The intervals are stated rather than defaulted because `talosctl` accepts `interval: 0s` while rejecting `1s`/`9s` against its own documented 10s minimum, so zero is an unset sentinel and an omitted field lands on it. Whether that resolves to a week or to nothing is not stated in the schema, and the failure mode of guessing wrong is that scrubbing silently never runs.

## Verification, and its limit

| Check | Result |
| --- | --- |
| `just talos render-config control-2` | 8 documents, all four present |
| `talosctl validate -m metal` | valid |
| sysctl move | all 16 keys and values identical; `machine.sysctls` absent from every rendered document |
| `diff-node` against a 1.13.9 node | rejected, as quoted above |

**This PR lands with weaker evidence than anything else in the stack.** Every other change was gated on `diff-node` reporting `No changes.` against all three live nodes. That check is unavailable here by construction — the nodes reject 1.14 documents until they are upgraded — so this merges on `talosctl validate` plus field-level comparison alone.

Mitigation when applying: run `apply-node` against **one** node first, then `diff-node` the other two before touching them.

## Deliberately not adopted

| Document | Why not |
| --- | --- |
| `KubeletConfig` + `KubeNodeConfig` | **Blocked, not deferred.** `machine.kubelet.extraMounts` has no equivalent — `ExtraMounts()` is `return nil` in v1.14.0-rc.1 — and we bind-mount `/var/openebs/local` through it. `KubeletConfig` is mutually exclusive with `machine.kubelet`, so there is no partial migration: adopting it fails on the key and silently drops the mount if the key is removed, breaking local-path storage |
| `OOMConfig` | changes which cgroup dies under pressure. This cluster has real OOM cascades, which is exactly why it needs a baseline first rather than a blind default |
| `SecurityProfileConfig` | `workloadIsolation: true` is a runtime change for every workload; wants its own change and its own rollback |
| `SysfsConfig` / `CRIBaseRuntimeSpecConfig` | the other two deprecated v1alpha1 fields; neither is used in this repo |

Reasons are recorded in `talos/README.md` so the next pass does not re-litigate them.
