### PR TITLE
fix(omniroute): hold digest at e8e2e69, ac9606f crashloops

### DIFF
--- a/kubernetes/apps/ai/omniroute/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/omniroute/app/helmrelease.yaml
@@ -31,7 +31,11 @@ spec:
               # can diff against, so it will only ever offer digest bumps that
               # walk this further along the branch. Digest-pinned so the branch
               # moving does not silently move us.
-              tag: next@sha256:ac9606fc9b813d8b066f32da79ee42214c7bdd0a21072bbd1e363827ab70236c
+              # Held at e8e2e69: the next digest (ac9606f) crashloops --
+              # package.json gained "type": "module" while server.js still
+              # uses require(), so the entrypoint dies at boot (upstream
+              # d87b97a78). Unhold once a next build starts cleanly.
+              tag: next@sha256:e8e2e69cc705b3d5ee2503dd6d1d17ab94a2d69f01e9425f10aa1b6a4cbb3633
             env:
               TZ: ${TIMEZONE}
               DATA_DIR: /app/data


### PR DESCRIPTION
Reverts #4594. The `next` digest `ac9606f` does not start.

```
file:///app/server.js:1
const path = require('path')
             ^
ReferenceError: require is not defined in ES module scope
This file is being treated as an ES module because it has a '.js' file extension
and '/app/package.json' contains "type": "module".
```

| | |
|---|---|
| pod | `omniroute-746f688f74-mzxsz`, 2 restarts in 47s, CrashLoopBackOff |
| probe | readiness refused on 20128 |
| upstream | `d87b97a78` touched `server.js` and the `type` declaration together |
| newer build | none — `next` is still `1621f015` (2026-08-20T21:51Z), which `ac9606f` resolves from |

`e8e2e69` is the last digest that starts. Comment added above the pin so the next Renovate bump gets a second look; drop it once a `next` build boots cleanly.