### PR TITLE
fix(fileflows): request ephemeral-storage so it stops being the eviction victim

### DIFF
--- a/kubernetes/apps/media/fileflows/app/helmrelease.yaml
+++ b/kubernetes/apps/media/fileflows/app/helmrelease.yaml
@@ -67,6 +67,12 @@ spec:
               requests:
                 cpu: 100m
                 memory: 512Mi
+                # Transcode scratch lives on the container filesystem, ~1.3GiB
+                # steady. With no request, usage-over-request ranking made this
+                # the first pod kubelet evicted when control-1 brushed its
+                # ephemeral-storage threshold (2026-08-20 19:40, exit 137).
+                # No limit on purpose: a limit evicts the pod itself mid-transcode.
+                ephemeral-storage: 2Gi
                 squat.ai/dri: 1
               limits:
                 cpu: 2


### PR DESCRIPTION
fileflows was evicted from control-1 on 2026-08-20 at 19:40:32Z:

```
reason=Evicted
The node was low on resource: ephemeral-storage.
Threshold: 80463020976, available: 78017988Ki.
Container app was using 1148032Ki, request is 0
exitCode 137
```

Kubelet ranks eviction victims by usage above request. With no `ephemeral-storage` request, fileflows sorted first — it was the largest consumer measured against a request of zero.

## Measured on control-1

| pod | ephemeral-storage |
|---|---|
| `media/fileflows` | **1301 MiB** |
| `default/nextcloud` | 670 MiB |
| `ai/qwen38-27b-vllm` | 336 MiB |
| everything else | < 64 MiB |

2Gi covers the steady state with headroom.

## Request without a limit, deliberately

An `ephemeral-storage` limit makes kubelet evict *this* pod once it exceeds the limit, which would trade a rare node-pressure eviction for a predictable mid-transcode one. The request alone is what moves it out of the front of the victim queue.

control-1 sits near its ephemeral floor by design (KV guard), so this will recur — this just makes the app doing real work stop being the one picked.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved FileFlows workload stability by reserving 2 GiB of temporary storage for scratch-space operations.
  * Reduced the likelihood of eviction during storage-intensive processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->