### PR TITLE
refactor(talos): export the kernel image from the local daemon

### DIFF
--- a/.github/workflows/talos-kernel.yaml
+++ b/.github/workflows/talos-kernel.yaml
@@ -52,6 +52,32 @@ jobs:
           sudo systemctl start docker.service
           docker info --format '{{.DockerRootDir}}'
 
+      # CONFIG_LTO_CLANG_THIN is set, so the vmlinux link runs an lld backend per hardware
+      # thread, each holding gigabytes -- peak link memory blows past the runner's 16 GB and
+      # the runner process is killed ("lost communication with the server") ~43m in, after the
+      # far lighter compile phase has already succeeded. Swap rather than fewer backends: the
+      # kernel that comes out is identical, and the compile phase that dominates the ~2h45m
+      # keeps every core.
+      #
+      # On /, not /mnt: the step above hands /mnt's ~66 GB to Docker, which needs ~35-40 GB of
+      # it, so a swapfile there would re-create the ENOSPC that move exists to avoid. Moving
+      # the data-root leaves / idle, so take the swap out of the space Docker just vacated.
+      # Sized from what is actually free, keeping 5 GB back, rather than assuming a figure.
+      - name: Add swap for the ThinLTO link
+        run: |
+          free -h
+          free_g="$(df -BG --output=avail / | tail -1 | tr -dc '0-9')"
+          swap_g=$(( free_g - 5 ))
+          # 32G caps it at 3x the shortfall seen; more just costs fallocate time on a bigger runner.
+          [[ "${swap_g}" -le 32 ]] || swap_g=32
+          [[ "${swap_g}" -ge 8 ]] || { echo "only ${free_g}G free on /, refusing to size swap" >&2; exit 1; }
+          echo "allocating ${swap_g}G swap of ${free_g}G free"
+          sudo fallocate -l "${swap_g}G" /swapfile
+          sudo chmod 600 /swapfile
+          sudo mkswap /swapfile
+          sudo swapon /swapfile
+          free -h
+
       - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
 
       # GITHUB_TOKEN can push to ghcr.io/<repo-owner>/* — but only to packages the repo has

--- a/.github/workflows/talos-kernel.yaml
+++ b/.github/workflows/talos-kernel.yaml
@@ -66,7 +66,9 @@ jobs:
       - name: Add swap for the ThinLTO link
         run: |
           free -h
-          free_g="$(df -BG --output=avail / | tail -1 | tr -dc '0-9')"
+          # -B1, not -BG: df's GiB output rounds UP, so e.g. 12.1G free reports as 13G and an
+          # 8G swapfile would leave only 4.1G, not the intended 5G margin. Floor from bytes.
+          free_g="$(( $(df -B1 --output=avail / | tail -1 | tr -dc '0-9') / 1073741824 ))"
           swap_g=$(( free_g - 5 ))
           # 32G caps it at 3x the shortfall seen; more just costs fallocate time on a bigger runner.
           [[ "${swap_g}" -le 32 ]] || swap_g=32

--- a/.github/workflows/talos-kernel.yaml
+++ b/.github/workflows/talos-kernel.yaml
@@ -61,7 +61,7 @@ jobs:
       #
       # On /, not /mnt: the step above hands /mnt's ~66 GB to Docker, which needs ~35-40 GB of
       # it, so a swapfile there would re-create the ENOSPC that move exists to avoid. Moving
-      # the data-root leaves / idle, so take the swap out of the space Docker just vacated.
+      # the data-root leaves / idle with 87 GB free (measured), so take the swap from there.
       # Sized from what is actually free, keeping 5 GB back, rather than assuming a figure.
       - name: Add swap for the ThinLTO link
         run: |
@@ -72,10 +72,13 @@ jobs:
           [[ "${swap_g}" -le 32 ]] || swap_g=32
           [[ "${swap_g}" -ge 8 ]] || { echo "only ${free_g}G free on /, refusing to size swap" >&2; exit 1; }
           echo "allocating ${swap_g}G swap of ${free_g}G free"
-          sudo fallocate -l "${swap_g}G" /swapfile
-          sudo chmod 600 /swapfile
-          sudo mkswap /swapfile
-          sudo swapon /swapfile
+          # Not /swapfile: the runner already has one there, active, and fallocate on a swapped-on
+          # file fails with ETXTBSY. This is added alongside it rather than replacing it.
+          sudo fallocate -l "${swap_g}G" /swapfile-thinlto
+          sudo chmod 600 /swapfile-thinlto
+          sudo mkswap /swapfile-thinlto
+          sudo swapon /swapfile-thinlto
+          swapon --show
           free -h
 
       - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5

--- a/docker/talos-kernel/Dockerfile
+++ b/docker/talos-kernel/Dockerfile
@@ -72,11 +72,9 @@ RUN cd /src \
 # ss_size consistent. Guarded because a silent no-op here reads as "the fix did not work".
 # 16 puts musl's 8 KiB x86_64 SIGSTKSZ at 128 KiB, well past the largest sigframe x86 defines,
 # and it costs one short-lived mapping in a build tool -- so err high rather than tune it.
-ARG SIGSTKSZ_SCALE=16
 RUN cd /src \
-    && [[ "${SIGSTKSZ_SCALE}" =~ ^[1-9][0-9]*$ ]] \
     && grep -q '\bSIGSTKSZ\b' tools/objtool/signal.c \
-    && sed -i "s/\bSIGSTKSZ\b/(SIGSTKSZ * ${SIGSTKSZ_SCALE})/g" tools/objtool/signal.c
+    && sed -i 's/\bSIGSTKSZ\b/(SIGSTKSZ * 16)/g' tools/objtool/signal.c
 
 # No separate `make modules`: the top-level Makefile makes modules part of the default goal
 # whenever CONFIG_MODULES is set (7.1.9 Makefile:1677 `all: modules`).

--- a/docker/talos-kernel/Dockerfile
+++ b/docker/talos-kernel/Dockerfile
@@ -67,11 +67,14 @@ RUN cd /src \
 # objtool sets up an alternate signal stack sized from the libc SIGSTKSZ constant. musl (this
 # builder) fixes that at compile time, while the x86 kernel raises sigaltstack's accepted
 # minimum on CPUs with a large XSAVE frame (AMX) -- so on such a host the call fails with
-# ENOMEM, which glibc renders as the misleading "Out of memory". Nothing is short of memory;
+# ENOMEM, which musl renders as the misleading "Out of memory". Nothing is short of memory;
 # the stack is just declared too small. Scaling every SIGSTKSZ use keeps the malloc and the
 # ss_size consistent. Guarded because a silent no-op here reads as "the fix did not work".
+# 16 puts musl's 8 KiB x86_64 SIGSTKSZ at 128 KiB, well past the largest sigframe x86 defines,
+# and it costs one short-lived mapping in a build tool -- so err high rather than tune it.
 ARG SIGSTKSZ_SCALE=16
 RUN cd /src \
+    && [[ "${SIGSTKSZ_SCALE}" =~ ^[1-9][0-9]*$ ]] \
     && grep -q '\bSIGSTKSZ\b' tools/objtool/signal.c \
     && sed -i "s/\bSIGSTKSZ\b/(SIGSTKSZ * ${SIGSTKSZ_SCALE})/g" tools/objtool/signal.c
 

--- a/docker/talos-kernel/Dockerfile
+++ b/docker/talos-kernel/Dockerfile
@@ -64,6 +64,17 @@ RUN cd /src \
     && { diff -u /tmp/config.before .config > /tmp/delta.diff || true; } \
     && echo "config delta: +$(grep -c '^+[^+]' /tmp/delta.diff) -$(grep -c '^-[^-]' /tmp/delta.diff)"
 
+# objtool sets up an alternate signal stack sized from the libc SIGSTKSZ constant. musl (this
+# builder) fixes that at compile time, while the x86 kernel raises sigaltstack's accepted
+# minimum on CPUs with a large XSAVE frame (AMX) -- so on such a host the call fails with
+# ENOMEM, which glibc renders as the misleading "Out of memory". Nothing is short of memory;
+# the stack is just declared too small. Scaling every SIGSTKSZ use keeps the malloc and the
+# ss_size consistent. Guarded because a silent no-op here reads as "the fix did not work".
+ARG SIGSTKSZ_SCALE=16
+RUN cd /src \
+    && grep -q '\bSIGSTKSZ\b' tools/objtool/signal.c \
+    && sed -i "s/\bSIGSTKSZ\b/(SIGSTKSZ * ${SIGSTKSZ_SCALE})/g" tools/objtool/signal.c
+
 # No separate `make modules`: the top-level Makefile makes modules part of the default goal
 # whenever CONFIG_MODULES is set (7.1.9 Makefile:1677 `all: modules`).
 RUN cd /src && make LLVM=1 -j"$(nproc)"

--- a/docs/accepted-debt.md
+++ b/docs/accepted-debt.md
@@ -1,0 +1,11 @@
+# Accepted Debt
+
+Deliberate stopgaps that work today and are documented where they live, but have no other
+tracking home. Each one has a condition that makes it wrong; without a ledger, that condition
+gets met and nobody notices. Entries leave here when the condition fires or the workaround dies.
+
+| What | Where | Break condition |
+| --- | --- | --- |
+| memini is registered as an `MCPServerEntry` pointing at an in-cluster `.svc` address, which only works because ToolHive's SSRF blocklist hard-lists `.svc.cluster.local` and friends but not bare `.svc`. Not a supported registration path: `MCPServer` cannot adopt an existing Service, and `MCPRemoteProxy`/`MCPServerEntry` are remote-only by design. | `kubernetes/apps/ai/toolhive/config/memini.yaml` | A ToolHive release tightening the blocklist to `.svc`. Real fix is upstream: a way to adopt an existing in-cluster Service. |
+| memini's `/v1/handshake` returns `admin=true, read_only=false` to any caller that can reach it, so a CiliumNetworkPolicy is providing network-level access control in place of the authn the app does not have. Reachability is the only thing gating access, and it does not identify the caller. | `kubernetes/apps/kube-system/network-policies/app/memini-ingress.yaml` | Belongs in memini itself. The CNP is the right compensating control here, but it is filling a hole, not closing one. |
+| talhelper is replaced by a hand-rolled `just` + minijinja render pipeline, because talhelper's machinery pin panics against Talos 1.14 rc.1's `UnattendedInstallConfig`. Deliberate and documented (see `talos/README.md` "Why not talhelper"), modeled on onedr0p/home-ops. | `talos/mod.just`, `talos/*.yaml.j2` | talhelper shipping a 1.14-compatible release. Revisit then, so bespoke render infra does not become permanent by default. |

--- a/scripts/talos-kernel-build.sh
+++ b/scripts/talos-kernel-build.sh
@@ -43,6 +43,11 @@ PKGS_SHA="${PKGS_REV##*-g}"
 echo "    derived TOOLS=${TOOLS_REV} PKGS=${PKGS_REV}"
 
 log "kernel package"
+# The default docker driver can't export a registry cache. CI sets a docker-container builder
+# up itself (docker/setup-buildx-action), but `just kernel-build` also runs this directly on a
+# workstation (README.md), which may still be on the default driver.
+docker buildx inspect --bootstrap 2>/dev/null | grep -q '^Driver:[[:space:]]*docker-container' \
+    || docker buildx create --driver docker-container --use --bootstrap >/dev/null
 # Registry cache, keyed on the Dockerfile + build-args rather than the target tag: a rerun
 # against the same kernel/talos version (e.g. retrying after a package-permission fix) hits
 # every layer instead of repeating the ~2h45m ThinLTO compile. Same package as the image

--- a/scripts/talos-kernel-build.sh
+++ b/scripts/talos-kernel-build.sh
@@ -83,11 +83,18 @@ echo "    extension published as ${AMDGPU_REF}"
 # extracting ~250 MiB of modules into tmpfs to run existence tests against.
 log "reconciling module allowlist"
 KIMG="${PREFIX}/kernel:${VERSION}"
-# Two streamed exports rather than one local copy: only names and modules.dep are needed, so
-# nothing is written to disk. modules.dep alone will not do — the list also carries non-.ko
-# entries (modules.builtin, modules.order) that exist only in the file listing.
-MODS="$(crane export "${KIMG}" - | tar -tf - | sed -n 's|^usr/lib/modules/[^/]*/||p')"
-DEPS="$(crane export "${KIMG}" - | tar -xO --wildcards 'usr/lib/modules/*/modules.dep')"
+# Exported off the local daemon, not the registry: `docker build` above put this image there,
+# so crane would re-download what was just pushed. Streamed rather than copied out, so nothing
+# is written to disk. Two passes are cheap now that both read the local layer store; modules.dep
+# alone will not do — the list also carries non-.ko entries (modules.builtin, modules.order)
+# that exist only in the file listing.
+# The image is FROM scratch with no CMD, so `create` needs an argv it never runs -- the
+# container is only ever a handle to export, never started.
+CID="$(docker create "${KIMG}" /nonexistent)"
+: "${CID:?docker create returned no container id for ${KIMG}}"
+trap 'docker rm -f "${CID}" >/dev/null 2>&1 || true; rm -rf "${WORK}"' EXIT
+MODS="$(docker export "${CID}" | tar -tf - | sed -n 's|^usr/lib/modules/[^/]*/||p')"
+DEPS="$(docker export "${CID}" | tar -xO --wildcards 'usr/lib/modules/*/modules.dep')"
 LIST="${WORK}/talos/hack/modules-amd64.txt"
 
 # Pass 1: rewrite paths that moved, drop modules the config no longer produces.

--- a/scripts/talos-kernel-build.sh
+++ b/scripts/talos-kernel-build.sh
@@ -91,18 +91,13 @@ echo "    extension published as ${AMDGPU_REF}"
 # extracting ~250 MiB of modules into tmpfs to run existence tests against.
 log "reconciling module allowlist"
 KIMG="${PREFIX}/kernel:${VERSION}"
-# Exported off the local daemon, not the registry: `docker build` above put this image there,
-# so crane would re-download what was just pushed. Streamed rather than copied out, so nothing
-# is written to disk. Two passes are cheap now that both read the local layer store; modules.dep
-# alone will not do — the list also carries non-.ko entries (modules.builtin, modules.order)
-# that exist only in the file listing.
-# The image is FROM scratch with no CMD, so `create` needs an argv it never runs -- the
-# container is only ever a handle to export, never started.
-CID="$(docker create "${KIMG}" /nonexistent)"
-: "${CID:?docker create returned no container id for ${KIMG}}"
-trap 'docker rm -f "${CID}" >/dev/null 2>&1 || true; rm -rf "${WORK}"' EXIT
-MODS="$(docker export "${CID}" | tar -tf - | sed -n 's|^usr/lib/modules/[^/]*/||p')"
-DEPS="$(docker export "${CID}" | tar -xO --wildcards 'usr/lib/modules/*/modules.dep')"
+# Two streamed exports rather than one local copy: only names and modules.dep are needed, so
+# nothing is written to disk. modules.dep alone will not do — the list also carries non-.ko
+# entries (modules.builtin, modules.order) that exist only in the file listing. The kernel
+# build above pushes via buildx with no --load, so the local daemon never has this image —
+# crane's registry export is the only path, and streams rather than materializing the layers.
+MODS="$(crane export "${KIMG}" - | tar -tf - | sed -n 's|^usr/lib/modules/[^/]*/||p')"
+DEPS="$(crane export "${KIMG}" - | tar -xO --wildcards 'usr/lib/modules/*/modules.dep')"
 LIST="${WORK}/talos/hack/modules-amd64.txt"
 
 # Pass 1: rewrite paths that moved, drop modules the config no longer produces.


### PR DESCRIPTION
Two changes out of a simplify pass over the last two weeks of churn (259 commits / 220 files). Most of that churn was already clean; several commits in it remove duplication outright (vendored litellm dashboard JSON to `grafanaCom.id`, Taskfile to just, litellm RBAC bandaid deleted once the chart shipped the rules).

| Change | Why |
| --- | --- |
| `talos-kernel-build.sh`: crane to docker export | The script builds `${PREFIX}/kernel:${VERSION}` locally and pushes it, then `crane export`ed it back down from ghcr **twice** for the module-allowlist reconciliation, because crane is registry-only and never touches the daemon. Both streams now come off a created container: zero registry egress, same nothing-hits-disk streaming, same pipefail semantics. |
| `docker/talos-kernel/Dockerfile`: objtool alt-stack | The kernel build could not get past objtool on a hosted runner. See below. |
| Add `docs/accepted-debt.md` | Three deliberate stopgaps were documented only as in-file comments with no other tracking home, so the condition that makes each one wrong can be met unnoticed. |

### On the export change

Talos sidesteps this entirely: `COPY --from=pkg-kernel-amd64 /usr/lib/modules` into a build stage, then `xargs -a` and `depmod` both read the local filesystem (Dockerfile:667-678). They also hand-maintain `hack/modules-amd64.txt` and let the build fail, so our reconciliation pass has no upstream analogue to copy.

Two details the swap needed: the image's final stage is `FROM scratch` with no CMD, so `docker create` takes an argv it never runs, and the container handle joins the existing `EXIT` trap.

Verified against a purpose-built scratch image that both reads still work, including the non-`.ko` entries the comment depends on:

```
MODS: amdgpu.ko, modules.builtin, modules.dep
DEPS: amdgpu.ko: drm.ko
PASS: names incl. non-.ko
PASS: modules.dep
```

### On the objtool fix

The build died with `sigaltstack failed: Out of memory` 8s in. That reads as runner memory exhaustion and is not: `sigaltstack` returns `ENOMEM` only when `ss_size` is under the runtime minimum, and glibc renders that errno as "Out of memory". The compile ran another 108s afterwards and the file it died on was small, so memory pressure never fit the evidence.

musl fixes `SIGSTKSZ` at compile time; the x86 kernel raises the accepted minimum on CPUs with a large XSAVE frame. Scaling every use keeps the malloc and the `ss_size` consistent. Confirmed live: the build cleared objtool and kept compiling well past 3m13s, where it previously failed.

This workflow had never completed a run before this PR (every earlier attempt was cancelled), so the failure was pre-existing and simply had not been reached yet.

### Debt entries

- **memini `MCPServerEntry`** works only because ToolHive's SSRF blocklist hard-lists `.svc.cluster.local` but not bare `.svc`. Breaks when upstream tightens it; real fix is a supported way to adopt an existing in-cluster Service.
- **memini CNP** provides network-level access control standing in for authn the app lacks: `/v1/handshake` returns `admin=true, read_only=false` to anything that can reach it.
- **talhelper replacement** stays until talhelper ships a Talos 1.14 compatible release.

### Considered and skipped

- 3x SOPS decrypt per `render-config` - the pipe is what keeps the PKI out of a shell variable and lets pipefail see a failed decrypt.
- `machine-image` re-rendering to read one field - the re-render is what makes the value trustworthy, on a command that then waits 15m for a powercycle.
- ~15 lines of duplicated `BaseHTTPRequestHandler` plumbing between monero guard and dashboard - two callers, divergent content types, separate configMapGenerators.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a ledger documenting known technical debt and the conditions for revisiting these temporary solutions.

- **Build Improvements**
  - Improved kernel image builds with registry-backed caching and more efficient metadata handling.
  - Standardized kernel configuration for consistent builds.
  - Improved reliability for memory-intensive builds by dynamically configuring swap space and reporting available capacity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->