### PR TITLE
fix(rook-ceph): finish the aes256k migration by dropping aes entirely

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -44,10 +44,14 @@ spec:
       # Ceph 20 flags cipher `aes` as HEALTH_ERR, which makes Rook refuse the OSD upgrade
       # ("refusing to upgrade"), stranding OSDs on 20.2.3 while mon/mgr/mds ran 20.2.4.
       # aes256k needs the in-kernel Ceph client from Linux 7.0; all nodes run 7.1.9 since 2026-08-21.
-      # keyType is a no-op unless keyRotationPolicy is set. allowedCiphers is deliberately NOT set
-      # here: restricting to aes256k before every key has rotated locks out the aes clients.
+      # keyType is a no-op unless keyRotationPolicy is set.
       security:
         cephx:
+          # Rotation is complete (all groups gen=2/aes256k as of 2026-08-21), so drop `aes`.
+          # This is what clears AUTH_INSECURE_SERVICE_TICKETS, KEYS_ALLOWED, KEYS_CREATABLE and
+          # Rook's transitional AUTH_EMERGENCY_CIPHERS_SET. Safe only once no entity still uses an
+          # aes key -- setting it earlier locks out the CSI clients that mount the PVs.
+          allowedCiphers: ["aes256k"]
           daemon:
             keyRotationPolicy: KeyGeneration
             keyGeneration: 2
@@ -56,8 +60,10 @@ spec:
             keyRotationPolicy: KeyGeneration
             keyGeneration: 2
             keyType: aes256k
-            # Keeps the prior key active so in-flight PV connections survive the rotation.
-            keepPriorKeyCountMax: 1
+            # 1 during the rotation kept the prior key alive so in-flight PV connections survived
+            # (they did, zero pods disrupted). 0 now deletes the stale generation-1 `aes` keys,
+            # which are the only remaining AUTH_INSECURE_CLIENT_KEY_TYPE entities.
+            keepPriorKeyCountMax: 0
           rbdMirrorPeer:
             keyRotationPolicy: KeyGeneration
             keyGeneration: 2


### PR DESCRIPTION
Follow-up to #4614. Rotation completed 2026-08-21; this removes the two things still advertising `aes`.

## State after rotation

```
admin gen=2 · cephExporter gen=2 · crashCollector gen=2 · mon gen=2
csi gen=2 aes256k · mgr gen=2 aes256k · osd gen=2 aes256k · rbdMirrorPeer gen=2 aes256k

AUTH_INSECURE_SERVICE_KEY_TYPE  CLEARED (7 -> 0 entities)
osd 3x 20.2.3 -> 3x 20.2.4      the upgrade that was deadlocked
pods disrupted                   0
```

## Changes

| field | from | to | clears |
|---|---|---|---|
| `csi.keepPriorKeyCountMax` | 1 | 0 | `AUTH_INSECURE_CLIENT_KEY_TYPE` |
| `allowedCiphers` | unset | `[aes256k]` | `SERVICE_TICKETS`, `KEYS_ALLOWED`, `KEYS_CREATABLE`, `EMERGENCY_CIPHERS_SET` |

`keepPriorKeyCountMax: 1` kept the generation-1 keys alive so in-flight PV connections survived the rotation. Those stale `.1` keys (`client.csi-cephfs-node.1`, `client.csi-rbd-node.1`, and both provisioners) are now the only remaining `aes` entities.

## Ordering

`allowedCiphers` was deliberately excluded from #4614. Applied before rotation finished, it would have locked out the CSI clients that mount the PVs. It is only safe now because no entity still depends on an `aes` key.

## After merge

CSI pods may hold the old key in memory and need a restart to re-read the rotated secret — the same way the toolbox pod did. Verifying that rather than assuming it.

The two temporary `ceph health mute`s (`AUTH_INSECURE_SERVICE_KEY_TYPE`, `AUTH_INSECURE_SERVICE_TICKETS`) get removed once this lands and the checks are confirmed genuinely gone.