### PR TITLE
fix(rook-ceph): rotate csi keys back to aes, ceph-csi cannot read aes256k

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -45,15 +45,19 @@ spec:
       # in-kernel client from Linux 7.0. keyType does nothing unless keyRotationPolicy is set.
       security:
         cephx:
-          # allowedCiphers ["aes256k"] reverted: it broke rbd provisioning with rados ret=-22.
+          # allowedCiphers ["aes256k"] omitted: ceph-csi still needs aes to be accepted.
           daemon:
             keyRotationPolicy: KeyGeneration
             keyGeneration: 2
             keyType: aes256k
           csi:
             keyRotationPolicy: KeyGeneration
-            keyGeneration: 2
-            keyType: aes256k
+            # gen 3 rotates back to aes. ceph-csi v3.17.0 ships librados 20.2.1, which cannot use
+            # an aes256k key: provisioning failed with `rados: ret=-22` for 9h. Proven by the same
+            # key working from the 20.2.4 toolbox and failing from the CSI pod. Return to aes256k
+            # once ceph-csi ships a librados that supports it.
+            keyGeneration: 3
+            keyType: aes
             # 0 deletes prior-generation keys; raise to 1 to keep them alive across a rotation.
             keepPriorKeyCountMax: 0
           rbdMirrorPeer:


### PR DESCRIPTION
rbd provisioning has been broken since the aes256k rotation. Every new PVC stuck `Pending` for 9h:

```
failed to get connection: connecting failed: rados: ret=-22, Invalid argument
```

## Root cause — the key cipher, not the cluster policy

#4618 reverted `allowedCiphers` on the theory that the cluster-wide restriction was locking CSI out. **That was wrong** — the revert applied and provisioning stayed broken. The CSI *keys themselves* are aes256k, and ceph-csi v3.17.0 ships librados **20.2.1**, which cannot consume them.

## Proven, not inferred

| check | result |
|---|---|
| secret `userKey` vs `ceph auth get-key` | sha256 **match** |
| caps on `client.csi-rbd-provisioner.2` | correct (`profile rbd` mon+osd, `allow rw` mgr) |
| same key from toolbox (librados **20.2.4**) | **connects, returns full cluster status** |
| same key from CSI pod (librados **20.2.1**) | `rados: ret=-22` |
| pool health | serving IO throughout |

The toolbox-vs-CSI comparison is the decisive one: identical credentials, different librados, opposite outcomes.

## Fix

`csi.keyType: aes` with `keyGeneration: 3` to trigger the rotation. `daemon` and `rbdMirrorPeer` stay on **aes256k** — they are served by Ceph's own daemons, which are all 20.2.4.

## Impact

Existing PVs and running workloads were never affected; only new volume creation uses this path.

## Follow-up

Return CSI to aes256k once ceph-csi ships a librados that supports it. v3.17.1 was built 2026-08-20 and may already carry it — unverified, so not bundled here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Ceph CSI encryption key configuration to use the supported generation 3 AES keys.
  * Preserved existing daemon key settings for compatibility.
  * Added configuration guidance documenting the CSI encryption constraint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->