### PR TITLE
chore: trim the comments added by the kernel and cephx work

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -41,17 +41,11 @@ spec:
       repository: quay.io/ceph/ceph
       tag: v20.2.4@sha256:6bb1c8a42fbc0bf87938946990b65174466997bc11c31eb5a323225a779fd8f9
     cephClusterSpec:
-      # Ceph 20 flags cipher `aes` as HEALTH_ERR, which makes Rook refuse the OSD upgrade
-      # ("refusing to upgrade"), stranding OSDs on 20.2.3 while mon/mgr/mds ran 20.2.4.
-      # aes256k needs the in-kernel Ceph client from Linux 7.0; all nodes run 7.1.9 since 2026-08-21.
-      # keyType is a no-op unless keyRotationPolicy is set.
+      # Ceph 20 rates cipher `aes` HEALTH_ERR, which blocks Rook's OSD upgrades. aes256k needs the
+      # in-kernel client from Linux 7.0. keyType does nothing unless keyRotationPolicy is set.
       security:
         cephx:
-          # allowedCiphers: ["aes256k"] REVERTED 2026-08-21. Every key is aes256k, but restricting
-          # the cluster to it broke rbd provisioning: `failed to get connection: rados: ret=-22`,
-          # PVCs stuck Pending. ceph-csi v3.17.0 ships librados 20.2.1 against a 20.2.4 cluster.
-          # Restarting the CSI plugins did not clear it. Re-enable only once that is understood and
-          # a fresh PVC binds; the keys below already give the security win without it.
+          # allowedCiphers ["aes256k"] reverted: it broke rbd provisioning with rados ret=-22.
           daemon:
             keyRotationPolicy: KeyGeneration
             keyGeneration: 2
@@ -60,9 +54,7 @@ spec:
             keyRotationPolicy: KeyGeneration
             keyGeneration: 2
             keyType: aes256k
-            # 1 during the rotation kept the prior key alive so in-flight PV connections survived
-            # (they did, zero pods disrupted). 0 now deletes the stale generation-1 `aes` keys,
-            # which are the only remaining AUTH_INSECURE_CLIENT_KEY_TYPE entities.
+            # 0 deletes prior-generation keys; raise to 1 to keep them alive across a rotation.
             keepPriorKeyCountMax: 0
           rbdMirrorPeer:
             keyRotationPolicy: KeyGeneration

--- a/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
@@ -13,10 +13,8 @@ spec:
     version: &talosVersion v1.14.0-rc.1
   talosctl:
     image:
-      # tuppr derives this tag from the node's CURRENT version. Custom-kernel nodes report
-      # v1.13.9-k7.1.9, which siderolabs never publishes, so leaving it unset ImagePullBackOffs
-      # the upgrade job on the second roll of any such node. Aliased, not repeated: the two must
-      # agree, and the preset's regex handles `&anchor` so Renovate still bumps the one literal.
+      # Unset, tuppr derives this from the node's CURRENT version; a -k<kernel> one is unpublished
+      # and the job ImagePullBackOffs. Aliased so the two cannot drift.
       tag: *talosVersion
   policy:
     rebootMode: powercycle

--- a/talos/nodes/controlplane/control-3.yaml.j2
+++ b/talos/nodes/controlplane/control-3.yaml.j2
@@ -5,9 +5,8 @@
 machine:
   install:
     disk: /dev/disk/by-id/nvme-Micron_7450_MTFDKBA480TFR_241548387F46
-    # Same shared installer as control-2: both nodes use talos/schematic.yaml, so the image is
-    # byte-identical. Pointing this at our registry rather than the Factory is what stops the
-    # next Talos bump silently reinstalling the stock 6.18 kernel.
+    # Shared with control-2 (same schematic). Our registry, not the Factory: tuppr rebuilds the
+    # upgrade target from this field, so leaving it on factory.talos.dev reinstalls the stock kernel.
     image: ghcr.io/tanguille/installer/shared:{{ pinned }}
   # Must match the tag above exactly; getTargetVersion prefers this over spec.talos.version.
   nodeAnnotations:


### PR DESCRIPTION
Comments only. No config values change — verified: the talosupgrade anchor still resolves, the cephx keys are intact, and all three node templates render with the same installer images.

| file | comment lines |
|---|---|
| `rook-ceph/cluster/helmrelease.yaml` (cephx block) | 12 → 4 |
| `tuppr/upgrades/talosupgrade.yaml` | 4 → 2 |
| `talos/nodes/controlplane/control-3.yaml.j2` | 3 → 2 |

Dropped: dates, "zero pods disrupted", which entities were left mid-migration — past-tense narrative, some of it false the moment it reconciled.

Kept: why aes256k matters at all, that `keyType` is inert without `keyRotationPolicy`, why `allowedCiphers` is deliberately absent, what `keepPriorKeyCountMax` does, and why the installer must not point at the Factory.