### PR TITLE
fix(omniroute): revert to e8e2e69 and make the Renovate hold actually match

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -96,7 +96,11 @@
       // merged, so a comment on the pin does not hold it -- the PR has to not exist.
       description: 'omniroute next digest -- HELD. The current `next` build ships package.json with "type": "module" while server.js still calls require(), so the entrypoint throws at boot and the pod crashloops (upstream d87b97a78, no fixed build as of 2026-08-21). Re-enable together with the hold note in the omniroute HelmRelease once a `next` build starts cleanly.',
       matchDatasources: ["docker"],
-      matchPackageNames: ["diegosouzapw/omniroute"],
+      // regex form on purpose: the HelmRelease writes the image as
+      // docker.io/diegosouzapw/omniroute, so the depName carries the registry
+      // prefix and the bare exact-match name never matched -- the first attempt
+      // at this rule was bypassed by two bumps within 90 seconds.
+      matchPackageNames: ["/diegosouzapw\\/omniroute/"],
       enabled: false
     },
     {

--- a/kubernetes/apps/ai/omniroute/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/omniroute/app/helmrelease.yaml
@@ -36,7 +36,7 @@ spec:
               # entrypoint dies at boot (upstream d87b97a78). This comment alone
               # did not hold it (merged past twice), so the hold is enforced by
               # the disabled Renovate rule in .renovaterc.json5; lift both together.
-              tag: next@sha256:ed185b5f8ae7891d23f5c79a31b2bf3b5a6295ea70ad7fa541ed30ef7b098aa7
+              tag: next@sha256:e8e2e69cc705b3d5ee2503dd6d1d17ab94a2d69f01e9425f10aa1b6a4cbb3633
             env:
               TZ: ${TIMEZONE}
               DATA_DIR: /app/data


### PR DESCRIPTION
omniroute spent the night in CrashLoopBackOff — **338 restarts over 6h58m** on `ac9606f`.

## The hold from #4604 never matched

The HelmRelease writes `repository: docker.io/diegosouzapw/omniroute`, so Renovate's depName carries the registry prefix. `matchPackageNames: ["diegosouzapw/omniroute"]` is an exact match, so it matched nothing:

| PR | created | vs hold (merged 22:50Z) | result |
|---|---|---|---|
| #4606 | 22:51:37Z | +90 seconds | merged → crashloop |
| #4608 | 00:14:22Z | +1h24m | merged → crashloop |

Switched to the regex form the rest of this file already uses (`"/gha-runner-scale-set/"`, `"/siderolabs\\//"`).

## ed185b5 does not fix it

The new `next` build (2026-08-21T03:51Z) crashes identically:

```
file:///app/server.js:1
const path = require('path')
ReferenceError: require is not defined in ES module scope
```

Upstream still has not renamed `server.js` to `.cjs` alongside the `"type": "module"` change in `d87b97a78`.

Back to `e8e2e69`, the last digest that boots. Validator output unchanged apart from the pre-existing `minimumGroupSize` / `managerFilePatterns` false positives.