### PR TITLE
feat(ci): build the custom-kernel installers on a Renovate bump

### DIFF
--- a/.github/workflows/talos-kernel.yaml
+++ b/.github/workflows/talos-kernel.yaml
@@ -1,0 +1,80 @@
+---
+# Builds the custom-kernel Talos installers and publishes them to ghcr, so a Renovate kernel
+# bump produces the artifact its own config change depends on. Without this, merging a bump
+# points nodes at a tag nobody built.
+name: Talos Kernel
+
+on:
+  pull_request:
+    paths:
+      - docker/talos-kernel/**
+      - scripts/talos-kernel-build.sh
+      - talos/schematic.yaml
+      - talos/nodes/**/*.schematic.yaml
+      - kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
+  workflow_dispatch:
+    inputs:
+      talos-version:
+        description: "Talos version to build against; defaults to the tuppr CR's"
+        required: false
+
+# A push supersedes the in-flight run rather than racing it. Learned the hard way: without
+# this, successive pushes leave cancelled runs that look like a wedged runner.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    # ~2h45m measured shape: the ThinLTO kernel compile dominates and a hosted runner is 4 vCPU
+    # against the 24 threads this takes locally. Well under the 6h job ceiling, but nowhere near
+    # the default 360m step budget, so it is set explicitly.
+    timeout-minutes: 340
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      # The pipeline needs ~35-40 GB: the kernel build layer alone is ~17.7 GB. Docker's
+      # data-root lives on /, which has only 21-31 GB free on a hosted runner, so the build dies
+      # mid-compile with an opaque ENOSPC. /mnt is undocumented but present with ~66 GB free.
+      # This is cheaper and more reliable than the disk-reclaim actions.
+      - name: Move Docker data-root to /mnt
+        run: |
+          df -h / /mnt
+          sudo systemctl stop docker.service docker.socket
+          sudo mkdir -p /mnt/docker
+          printf '{"data-root":"/mnt/docker"}' | sudo tee /etc/docker/daemon.json
+          sudo systemctl start docker.service
+          docker info --format '{{.DockerRootDir}}'
+
+      - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
+
+      # GITHUB_TOKEN can push to ghcr.io/<repo-owner>/* — but only to packages the repo has
+      # been granted access to. These packages were created by hand from a workstation, so they
+      # are NOT linked to this repo and the first run 403s until each is given write access
+      # under Package settings -> Manage Actions access -> Add repository. One-time, per package:
+      # kernel, linux-firmware, amdgpu, installer-base, imager, installer/shared, installer/control-1.
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # The script derives everything else itself: the kernel version from the Renovate-managed
+      # ARG, and TOOLS/PKGS from the Talos release's own Makefile.
+      - name: Build and publish installers
+        # Through env, not interpolated into the shell: a workflow_dispatch input expanded
+        # directly into a run block is a code-injection vector.
+        env:
+          TALOS_VERSION_INPUT: ${{ inputs.talos-version }}
+        run: |
+          talos_version="${TALOS_VERSION_INPUT}"
+          [ -n "${talos_version}" ] || talos_version="$(just tuppr-version talos)"
+          # The node list comes from talos/nodes/, and the script writes its own job summary
+          # naming every ref it published.
+          scripts/talos-kernel-build.sh "${talos_version}" $(just talos nodes)

--- a/.justfile
+++ b/.justfile
@@ -17,6 +17,15 @@ tuppr-version kind:
     yq -e '.spec.{{ kind }}.version' \
         "{{ justfile_directory() }}/kubernetes/apps/system-upgrade/tuppr/upgrades/{{ kind }}upgrade.yaml"
 
+# Renovate maintains the kernel version in one place, the Dockerfile ARG. Read here rather than
+# re-parsed per caller, so a node cannot advertise a version whose image was never built.
+# Guarded because sed exits 0 with empty output, which neither --strict nor `set -e` catches.
+[private]
+kernel-version:
+    version="$(sed -nE 's/^ARG KERNEL_VERSION=(.+)$/\1/p' "{{ justfile_directory() }}/docker/talos-kernel/Dockerfile")"
+    [[ -n "${version}" ]] || { echo "no 'ARG KERNEL_VERSION=' in docker/talos-kernel/Dockerfile" >&2; exit 1; }
+    echo "${version}"
+
 # Decrypts on stdout only; callers pipe it so the plaintext lives no longer than the command
 # and never reaches disk or a shell variable.
 [private]
@@ -32,11 +41,7 @@ talsecret:
 template file *args:
     talos_version="$(just tuppr-version talos)"
     kubernetes_version="$(just tuppr-version kubernetes)"
-    # Renovate maintains the kernel version in one place, the Dockerfile ARG. Reading it here
-    # stops a node advertising a version whose image was never built. Guarded because sed exits
-    # 0 with empty output, which --strict cannot catch.
-    kernel_version="$(sed -nE 's/^ARG KERNEL_VERSION=(.+)$/\1/p' "{{ justfile_directory() }}/docker/talos-kernel/Dockerfile")"
-    [ -n "${kernel_version}" ] || { echo "no 'ARG KERNEL_VERSION=' in docker/talos-kernel/Dockerfile" >&2; exit 1; }
+    kernel_version="$(just kernel-version)"
     # Piped, not <(just talsecret): through a pipe `pipefail` sees a failed decrypt.
     just talsecret | minijinja-cli --strict --format=yaml --autoescape=none \
         -D "talosVersion=${talos_version}" \

--- a/scripts/talos-kernel-build.sh
+++ b/scripts/talos-kernel-build.sh
@@ -20,9 +20,7 @@ trap 'rm -rf "${WORK}"' EXIT
 # Read the kernel version out of the Renovate-managed line rather than taking it as an
 # argument: a bump PR is then what changes the build. Taken separately, Renovate could edit
 # the Dockerfile while the tag and the built kernel came from whatever number was typed.
-KERNEL_DOCKERFILE="${REPO_ROOT}/docker/talos-kernel/Dockerfile"
-KERNEL_VERSION="$(sed -nE 's/^ARG KERNEL_VERSION=(.+)$/\1/p' "${KERNEL_DOCKERFILE}")"
-: "${KERNEL_VERSION:?no 'ARG KERNEL_VERSION=' line in ${KERNEL_DOCKERFILE}}"
+KERNEL_VERSION="$(just kernel-version)"
 
 # tuppr compares this to the version the node reports, so the kernel has to be IN the string
 # or a kernel-only bump is invisible to it. See README.md "Version tagging".
@@ -165,6 +163,7 @@ DIGESTS="$(crane export "ghcr.io/siderolabs/extensions:${TALOS_VERSION}" - | tar
 # EXIT trap then cannot unlink the imager's output, leaking it and failing the script's exit.
 mkdir -p "${WORK}/out"
 declare -A BUILT=()
+PUBLISHED=()
 for node in "$@"; do
     schematic="$(just talos schematic-file "${node}")"
     # One image per SCHEMATIC, not per node — two schematics, two images, however many nodes.
@@ -186,6 +185,7 @@ for node in "$@"; do
         else
             log "installer for ${node}: copying from ${BUILT[${schematic}]}"
             crane copy "${BUILT[${schematic}]}" "${dst}"
+            PUBLISHED+=("${dst}")
         fi
         continue
     fi
@@ -217,6 +217,15 @@ for node in "$@"; do
         --arch amd64 --base-installer-image "${PREFIX}/installer-base:${VERSION}" "${args[@]}"
     crane push "${WORK}/out/installer-amd64.tar" "${dst}"
     BUILT[${schematic}]="${dst}"
+    PUBLISHED+=("${dst}")
 done
 
-log "done: ${PREFIX}/installer[/<node>]:${VERSION}"
+# Reported from here rather than rebuilt in CI: the mapping from schematic to repo lives in the
+# loop above, and a second copy in a workflow step drifts. Under Actions this becomes the job
+# summary; locally it is the closing log line.
+{
+    echo "### Talos custom kernel"
+    echo "Linux \`${KERNEL_VERSION}\` on Talos \`${TALOS_VERSION}\`"
+    echo
+    for ref in "${PUBLISHED[@]}"; do echo "- \`${ref}\`"; done
+} >> "${GITHUB_STEP_SUMMARY:-/dev/stdout}"

--- a/talos/mod.just
+++ b/talos/mod.just
@@ -76,6 +76,14 @@ download-image node version:
         -o "{{ source_directory() }}/talos-{{ version }}-${schematic:0:8}.iso" \
         "https://factory.talos.dev/image/${schematic}/{{ version }}/metal-amd64.iso"
 
+# The node files are the fleet inventory, so a caller cannot build against a stale hand-written
+# list. Schematics are `<node>.schematic.yaml`, so the glob picks up node files only.
+[private]
+nodes:
+    names="$(basename -s .yaml.j2 -a "{{ source_directory() }}"/nodes/*/*.yaml.j2 | sort | tr '\n' ' ')"
+    [[ -n "${names// /}" ]] || { echo "no node files under nodes/" >&2; exit 1; }
+    echo "${names}"
+
 # Directory placement is the single source of truth for a node's role; machine.type is
 # set by the role layer, so a node cannot claim one role by filename and another by content.
 [private]
@@ -128,7 +136,9 @@ machine-image node:
     [[ -n "${image}" ]] || { echo "no install image in rendered config for {{ node }}" >&2; exit 1; }
     echo "${image}"
 
-[doc('Build the custom-kernel Talos installer for the given nodes (docker/talos-kernel/README.md)')]
-kernel-build +nodes:
+[doc('Build the custom-kernel Talos installers; defaults to every node (docker/talos-kernel/README.md)')]
+kernel-build *nodes:
+    names="{{ nodes }}"
+    [[ -n "${names}" ]] || names="$(just talos nodes)"
     "{{ justfile_directory() }}/scripts/talos-kernel-build.sh" \
-        "$(just tuppr-version talos)" {{ nodes }}
+        "$(just tuppr-version talos)" ${names}


### PR DESCRIPTION
Closes the loop the kernel PR opens: Renovate bumps `ARG KERNEL_VERSION`, the node config derives its install tag from that same ARG, so merging a bump without building points nodes at a tag nobody published.

## Shape

One job, not the three the sizing work suggested. The split existed to get disk headroom, and moving Docker's `data-root` to `/mnt` solves that directly:

| | |
|---|---|
| pipeline needs | ~35-40 GB (kernel layer alone ~17.7 GB) |
| free on `/` | 21-31 GB — dies mid-compile with an opaque ENOSPC |
| free on `/mnt` | ~66 GB |
| runtime | ~2h45m on 4 vCPU, against a 6h job ceiling |

`concurrency: cancel-in-progress` because successive pushes otherwise leave cancelled runs that read as a wedged runner — we spent an evening misdiagnosing exactly that.

## One-time setup required before the first run

`GITHUB_TOKEN` can push to `ghcr.io/<repo-owner>/*`, but only to packages the repo has been granted access to. These packages were created by hand from a workstation, so they are **not** linked to this repo and the first run will 403 until each is given write access under **Package settings → Manage Actions access → Add repository**:

`kernel`, `linux-firmware`, `amdgpu`, `installer-base`, `imager`, `installer/shared`, `installer/control-1`

Noted in a comment beside the login step too, since that is where a 403 sends you.

## Checks

- `zizmor`: no findings — actions hash-pinned, `persist-credentials: false`, and the `workflow_dispatch` input passed through `env` rather than interpolated into a `run` block
- Stacked on #4615, which touches the same `.justfile` and `talos/mod.just` lines

## Derived, not hardcoded

| was | now |
|---|---|
| `control-1 control-2 control-3` in the run block | `just talos nodes`, globbed from `talos/nodes/` |
| kernel `sed` in three files | one `kernel-version` recipe, shared by `.justfile` and the build script |
| summary step re-deriving the schematic→repo map and calling `crane digest` twice per ref | script reports the refs it already published |

