### PR TITLE
fix(omniroute): hold at e8e2e69 and stop Renovate reopening the bump

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -76,6 +76,14 @@
       automergeType: "pr"
     },
     {
+      // Renovate opened this digest bump twice within eight minutes and both were
+      // merged, so a comment on the pin does not hold it -- the PR has to not exist.
+      description: 'omniroute next digest -- HELD. The current `next` build ships package.json with "type": "module" while server.js still calls require(), so the entrypoint throws at boot and the pod crashloops (upstream d87b97a78, no fixed build as of 2026-08-21). Re-enable together with the hold note in the omniroute HelmRelease once a `next` build starts cleanly.',
+      matchDatasources: ["docker"],
+      matchPackageNames: ["diegosouzapw/omniroute"],
+      enabled: false
+    },
+    {
       description: "vllm-openai-rocm nightly digest — the rolling `nightly` tag is digest-pinned so Renovate can detect new builds at all; never auto-merge, a bump rolls the single-GPU serving pod and can move the KV pool that maxModelLen is sized against",
       matchDatasources: ["docker"],
       matchPackageNames: ["vllm/vllm-openai-rocm"],

--- a/kubernetes/apps/ai/omniroute/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/omniroute/app/helmrelease.yaml
@@ -31,11 +31,12 @@ spec:
               # can diff against, so it will only ever offer digest bumps that
               # walk this further along the branch. Digest-pinned so the branch
               # moving does not silently move us.
-              # Held at e8e2e69: the next digest (ac9606f) crashloops --
-              # package.json gained "type": "module" while server.js still
-              # uses require(), so the entrypoint dies at boot (upstream
-              # d87b97a78). Unhold once a next build starts cleanly.
-              tag: next@sha256:ac9606fc9b813d8b066f32da79ee42214c7bdd0a21072bbd1e363827ab70236c
+              # Held at e8e2e69: ac9606f crashloops -- package.json gained
+              # "type": "module" while server.js still uses require(), so the
+              # entrypoint dies at boot (upstream d87b97a78). This comment alone
+              # did not hold it (merged past twice), so the hold is enforced by
+              # the disabled Renovate rule in .renovaterc.json5; lift both together.
+              tag: next@sha256:e8e2e69cc705b3d5ee2503dd6d1d17ab94a2d69f01e9425f10aa1b6a4cbb3633
             env:
               TZ: ${TIMEZONE}
               DATA_DIR: /app/data


### PR DESCRIPTION
Third deployment of `ac9606f` tonight, third crashloop. Reverts the pin and enforces the hold where a comment cannot.

## Why it crashes

```
file:///app/server.js:1
const path = require('path')
             ^
ReferenceError: require is not defined in ES module scope
```

`package.json` ships `"type": "module"` while `server.js` still calls `require()`. Upstream `d87b97a78` changed both together. No fixed `next` build exists — Docker Hub `next` is still `1621f015` (2026-08-20T21:51Z), which `ac9606f` resolves from.

## Why a comment did not hold it

| | |
|---|---|
| #4594 | bump merged → crashloop, 6 restarts |
| #4597 | revert + pin comment → healthy |
| #4598 | Renovate reopened the **identical** digest 8 min later, merged → crashloop |
| ks interval | reapplied it a third time at 22:37Z |

Both bumps were authored by Renovate and **merged by hand**, so `automerge: false` would not have stopped either. The PR has to not be created — hence `enabled: false`, following the `vllm-openai-rocm` precedent for a digest-pinned rolling tag.

## Lifting it

Delete the `.renovaterc.json5` rule and the hold note in the HelmRelease together, once a `next` build boots cleanly.

Validator output is unchanged apart from the pre-existing `minimumGroupSize` / `managerFilePatterns` false positives.