### PR TITLE
refactor(talos): condense the shell-rule comments to their local facts

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -5,8 +5,7 @@
 # No direnv? `export PATH="$HOME/.local/share/mise/shims:$PATH"` gives the same result.
 if has mise; then
   watch_file .mise.toml
-  # Captured before eval: `eval "$(mise env)"` reports eval's status, not mise's, so a config
-  # error would leave every repo tool off PATH with no indication why.
+  # Captured before eval: `eval "$(...)"` reports eval's status, not mise's.
   if mise_env="$(mise env -s bash)"; then
     eval "$mise_env"
   else

--- a/.justfile
+++ b/.justfile
@@ -12,7 +12,6 @@ mod talos "talos"
 
 # The tuppr upgrade CRs are the single source for both versions, so Renovate manages them in
 # one place. `kind` names both the file and the spec key (talos -> talosupgrade.yaml).
-# -e so a missing or null key exits non-zero; without it yq prints "null" and exits 0.
 [private]
 tuppr-version kind:
     yq -e '.spec.{{ kind }}.version' \
@@ -31,14 +30,9 @@ talsecret:
 # --strict makes a typo'd variable an error rather than an empty string.
 [private]
 template file *args:
-    # Assigned before the render rather than inline: a failing command substitution inside an
-    # argument does NOT trip `set -e`, so a renamed key would silently render as "null" and be
-    # baked into a node's install image. As bare assignments these abort the recipe instead.
     talos_version="$(just tuppr-version talos)"
     kubernetes_version="$(just tuppr-version kubernetes)"
-    # Piped, not <(just talsecret): a process substitution's producer exit status is invisible to
-    # the outer command, so a failed decrypt would hand minijinja an empty context instead of
-    # aborting. Through a pipe, `pipefail` fails the recipe. Verified both ways.
+    # Piped, not <(just talsecret): through a pipe `pipefail` sees a failed decrypt.
     just talsecret | minijinja-cli --strict --format=yaml --autoescape=none \
         -D "talosVersion=${talos_version}" \
         -D "kubernetesVersion=${kubernetes_version}" \

--- a/docs/useful_commands.md
+++ b/docs/useful_commands.md
@@ -30,29 +30,17 @@ flux get helmreleases -A
 
 ## Talos
 
-These use the repo's pinned `talosctl` and `minijinja-cli`, which `.envrc` puts on `PATH` via mise.
-Without direnv, either add the shims to `PATH` (`fish_add_path ~/.local/share/mise/shims`) or prefix
-each command with `mise exec --`.
+Machine configs are rendered on demand and pushed by hand; nothing applies them automatically.
+See [talos/README.md](../talos/README.md) for the layer model, the full recipe list, and the
+toolchain the bare `just` commands assume.
 
 ```bash
-# Render a node's machine config, and diff it against what the node is running
-just talos render-config <node>
-just talos diff-node <node> <node-ip>
-
-# Apply config to a node / upgrade node / upgrade Kubernetes
-just talos apply-node <node> <node-ip>
-just talos upgrade-node <node> <node-ip>
-just talos upgrade-k8s
+just talos diff-node <node> <node-ip>     # dry-run against the running node
+just talos apply-node <node> <node-ip>    # render and apply
 ```
 
-Schematics no longer need a separate update step: `just talos schematic-id <node>` resolves the
-Image Factory ID at render time and templates it into the installer image. Editing
-`talos/schematic.yaml` (or a per-node `talos/nodes/<role>/<node>.schematic.yaml` override) is
-enough. These are plain YAML, not templates.
-
-Always run `just talos diff-node <node> <node-ip>` against every node and confirm `No changes.`
-before applying.
-See [talos/README.md](../talos/README.md) for the layer model.
+Run `diff-node` against **every** node and confirm `No changes.` before applying anything.
+Upgrade `control-1` last: it is the TrueNAS VM and the only dGPU host.
 
 ---
 

--- a/talos/AGENTS.md
+++ b/talos/AGENTS.md
@@ -1,18 +1,14 @@
 # Talos Guidance
 
-- Read [the README](README.md) for the layer model before changing machine configuration, and the
-  Talos entries in [learned workspace facts](../.agents/learned-workspace.md).
-- Render with `just talos render-config <node>`.
-- **Always** verify with `just talos diff-node <node> <ip>` on every node and confirm
-  each reports `No changes.` before applying anything. A rendered config that merely validates is not
-  evidence; the dry-run diff against the running node is.
-- Apply with `just talos apply-node <node> <ip>`, upgrade with
-  `just talos upgrade-node <node> <ip>`.
+- Read [the README](README.md) for the layer model and the recipe list before changing machine
+  configuration, and the Talos entries in [learned workspace facts](../.agents/learned-workspace.md).
+- **Always** run `just talos diff-node <node> <ip>` against every node and confirm each reports
+  `No changes.` before applying anything. A config that merely validates is not evidence; the
+  dry-run diff against the running node is.
 - Ask before applying configuration or upgrading a live node.
 - Machine configs are **never** applied automatically. Nothing in Flux, CI or tuppr pushes them;
-  merging a change to `talos/` only changes what `render-config` produces. A human runs
-  `apply-node` per node.
-- Talos 1.14 documents cannot be applied to a node still on 1.13: the node rejects the whole
-  config, so one such document in `cluster.yaml.j2` breaks `diff-node` for every node in the fleet
-  until the last one is upgraded.
-- `control-1` is the TrueNAS VM and the only dGPU host. Upgrade it last.
+  merging a change to `talos/` only changes what `render-config` produces.
+- A node rejects the whole config if it contains a document its version does not know, so during
+  any mixed-version window a new document in `cluster.yaml.j2` breaks `diff-node` fleet-wide.
+- `control-1` is the TrueNAS VM and the only dGPU host. Upgrade it last, and never taint it or
+  GPU workloads have nowhere to schedule.

--- a/talos/README.md
+++ b/talos/README.md
@@ -60,7 +60,8 @@ Two conventions keep the layers honest:
 Talos and Kubernetes versions are not hardcoded. The root `template` recipe reads them from the tuppr
 CRs (`kubernetes/apps/system-upgrade/tuppr/upgrades/`), so Renovate keeps managing them in one place.
 `vip` and `gateway` are defined once in `mod.just` and passed to every layer alongside the node's
-schematic id, so each address has a single definition rather than one per file that references it.
+schematic id. Node addresses and the `192.168.0.0/24` subnet are still literals in the files that
+use them; only these two are centralised.
 
 Documents are laid out to keep `diff-node` honest: `talosctl` diffs a config **textually**, so moving
 a document between layers reorders the output stream and reads as a change even when the content is
@@ -80,8 +81,9 @@ Schematics are plain YAML, deliberately not templates. Routing them through `tem
 decrypt the secrets bundle to render a file that references no secrets, on the hot path of nearly
 every `just talos` command. If a schematic ever needs a variable, add the extension back.
 
-**The ID is content-addressed, so any edit to a schematic moves it** — including a one-character
-change to `extraKernelArgs`. Every installer reference derived from that ID moves with it. For nodes
+**The ID is content-addressed, so any change to a schematic's fields moves it** — including a
+one-character change to `extraKernelArgs`. Comments and formatting do not: the Factory canonicalises
+the YAML before hashing, verified by stripping a comment and getting the same id back. Every installer reference derived from that ID moves with it. For nodes
 pointing at the Image Factory that is invisible and self-healing, because the Factory builds the new
 ID on demand. It is *not* self-healing for any node whose installer is mirrored to another registry
 under the schematic path: that mirror must be republished under the new ID first, or the next upgrade

--- a/talos/mod.just
+++ b/talos/mod.just
@@ -4,6 +4,10 @@ set default-script
 set script-interpreter := ['bash', '-euo', 'pipefail']
 set shell := ['bash', '-euo', 'pipefail', '-c']
 
+# Values are assigned and checked before use throughout this file. Process substitutions and
+# argument-position command substitutions discard their producer's exit status, and some tools
+# exit 0 with empty output; see .agents/common-operations.md.
+
 # Cluster-wide addresses, defined once: the VIP is referenced from every layer and from
 # talosconfig, and the retired talconfig.yaml used a YAML anchor for the same reason.
 vip := "192.168.0.2"
@@ -11,23 +15,17 @@ gateway := "192.168.0.1"
 
 [doc('Render a node full machine config to stdout')]
 render-config node:
-    # Bare assignments: a failing command substitution inside an argument or array element does
-    # NOT trip `set -e`, so these would silently render as empty.
     schematic="$(just talos schematic-id "{{ node }}")"
     role="$(just talos node-role "{{ node }}")"
-    # Assignment alone catches a non-zero exit; these catch the other half, a producer that
-    # succeeds with empty output. schematic feeds an install image path, where empty renders a
-    # plausible ref that resolves to nothing.
+    # Belt and braces: both callees already fail on empty, but schematic feeds an install image
+    # path where an empty value renders a plausible ref that resolves to nothing.
     [[ -n "${schematic}" ]] || { echo "empty schematic id for {{ node }}" >&2; exit 1; }
     [[ -n "${role}" ]] || { echo "empty role for {{ node }}" >&2; exit 1; }
     # One context for every layer, so any layer may reference any of these.
     ctx=(-D "vip={{ vip }}" -D "gateway={{ gateway }}" -D "schematic=${schematic}")
-    # Each layer is rendered to a variable BEFORE talosctl runs, not inline as <(just template).
-    # A process substitution is asynchronous: its exit status never reaches talosctl, so a failed
-    # layer was silently dropped. Verified by breaking controlplane.yaml.j2 -- render-config
-    # exited 0 and emitted a config with no machine.type, which apply-node pipes straight to a
-    # control-plane node. Assigning first also means a failure aborts before anything reaches
-    # stdout, so a consumer can never see a partial config.
+    # Rendered to variables before talosctl runs, so a failed layer aborts before a single byte
+    # reaches stdout. Inline <(just template) dropped the layer silently and still emitted a
+    # config, which apply-node pipes straight to a node.
     cluster_layer="$(just template "{{ source_directory() }}/cluster.yaml.j2" "${ctx[@]}")"
     role_layer="$(just template "{{ source_directory() }}/${role}.yaml.j2" "${ctx[@]}")"
     node_layer="$(just template "{{ source_directory() }}/nodes/${role}/{{ node }}.yaml.j2" "${ctx[@]}")"
@@ -59,8 +57,7 @@ apply-node node ip *args:
 [confirm('Upgrade Talos on the node. Continue? [y|N]')]
 [doc('Upgrade Talos on a single node')]
 upgrade-node node ip:
-    # Assigned, not inlined: in argument position a failed substitution does not trip `set -e`,
-    # so an empty image would reach `upgrade -i ""` and powercycle the node anyway.
+    # Assigned: inlined, an empty image would reach `upgrade -i ""` and powercycle the node anyway.
     image="$(just talos machine-image "{{ node }}")"
     talosctl -n "{{ ip }}" upgrade -i "${image}" -m powercycle --timeout=15m
 
@@ -117,12 +114,8 @@ schematic-file node:
 # `template`, which would decrypt the secrets bundle to render a file that references no secrets.
 # Bounded because a stalled factory blocks every render. Retries are safe: the endpoint is
 # content-addressed, so re-POSTing identical content returns the same id.
-# jq -er, not -r: a response without a usable .id must fail loudly, not print "null" and end up
-# in an installer reference.
 [private]
 schematic-id node:
-    # Assigned, not inlined into --data-binary: a command substitution in argument position
-    # discards its exit status, so a failed lookup would POST the literal path "@" instead.
     file="$(just talos schematic-file "{{ node }}")"
     [[ -f "${file}" ]] || { echo "no schematic file for {{ node }}: ${file}" >&2; exit 1; }
     curl -sfX POST --connect-timeout 5 --max-time 30 --retry 3 --retry-max-time 60 \
@@ -132,9 +125,8 @@ schematic-id node:
 
 [private]
 machine-image node:
-    # -e, and checked: plain `yq -r` exits 0 with EMPTY output when the selector matches nothing,
-    # and this value becomes `talosctl upgrade -i ""` against a live node. The selector breaks the
-    # moment the install image moves document (UnattendedInstallConfig), which is not hypothetical.
+    # Read back from the render rather than rebuilt from schematic+version: the field moves
+    # document under UnattendedInstallConfig, and this value becomes `talosctl upgrade -i`.
     image="$(just talos render-config "{{ node }}" | yq -er 'select(.machine.install != null) | .machine.install.image')"
     [[ -n "${image}" ]] || { echo "no install image in rendered config for {{ node }}" >&2; exit 1; }
     echo "${image}"

--- a/talos/nodes/controlplane/control-1.schematic.yaml
+++ b/talos/nodes/controlplane/control-1.schematic.yaml
@@ -2,7 +2,6 @@
 # control-1 diverges from the fleet: TrueNAS VM (qemu-guest-agent) and the only
 # dGPU host, so it carries the amdgpu tuning args the Chuwi boxes do not need.
 # Overrides are complete files, not deltas.
-# Resolves to c68c8884333629a78b939df2c920651ecddd733c41ca9bd0a872ec53dc060d8e
 customization:
   extraKernelArgs:
     - apparmor=0

--- a/talos/schematic.yaml
+++ b/talos/schematic.yaml
@@ -1,6 +1,5 @@
 ---
 # Shared Image Factory schematic: Chuwi ubox nodes (control-2, control-3).
-# Resolves to 1fd419f5873a6e96fcd35ad1f849c02b53578eb39922041b24ab475fccd99780
 customization:
   extraKernelArgs:
     - talos.platform=metal


### PR DESCRIPTION
Follow-up to #4580. The `/simplify` pass was pushed a few minutes after #4580 was squash-merged, so it missed the merge. No behaviour change; all three nodes still report `No changes.`

## Comment bloat

The "`set -e` does not see this" justification had been re-derived **eleven times** across `talos/mod.just`, `.justfile` and `.envrc` — roughly 30 lines restating one principle that `.agents/common-operations.md` now owns in full. `render-config` alone was 16 comment lines to 12 code lines.

Each site now keeps only its local fact; one file-level note in `mod.just` carries the general rule and points at the doc.

## Docs that had already diverged

`talos/AGENTS.md` and `docs/useful_commands.md` each carried a third copy of the recipe list, and both had drifted: AGENTS dropped `talosconfig` and `download-image`, `useful_commands` dropped those plus `reset-node`. Both now link to the README and keep only what they add.

Two things were recovered rather than deduplicated:

- "Upgrade `control-1` last" existed only in the agent-facing doc, invisible to a human reading the README.
- "Never taint `control-1` or GPU workloads have nowhere to schedule" was lost entirely when `talos/patches/kepler-node.yaml` was deleted in #4580.

## Two claims that were too strong

| Claim | Correction |
| --- | --- |
| "any edit to a schematic moves its id" | Only field changes do. Verified by stripping a comment from both schematic files and getting the same ids back — the Factory canonicalises the YAML before hashing. |
| "each address has a single definition" | True for `vip` and `gateway` only. Node addresses and `192.168.0.0/24` are still literals. |

The `# Resolves to <hash>` comments are dropped from both schematic files: stale by construction, and `just talos schematic-id <node>` recomputes the value.

## Reviewed and deliberately left alone

| Finding | Why not |
| --- | --- |
| Four `x="$(...)"; [[ -n "$x" ]] \|\| exit 1` blocks could be one shared recipe | Would spawn a `just`+`bash` per check and route the value through another command's argv — the exact hazard these guards exist for |
| 3× `sops -d` and 6× `yq` per render | `template` re-deriving its own inputs is simpler than threading resolved values through every call site; ~100ms on a hand-run tool |
| `machine-image` does a full render to read one field | Reading back what talosctl actually rendered is format-independent; the field moves document under `UnattendedInstallConfig`. 0.6s against a 15-minute powercycle |

## Verification

| Check | Result |
| --- | --- |
| `diff-node` × 3 nodes | `No changes.` |
| schematic ids after comment removal | unchanged (`c68c8884…`, `1fd419f5…`) |
| failure guards (node-role, pipefail, `yq -e`, `--strict`) | all 4 abort |
