### PR TITLE
fix(rook-ceph): revert allowedCiphers, it broke rbd provisioning

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -47,11 +47,11 @@ spec:
       # keyType is a no-op unless keyRotationPolicy is set.
       security:
         cephx:
-          # Rotation is complete (all groups gen=2/aes256k as of 2026-08-21), so drop `aes`.
-          # This is what clears AUTH_INSECURE_SERVICE_TICKETS, KEYS_ALLOWED, KEYS_CREATABLE and
-          # Rook's transitional AUTH_EMERGENCY_CIPHERS_SET. Safe only once no entity still uses an
-          # aes key -- setting it earlier locks out the CSI clients that mount the PVs.
-          allowedCiphers: ["aes256k"]
+          # allowedCiphers: ["aes256k"] REVERTED 2026-08-21. Every key is aes256k, but restricting
+          # the cluster to it broke rbd provisioning: `failed to get connection: rados: ret=-22`,
+          # PVCs stuck Pending. ceph-csi v3.17.0 ships librados 20.2.1 against a 20.2.4 cluster.
+          # Restarting the CSI plugins did not clear it. Re-enable only once that is understood and
+          # a fresh PVC binds; the keys below already give the security win without it.
           daemon:
             keyRotationPolicy: KeyGeneration
             keyGeneration: 2


### PR DESCRIPTION
Reverts the `allowedCiphers: ["aes256k"]` half of #4616. Key rotation is kept.

## What broke

```
ProvisioningFailed: rpc error: code = Internal desc = failed to get connection:
connecting failed: rados: ret=-22, Invalid argument
```

New PVCs stuck `Pending`. **Existing PVs and all running workloads were unaffected** — only new volume creation uses that path. Found with a throwaway PVC before it hit real use.

## What was ruled out

| checked | result |
|---|---|
| stale in-memory keys | restarted both CSI ctrlplugins + nodeplugins — no change |
| secret/entity mismatch | secrets reference `.2`, ceph has `.2` — they agree |
| `ms_mode=secure` | reverted live first; failure persisted |

## Leading suspect, NOT proven

ceph-csi v3.17.0 ships librados **20.2.1**; the cluster runs **20.2.4**. `-22` is `EINVAL`, consistent with failed cipher negotiation rather than an auth denial. I could not confirm this — a direct test from the CSI container was invalid (no `ceph.conf` there), and the driver container logs no cipher detail.

## Kept

All eight cephx groups stay `keyGeneration: 2` / `aes256k`, and `keepPriorKeyCountMax: 0`. That is the real security gain and it is unaffected. Only the cluster-wide restriction is reverted, so `AUTH_INSECURE_KEYS_ALLOWED`, `KEYS_CREATABLE` and `SERVICE_TICKETS` return as warnings.

Re-enable once the librados gap is confirmed and a fresh PVC binds with it set.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored compatibility for CSI RBD provisioning with ceph-csi 3.17.0 and cluster version 20.2.4.
  * Removed the restrictive encryption cipher setting that could prevent volume provisioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->