### PR TITLE
chore: drop the ponytail: prefix from two comments

### DIFF
--- a/kubernetes/apps/ai/llmkube/models/qwen38-27b-vllm.yaml
+++ b/kubernetes/apps/ai/llmkube/models/qwen38-27b-vllm.yaml
@@ -47,7 +47,7 @@ spec:
   # Hourly, not daily: a daily window let a busy day cross the floor and sit
   # there for hours. Safe to run this often only because eviction is now
   # incremental (see the script) rather than a full wipe.
-  # ponytail: periodic sweep, not a hard cap -- move to a quota-enforcing
+  # Periodic sweep, not a hard cap -- move to a quota-enforcing
   # storage class if the floor is ever actually breached.
   schedule: "0 * * * *"
   concurrencyPolicy: Forbid

--- a/kubernetes/apps/ai/toolhive/config/virtualmcpservers.yaml
+++ b/kubernetes/apps/ai/toolhive/config/virtualmcpservers.yaml
@@ -70,7 +70,7 @@ spec:
   config:
     # Cold embedding cache takes ~27-35s on the iGPU, past the 30s default
     # (2026-07-03). Anchored to embeddingServiceTimeout — same call.
-    # ponytail: `default` covers every backend request, not just session-build;
+    # `default` covers every backend request, not just session-build;
     # switch to perWorkload if a hung backend's slow failure starts mattering.
     operational:
       timeouts:


### PR DESCRIPTION
Tool-specific marker with no meaning to anyone reading the repo.

Only the prefix goes — both comments record a real decision plus a concrete upgrade path, so they read the same without it:

| file | comment keeps |
|---|---|
| `llmkube/models/qwen38-27b-vllm.yaml` | "periodic sweep, not a hard cap — move to a quota-enforcing storage class if the floor is ever actually breached" |
| `toolhive/config/virtualmcpservers.yaml` | "`default` covers every backend request, not just session-build; switch to perWorkload if a hung backend's slow failure starts mattering" |

These are the only two in tracked files on `main`. A third exists in `talos/mod.just` but arrives with #4580, so it belongs there rather than here.