### PR TITLE
fix(talos): complete the custom-kernel rollout and keep tuppr able to upgrade it

### DIFF
--- a/docker/talos-kernel/README.md
+++ b/docker/talos-kernel/README.md
@@ -232,7 +232,7 @@ talosctl -n <ip> upgrade --image ghcr.io/tanguille/installer/<node>:<version> \
 Do one node at a time and confirm `etcd` rejoins between each — the fleet is three
 control-plane nodes and etcd tolerates exactly one down.
 
-### The rollout is not self-closing yet
+### The rollout is not self-closing
 
 Booting a node off a locally imaged installer does **not** finish the job, and the failure is
 silent. A locally imaged node reports no `schematic` extension, and `looksLikeGenericInstaller`
@@ -248,7 +248,7 @@ reported "All nodes are up to date" only because `findNextNodes` skips every nod
 `Status.CompletedNodes` before it ever compares versions; that list resets when the CR
 generation changes, i.e. on the next Talos bump.
 
-Two things have to be true for a node, and both are now done for control-2:
+Two things have to be true for a node. All three nodes satisfy both as of 2026-08-21:
 
 1. **`.machine.install.image` repointed** to `ghcr.io/tanguille/installer/<schematic>`. Left on
    `factory.talos.dev`, tuppr's bare `<repo>:<targetVersion>` substitution silently reinstalls
@@ -258,10 +258,18 @@ Two things have to be true for a node, and both are now done for control-2:
    Renovate-managed against `siderolabs/talos` and would rewrite `v1.13.9-k7.1.9` to
    `v1.13.10`, eating the suffix. So the kernel half lives in a per-node
    `machine.nodeAnnotations."tuppr.home-operations.com/version"`, which `getTargetVersion`
-   prefers over the CR (`upgrade.go:855`). control-1 and control-3 keep taking the plain
-   version from `spec.talos.version` and still resolve against the Factory.
+   prefers over the CR (`upgrade.go:855`).
 
-Still outstanding for the other two nodes: build their installers, repoint and annotate them
-the same way, and flip each new ghcr package public. Until then treat a Talos bump as "re-run
-the build and re-cut the affected nodes by hand", and keep at least one node on stock so a bad
-kernel cannot take the fleet.
+Keep the annotation per-node rather than hoisting it to a shared layer: it is what allows one
+node to move while the others stay put, which is how all three were rolled.
+
+**A third thing is true for the CR.** Once a node reports `v<talos>-k<kernel>`, tuppr derives the
+talosctl job image tag from that same string and pulls
+`ghcr.io/siderolabs/talosctl:v1.13.9-k7.1.9`, which siderolabs never publishes — the job hangs in
+ImagePullBackOff until `policy.timeout`. Measured on control-2 on 2026-08-21. `spec.talosctl.image.tag`
+is pinned to the plain upstream version to stop it. It only bites on the *second* roll of a node,
+because the first still has an unsuffixed version at the moment the job is built.
+
+Since every node now runs a custom kernel, no node is left on stock as a fallback, and a Talos bump
+still means "re-run the build, then re-cut the nodes" — `just talos upgrade-node <node> <ip>` reads
+the pinned image straight out of the rendered config.

--- a/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
@@ -11,6 +11,13 @@ spec:
     # the default, so a docker datasource would silently freeze at the last tag it ever saw.
     # renovate: datasource=github-releases depName=siderolabs/talos
     version: v1.14.0-rc.1
+  talosctl:
+    image:
+      # tuppr derives this tag from the node's CURRENT version. Custom-kernel nodes report
+      # v1.13.9-k7.1.9, which siderolabs never publishes, so leaving it unset ImagePullBackOffs
+      # the upgrade job on the second roll of any such node.
+      # renovate: datasource=github-releases depName=siderolabs/talos
+      tag: v1.14.0-rc.1
   policy:
     rebootMode: powercycle
   healthChecks:

--- a/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
@@ -10,14 +10,14 @@ spec:
     # stopped partway through the v1.14 cycle (alpha.0 still had it) once Image Factory became
     # the default, so a docker datasource would silently freeze at the last tag it ever saw.
     # renovate: datasource=github-releases depName=siderolabs/talos
-    version: v1.14.0-rc.1
+    version: &talosVersion v1.14.0-rc.1
   talosctl:
     image:
       # tuppr derives this tag from the node's CURRENT version. Custom-kernel nodes report
       # v1.13.9-k7.1.9, which siderolabs never publishes, so leaving it unset ImagePullBackOffs
-      # the upgrade job on the second roll of any such node.
-      # renovate: datasource=github-releases depName=siderolabs/talos
-      tag: v1.14.0-rc.1
+      # the upgrade job on the second roll of any such node. Aliased, not repeated: the two must
+      # agree, and the preset's regex handles `&anchor` so Renovate still bumps the one literal.
+      tag: *talosVersion
   policy:
     rebootMode: powercycle
   healthChecks:

--- a/talos/nodes/controlplane/control-1.yaml.j2
+++ b/talos/nodes/controlplane/control-1.yaml.j2
@@ -1,8 +1,15 @@
+{%- set pinned = talosVersion ~ "-k" ~ kernelVersion -%}
 ---
 # TrueNAS hypervisor VM on 192.168.0.27. Only node with the dGPU (R9700).
 machine:
   install:
     disk: /dev/vda
+    # Its own schematic (control-1.schematic.yaml adds the dGPU extensions), so its own installer
+    # repo -- control-2/3 share talos/schematic.yaml and cannot use this image.
+    image: ghcr.io/tanguille/installer/control-1:{{ pinned }}
+  # Must match the tag above exactly; getTargetVersion prefers this over spec.talos.version.
+  nodeAnnotations:
+    tuppr.home-operations.com/version: {{ pinned }}
   nodeLabels:
     # GPU label for applications; the amdgpu kernel module is loaded
     # automatically by the siderolabs/amdgpu system extension

--- a/talos/nodes/controlplane/control-2.yaml.j2
+++ b/talos/nodes/controlplane/control-2.yaml.j2
@@ -2,7 +2,7 @@
 ---
 # Chuwi ubox. Runs in-cluster Kepler (has RAPL, unlike the control-1 VM).
 #
-# The only node on a self-built kernel: Linux {{ kernelVersion }} for the in-kernel Ceph client's
+# All three nodes run a self-built kernel: Linux {{ kernelVersion }} for the in-kernel Ceph client's
 # aes256k support, which 6.18.x does not have. Both lines below are load-bearing together —
 # see docker/talos-kernel/README.md "The rollout is not self-closing yet".
 machine:

--- a/talos/nodes/controlplane/control-2.yaml.j2
+++ b/talos/nodes/controlplane/control-2.yaml.j2
@@ -4,7 +4,7 @@
 #
 # All three nodes run a self-built kernel: Linux {{ kernelVersion }} for the in-kernel Ceph client's
 # aes256k support, which 6.18.x does not have. Both lines below are load-bearing together —
-# see docker/talos-kernel/README.md "The rollout is not self-closing yet".
+# see docker/talos-kernel/README.md "The rollout is not self-closing".
 machine:
   install:
     disk: /dev/nvme1n1

--- a/talos/nodes/controlplane/control-3.yaml.j2
+++ b/talos/nodes/controlplane/control-3.yaml.j2
@@ -1,9 +1,17 @@
+{%- set pinned = talosVersion ~ "-k" ~ kernelVersion -%}
 ---
 # Chuwi ubox. Runs in-cluster Kepler. Install disk is addressed by-id because the
 # Micron 7450 has a thermal-shutdown history and must stay unambiguous across reseats.
 machine:
   install:
     disk: /dev/disk/by-id/nvme-Micron_7450_MTFDKBA480TFR_241548387F46
+    # Same shared installer as control-2: both nodes use talos/schematic.yaml, so the image is
+    # byte-identical. Pointing this at our registry rather than the Factory is what stops the
+    # next Talos bump silently reinstalling the stock 6.18 kernel.
+    image: ghcr.io/tanguille/installer/shared:{{ pinned }}
+  # Must match the tag above exactly; getTargetVersion prefers this over spec.talos.version.
+  nodeAnnotations:
+    tuppr.home-operations.com/version: {{ pinned }}
   nodeLabels:
     amd.com/igpu: "true"
     kepler-node: "true"


### PR DESCRIPTION
All three nodes now run `v1.14.0-rc.1-k7.1.9` / kernel `7.1.9-talos`. Rolled manually one node at a time; this makes the live state durable in git.

| node | Talos | kernel | installer image |
|---|---|---|---|
| control-1 | v1.14.0-rc.1-k7.1.9 | 7.1.9-talos | `installer/control-1:v1.14.0-rc.1-k7.1.9` |
| control-2 | v1.14.0-rc.1-k7.1.9 | 7.1.9-talos | `installer/shared:v1.14.0-rc.1-k7.1.9` |
| control-3 | v1.14.0-rc.1-k7.1.9 | 7.1.9-talos | `installer/shared:v1.14.0-rc.1-k7.1.9` |

## tuppr talosctl tag

tuppr derives the talosctl job image tag from the node's **current** Talos version. Custom-kernel nodes report `v1.13.9-k7.1.9`, which siderolabs never publishes.

```
Failed to pull image "ghcr.io/siderolabs/talosctl:v1.13.9-k7.1.9": not found
```

Measured on control-2; the job hung in ImagePullBackOff. It only fires on the *second* roll of such a node, because the first still has a plain upstream version string. With all three nodes now on `-k` versions, tuppr cannot upgrade any of them until this lands.

`spec.talosctl.image.tag` carries the same renovate annotation as `talos.version`, so the existing Talos group bumps both together.

## control-1 / control-3 installer pins

Both still resolved `machine.install.image` against `factory.talos.dev`, so the next Talos bump would have reinstalled the stock 6.18 kernel with no error. Each is pinned to its own installer repo plus a matching tuppr version annotation.

## Verification

- `talosctl upgrade` exit 0 on all three
- 0 kernel faults on a strict `Oops:|kernel BUG at|Kernel panic|Call Trace:|...` scan after 8.5 h uptime
- Ceph returned to `81 pgs: 81 active+clean`, 3/3 OSDs, between every node
- Both installer images confirmed anonymously pullable with an empty `DOCKER_CONFIG`
- 1.13.9 node accepted the 1.14-rendered config (dry-run); diff was exactly the intended lines

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added explicit version pinning for Talos upgrades to improve upgrade consistency and predictability.
  - Control-plane nodes now use version-specific installer images aligned with the configured Talos and kernel versions.
  - Upgrade metadata is synchronized with the selected installer versions.

- **Documentation**
  - Clarified that all control-plane nodes use the self-built Linux kernel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->