### PR TITLE
refactor(talos): take the Image Factory off the render path

### DIFF
--- a/.agents/common-operations.md
+++ b/.agents/common-operations.md
@@ -13,6 +13,18 @@ Step-by-step procedures for frequent cluster tasks.
 - Shell-only changes: `mise exec -- shellcheck` on every touched `*.sh`.
 - Documentation-only changes: run `git diff --check` and verify every changed local reference exists.
 
+## Ceph: `crash ls-new` is a window, not a history
+
+`ceph crash ls-new` only retains entries newer than `mgr/crash/warn_recent_interval` (86400s here),
+so its oldest entry is the floor of that window, not when the problem started. Reading a first-seen
+date off it under-reports age, in one case by eight months. Use `ceph crash ls` for the real start.
+
+## Ceph: `crash ls-new` is a window, not a history
+
+`ceph crash ls-new` only retains entries newer than `mgr/crash/warn_recent_interval` (86400s here),
+so its oldest entry is the floor of that window, not when the problem started. Reading a first-seen
+date off it under-reports age, in one case by eight months. Use `ceph crash ls` for the real start.
+
 ## Shell: statuses `set -e` does not see
 
 `set -euo pipefail` does **not** catch a failure in a process substitution, or in a command

--- a/.agents/common-operations.md
+++ b/.agents/common-operations.md
@@ -19,12 +19,6 @@ Step-by-step procedures for frequent cluster tasks.
 so its oldest entry is the floor of that window, not when the problem started. Reading a first-seen
 date off it under-reports age, in one case by eight months. Use `ceph crash ls` for the real start.
 
-## Ceph: `crash ls-new` is a window, not a history
-
-`ceph crash ls-new` only retains entries newer than `mgr/crash/warn_recent_interval` (86400s here),
-so its oldest entry is the floor of that window, not when the problem started. Reading a first-seen
-date off it under-reports age, in one case by eight months. Use `ceph crash ls` for the real start.
-
 ## Shell: statuses `set -e` does not see
 
 `set -euo pipefail` does **not** catch a failure in a process substitution, or in a command

--- a/.agents/common-operations.md
+++ b/.agents/common-operations.md
@@ -13,11 +13,14 @@ Step-by-step procedures for frequent cluster tasks.
 - Shell-only changes: `mise exec -- shellcheck` on every touched `*.sh`.
 - Documentation-only changes: run `git diff --check` and verify every changed local reference exists.
 
-## Ceph: `crash ls-new` is a window, not a history
+## Ceph: `crash ls-new` hides archived crashes, not old ones
 
-`ceph crash ls-new` only retains entries newer than `mgr/crash/warn_recent_interval` (86400s here),
-so its oldest entry is the floor of that window, not when the problem started. Reading a first-seen
-date off it under-reports age, in one case by eight months. Use `ceph crash ls` for the real start.
+`ceph crash ls-new` filters on exactly one thing, whether a crash is archived (`crash/module.py`
+`do_ls_new`); age plays no part. `mgr/crash/warn_recent_interval` (86400s here) only gates the
+`RECENT_CRASH` health warning, so it is **not** what bounds this list. The oldest entry is the floor
+of "since the last `crash archive`/`archive-all`", not when the problem started -- which is how a
+first-seen date read off it under-reported an age by eight months. Use `ceph crash ls`, which lists
+archived crashes too, and `ceph crash info <crash-id>` for the real timestamps.
 
 ## Shell: statuses `set -e` does not see
 

--- a/.justfile
+++ b/.justfile
@@ -42,6 +42,7 @@ template file *args:
         -D "talosVersion=${talos_version}" \
         -D "kubernetesVersion=${kubernetes_version}" \
         -D "kernelVersion=${kernel_version}" \
+        -D "pinned=${talos_version}-k${kernel_version}" \
         {{ args }} "{{ file }}" -
 
 [doc('Force Flux to pull in changes from the Git repository')]

--- a/talos/AGENTS.md
+++ b/talos/AGENTS.md
@@ -10,5 +10,8 @@
   merging a change to `talos/` only changes what `render-config` produces.
 - A node rejects the whole config if it contains a document its version does not know, so during
   any mixed-version window a new document in `cluster.yaml.j2` breaks `diff-node` fleet-wide.
+- A new node must declare its own `machine.install.image`. There is no cluster-layer fallback:
+  every node pins a custom-kernel installer, so an unpinned node renders with no image rather than
+  falling back to a stock-kernel Factory build.
 - `control-1` is the TrueNAS VM and the only dGPU host. Upgrade it last, and never taint it or
   GPU workloads have nowhere to schedule.

--- a/talos/cluster.yaml.j2
+++ b/talos/cluster.yaml.j2
@@ -62,8 +62,6 @@ machine:
   install:
     wipe: false
     grubUseUKICmdline: true
-    # Identical for every node; the schematic id is resolved per node and passed in.
-    image: factory.talos.dev/installer/{{ schematic }}:{{ talosVersion }}
   time:
     disabled: false
     servers: [{{ gateway }}]

--- a/talos/mod.just
+++ b/talos/mod.just
@@ -110,8 +110,8 @@ schematic-file node:
 # Kept for download-image, and scripts/talos-kernel-build.sh reads the schematic files themselves.
 # Schematics are plain YAML, not templates: POST the file directly rather than routing it through
 # `template`, which would decrypt the secrets bundle to render a file that references no secrets.
-# Bounded because a stalled factory blocks every render. Retries are safe: the endpoint is
-# content-addressed, so re-POSTing identical content returns the same id.
+# Bounded so `download-image` fails rather than hanging on a stalled factory. Retries are safe:
+# the endpoint is content-addressed, so re-POSTing identical content returns the same id.
 [private]
 schematic-id node:
     file="$(just talos schematic-file "{{ node }}")"

--- a/talos/mod.just
+++ b/talos/mod.just
@@ -15,14 +15,10 @@ gateway := "192.168.0.1"
 
 [doc('Render a node full machine config to stdout')]
 render-config node:
-    schematic="$(just talos schematic-id "{{ node }}")"
     role="$(just talos node-role "{{ node }}")"
-    # Belt and braces: both callees already fail on empty, but schematic feeds an install image
-    # path where an empty value renders a plausible ref that resolves to nothing.
-    [[ -n "${schematic}" ]] || { echo "empty schematic id for {{ node }}" >&2; exit 1; }
     [[ -n "${role}" ]] || { echo "empty role for {{ node }}" >&2; exit 1; }
     # One context for every layer, so any layer may reference any of these.
-    ctx=(-D "vip={{ vip }}" -D "gateway={{ gateway }}" -D "schematic=${schematic}")
+    ctx=(-D "vip={{ vip }}" -D "gateway={{ gateway }}")
     # Rendered to variables before talosctl runs, so a failed layer aborts before a single byte
     # reaches stdout. Inline <(just template) dropped the layer silently and still emitted a
     # config, which apply-node pipes straight to a node.
@@ -110,6 +106,8 @@ schematic-file node:
     done
     echo "{{ source_directory() }}/schematic.yaml"
 
+# Not on the render path: every node pins its own installer, so nothing templates a Factory ref.
+# Kept for download-image, and scripts/talos-kernel-build.sh reads the schematic files themselves.
 # Schematics are plain YAML, not templates: POST the file directly rather than routing it through
 # `template`, which would decrypt the secrets bundle to render a file that references no secrets.
 # Bounded because a stalled factory blocks every render. Retries are safe: the endpoint is
@@ -130,7 +128,6 @@ machine-image node:
     image="$(just talos render-config "{{ node }}" | yq -er 'select(.machine.install != null) | .machine.install.image')"
     [[ -n "${image}" ]] || { echo "no install image in rendered config for {{ node }}" >&2; exit 1; }
     echo "${image}"
-
 
 [doc('Build the custom-kernel Talos installer for the given nodes (docker/talos-kernel/README.md)')]
 kernel-build +nodes:

--- a/talos/mod.just
+++ b/talos/mod.just
@@ -106,8 +106,7 @@ schematic-file node:
     done
     echo "{{ source_directory() }}/schematic.yaml"
 
-# Not on the render path: every node pins its own installer, so nothing templates a Factory ref.
-# Kept for download-image, and scripts/talos-kernel-build.sh reads the schematic files themselves.
+# Off the render path since every node pins its own installer: `download-image` is the only caller.
 # Schematics are plain YAML, not templates: POST the file directly rather than routing it through
 # `template`, which would decrypt the secrets bundle to render a file that references no secrets.
 # Bounded so `download-image` fails rather than hanging on a stalled factory. Retries are safe:

--- a/talos/nodes/controlplane/control-1.yaml.j2
+++ b/talos/nodes/controlplane/control-1.yaml.j2
@@ -1,4 +1,3 @@
-{%- set pinned = talosVersion ~ "-k" ~ kernelVersion -%}
 ---
 # TrueNAS hypervisor VM on 192.168.0.27. Only node with the dGPU (R9700).
 machine:

--- a/talos/nodes/controlplane/control-2.yaml.j2
+++ b/talos/nodes/controlplane/control-2.yaml.j2
@@ -1,4 +1,3 @@
-{%- set pinned = talosVersion ~ "-k" ~ kernelVersion -%}
 ---
 # Chuwi ubox. Runs in-cluster Kepler (has RAPL, unlike the control-1 VM).
 #
@@ -8,19 +7,13 @@
 machine:
   install:
     disk: /dev/nvme1n1
-    # Our registry, not the Factory: tuppr rebuilds the upgrade target as
-    # "<repo>:<targetVersion>", taking <repo> from this very field. Left pointing at
-    # factory.talos.dev, the next Talos bump reinstalls the stock kernel with no error,
-    # because a locally imaged node reports no schematic and both of tuppr's guards no-op.
-    # One image per schematic, not per node: this node and control-3 both use
-    # talos/schematic.yaml and so share a byte-identical installer. Not the schematic id —
-    # that moves whenever a schematic is edited, and each new id is a fresh ghcr package that
-    # starts private (there is no way to default them public), stranding the node on an
-    # unpullable ref.
+    # Our registry, not the Factory: tuppr rebuilds the upgrade target from this field, so
+    # leaving it on factory.talos.dev reinstalls the stock kernel. Shared with control-3 (same
+    # schematic); the repo is named for the schematic, not its id, which moves on every edit.
+    # Full rationale: docker/talos-kernel/README.md "Version tagging".
     image: ghcr.io/tanguille/installer/shared:{{ pinned }}
-  # getTargetVersion (upgrade.go:855) prefers this over spec.talos.version, so control-1 and control-3 keep
-  # taking the plain version from the tuppr CR and still resolve against factory.talos.dev.
-  # It must match the tag above exactly or tuppr requests an image that was never published.
+  # getTargetVersion (upgrade.go:855) prefers this over spec.talos.version. Must match the tag
+  # above exactly or tuppr requests an image that was never published.
   nodeAnnotations:
     tuppr.home-operations.com/version: {{ pinned }}
   nodeLabels:

--- a/talos/nodes/controlplane/control-3.yaml.j2
+++ b/talos/nodes/controlplane/control-3.yaml.j2
@@ -1,4 +1,3 @@
-{%- set pinned = talosVersion ~ "-k" ~ kernelVersion -%}
 ---
 # Chuwi ubox. Runs in-cluster Kepler. Install disk is addressed by-id because the
 # Micron 7450 has a thermal-shutdown history and must stay unambiguous across reseats.


### PR DESCRIPTION
Follow-up to #4610, which made this possible: every node now pins its own custom-kernel installer, so the cluster-layer factory default was the last reference to `{{ schematic }}` and nothing consumed it. `render-config` resolved it anyway, on every render.

## The cost that mattered

| | measured |
| --- | --- |
| `schematic-id` (Image Factory POST) | 475–516 ms |
| full `render-config`, before | 615–624 ms |
| full `render-config`, after | **148–153 ms** |

~80% of every render was a network round-trip producing a discarded value.

The latency is the lesser problem. `diff-node` is the gate run against every node before every apply — the thing this whole rendering pipeline's safety story rests on — and it could not run without reaching `factory.talos.dev`, on a fleet whose installers no longer come from there. A Factory outage or a slow DNS answer blocked the pre-apply check for no reason.

## Kept deliberately

The `schematic-id` recipe and both schematic YAML files stay. It is down to one caller and now reads like dead code, so there is a comment saying why:

- `download-image` still resolves an id to fetch an ISO from the Factory.
- `scripts/talos-kernel-build.sh` reads `talos/schematic.yaml` and `control-1.schematic.yaml` to decide which installer repo a node gets.

Breaking either breaks the image build, not just a render.

## One behaviour change, documented

There is no cluster-layer fallback install image any more. A **new node must declare its own `machine.install.image`** or it renders with none. Today all three are pinned so the default was dead, but an unpinned node would otherwise have silently fallen back to a stock-kernel Factory build — the revert hazard #4610 just closed. Recorded in `talos/AGENTS.md`.

## Verification

| Check | Result |
| --- | --- |
| render vs `main`, all three nodes | **byte-identical** |
| `diff-node` × 3 live nodes | `No changes.` |
| `{{ schematic }}` remaining in templates | none |
| `schematic-id` still resolves | `1fd419f5…` for control-3 |

## Unrelated one-liner

Records in `.agents/common-operations.md` that `ceph crash ls-new`'s oldest entry is a floor, not an origin. Reading a first-seen date off it under-reported a live mgr crash loop by eight months this morning.

The mechanism is archival, **not** `mgr/crash/warn_recent_interval` — verified against `crash/module.py` at v20.2.4:

| | |
|---|---|
| `do_ls_new` filter | `'archived' not in crash` — no age term |
| `warn_recent_interval` used in | `_refresh_health_checks` only, for `RECENT_CRASH` |

So `crash archive-all` is what sets the floor. Use `ceph crash ls` (lists archived too) and `ceph crash info <crash-id>` for real timestamps.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Talos configuration rendering now incorporates a pinned Talos and kernel version for node installer images and version annotations.
  - Node-specific installation settings are clearer and must be explicitly defined when needed.

- **Documentation**
  - Clarified that `ceph crash ls-new` hides archived crashes rather than old ones, so it cannot determine when an incident began.
  - Added guidance on configuring installer images for newly added Talos nodes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
