### PR TITLE
fix(victoria-metrics): drop the 43-label vllm:cache_config_info series

### DIFF
--- a/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
@@ -283,6 +283,14 @@ spec:
         namespaced: false
       spec:
         priorityClassName: homelab-critical # 512Mi, sole scrape path
+        # vllm:cache_config_info carries 43 labels, past vmsingle's 30-label cap, so every
+        # 30s scrape is rejected and logged: it fired RowsRejectedOnIngestion and TooManyLogs
+        # while never being stored. Dropped at the agent rather than raising the cap, since
+        # kv_cache_max_concurrency is a float that churns a new series on every restart.
+        inlineRelabelConfig:
+          - action: drop
+            sourceLabels: [__name__]
+            regex: vllm:cache_config_info
         resources:
           requests:
             cpu: 100m


### PR DESCRIPTION
Two firing alerts, one cause.

| Alert | Value | Source |
| --- | --- | --- |
| `RowsRejectedOnIngestion` | 0.033 rows/s, `reason=too_many_labels` | `vllm:cache_config_info` |
| `TooManyLogs` | 10 warns/5m | same, 1 per 30s scrape x 2/min x 5 |

`vllm:cache_config_info` (job `llmkube-inference`) carries 43 labels; vmsingle caps series at 30, so every scrape is rejected and warn-logged while storing nothing.

Dropped at the agent, not fixed by raising `-maxLabelsPerTimeseries`: `kv_cache_max_concurrency` is a float that churns a fresh series on every restart, which is what the cap exists to stop. The llmkube chart exposes no `metricRelabelings` knob on `prometheus.inferencePodMonitor`, so the rule lives in our `VMAgent` spec.