### PR TITLE
fix(observability): put node-exporter on the host network so its NIC metrics are real

### DIFF
--- a/kubernetes/apps/observability/exporters/node-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/exporters/node-exporter/app/helmrelease.yaml
@@ -38,4 +38,7 @@ spec:
         memory: 64M
       limits:
         memory: 64M
-    hostNetwork: false
+    # Without this the pod sits in its own netns and every node_network_*/node_netstat_* series
+    # describes eth0, not eno1/enp2s0 — measured: TCP OutSegs read 8.7/s across the whole fleet.
+    # CPU/memory/disk are unaffected, they come from the /proc and /sys mounts.
+    hostNetwork: true


### PR DESCRIPTION
`hostNetwork: false` meant node-exporter ran in its own network namespace, so every `node_network_*` and `node_netstat_*` series described the pod's `eth0` — not the host's `eno1`/`enp2s0`.

## How it surfaced

Comparing TCP retransmits across the kernel upgrade produced an apparent **32 ppm → 0** improvement. The absolute numbers gave it away:

```
TCP OutSegs: 8.7/s   summed across all three nodes
```

Impossible for a cluster running Ceph replication. Confirmed by listing the visible devices:

```
eth0, lo, tunl0, ip6tnl0, sit0     <- pod namespace
(no eno1, no enp2s0)
```

The "improvement" was 4 retransmits vs 0 in pod-local traffic.

## What was actually missing

No host NIC throughput, no interface errors, no real retransmit rate — on a fleet with a deliberately tuned 2.5 Gb path (BBR, 32 MB socket buffers, MTU probing) carrying Ceph replication.

**CPU, memory, disk and PSI are unaffected** — those come from the `/proc` and `/sys` hostPath mounts, not the netns.

## Verified before flipping

| check | result |
|---|---|
| namespace PSA | `enforce: privileged` (baseline is audit/warn only) |
| port 9100 on hosts | free on all three |
| why it was false | came in with the original integration commit, not a fix for a conflict |

`dnsPolicy` left as `ClusterFirst`: node-exporter performs no DNS lookups, it only serves `/metrics`.

## Expected side effect

The `instance` label moves from pod IP to node IP, so existing `node_network_*` series end and new ones begin. That is itself a fix — pod IPs changed on every restart, which silently split series across the node reboots earlier today.