### PR TITLE
fix(rook-ceph): rotate cephx keys to aes256k to unblock the stalled Ceph upgrade

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -41,6 +41,27 @@ spec:
       repository: quay.io/ceph/ceph
       tag: v20.2.4@sha256:6bb1c8a42fbc0bf87938946990b65174466997bc11c31eb5a323225a779fd8f9
     cephClusterSpec:
+      # Ceph 20 flags cipher `aes` as HEALTH_ERR, which makes Rook refuse the OSD upgrade
+      # ("refusing to upgrade"), stranding OSDs on 20.2.3 while mon/mgr/mds ran 20.2.4.
+      # aes256k needs the in-kernel Ceph client from Linux 7.0; all nodes run 7.1.9 since 2026-08-21.
+      # keyType is a no-op unless keyRotationPolicy is set. allowedCiphers is deliberately NOT set
+      # here: restricting to aes256k before every key has rotated locks out the aes clients.
+      security:
+        cephx:
+          daemon:
+            keyRotationPolicy: KeyGeneration
+            keyGeneration: 2
+            keyType: aes256k
+          csi:
+            keyRotationPolicy: KeyGeneration
+            keyGeneration: 2
+            keyType: aes256k
+            # Keeps the prior key active so in-flight PV connections survive the rotation.
+            keepPriorKeyCountMax: 1
+          rbdMirrorPeer:
+            keyRotationPolicy: KeyGeneration
+            keyGeneration: 2
+            keyType: aes256k
       cephConfig:
         global:
           # Rook rejects non-string cephConfig values.


### PR DESCRIPTION
## The deadlock

Ceph 20 flags cipher `aes` as **[ERR]**. That makes the cluster HEALTH_ERR, and Rook refuses to upgrade an unhealthy cluster, so the OSDs never left 20.2.3:

```
mon  3 daemons  20.2.4
mgr  2 daemons  20.2.4
mds  2 daemons  20.2.4
osd  3 daemons  20.2.3   ← stranded
```

```
CephCluster: failed the ceph version check: ceph status in namespace rook-ceph
is not healthy, refusing to upgrade
HelmRelease rook-ceph-cluster: UpgradeFailed + Stalled (MissingRollbackTarget)
```

```
[ERR] AUTH_INSECURE_SERVICE_KEY_TYPE: 7 auth service entities with insecure key types
        mds.ceph-filesystem-a/b, osd.0/1/3, mgr.a/b  -> aes
[ERR] AUTH_INSECURE_SERVICE_TICKETS
[WRN] AUTH_INSECURE_CLIENT_KEY_TYPE: 8 client entities -> aes
```

`spec.security.cephx` was `{"csi":{"keyType":"aes"}}` — the chart default, not set in this repo.

## Why now

`aes256k` requires the in-kernel Ceph client from Linux 7.0 (CVE-2025-30156). All three nodes have run `7.1.9-talos` since 2026-08-21, so the prerequisite that blocked this is gone.

## Notes

- `keyType` is a no-op unless `keyRotationPolicy` is set, so all three key groups get both.
- `keepPriorKeyCountMax: 1` keeps the prior CSI key active so existing PV connections survive the rotation.
- **`allowedCiphers` is deliberately not set here.** Restricting to `aes256k` before every key has rotated would lock out the eight clients still on `aes`. That is a follow-up once rotation is verified complete — and it is required, because `AUTH_INSECURE_SERVICE_TICKETS` is the second [ERR].

## Expected

Rotation clears `AUTH_INSECURE_SERVICE_KEY_TYPE`; after the `allowedCiphers` follow-up the cluster leaves HEALTH_ERR and Rook resumes the OSD upgrade to 20.2.4.

The HelmRelease is currently Stalled, so it may need a forced reconcile after merge.