### PR TITLE
fix(etcd): restore the defrag CronJob at a weekly cadence

### DIFF
--- a/kubernetes/apps/kube-system/etcd-defrag/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/etcd-defrag/app/helmrelease.yaml
@@ -30,11 +30,8 @@ spec:
       etcd-defrag:
         type: cronjob
         cronjob:
-          # Weekly, not the daily cadence this ran at before #4290 removed it.
-          # Hourly auto-compaction stays and does hold the live keyspace flat
-          # (in-use 137-160MB across 20d), but it cannot shrink the file, so the
-          # free space still ramps ~8MB/day and crossed the 50% fragmentation
-          # alert on its own. A full 3-member pass costs ~95s.
+          # Auto-compaction holds in-use flat (137-160MB over 20d) but cannot
+          # shrink the file; free space ramps ~8MB/day. A 3-member pass costs ~95s.
           timeZone: ${TIMEZONE}
           schedule: "0 3 * * 0"
           backoffLimit: 1

--- a/kubernetes/apps/kube-system/etcd-defrag/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/etcd-defrag/app/helmrelease.yaml
@@ -1,0 +1,85 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: etcd-defrag
+spec:
+  interval: 30m
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+
+  values:
+    defaultPodOptions:
+      # Must use host network and PID namespace to access Talos etcd on localhost:2379.
+      hostNetwork: true
+      hostPID: true
+      securityContext:
+        runAsGroup: 0
+        runAsNonRoot: false
+        runAsUser: 0
+      nodeSelector:
+        node-role.kubernetes.io/control-plane: ""
+      tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
+
+    controllers:
+      etcd-defrag:
+        type: cronjob
+        cronjob:
+          # Weekly, not the daily cadence this ran at before #4290 removed it.
+          # Hourly auto-compaction stays and does hold the live keyspace flat
+          # (in-use 137-160MB across 20d), but it cannot shrink the file, so the
+          # free space still ramps ~8MB/day and crossed the 50% fragmentation
+          # alert on its own. A full 3-member pass costs ~95s.
+          timeZone: ${TIMEZONE}
+          schedule: "0 3 * * 0"
+          backoffLimit: 1
+        containers:
+          app:
+            image:
+              repository: ghcr.io/ahrtr/etcd-defrag
+              tag: v0.43.0@sha256:a70b9bb5b946b5f3029f13d5dc06eb1c174ac0b3fe5e68b70953bcb20b1400d5
+            args:
+              - --endpoints=https://127.0.0.1:2379
+              - --cluster
+              - --cacert=/certs/ca.crt
+              - --cert=/certs/server.crt
+              - --key=/certs/server.key
+              - --defrag-rule=dbQuotaUsage > 0.5 || dbSizeFree > 50*1024*1024
+              - --move-leader
+              # --cluster defragments all three control-plane etcd members.
+              - --wait-between-defrags=30s
+              # Talos uses etcd's default --quota-backend-bytes value (2 GiB).
+              - --etcd-storage-quota-bytes=2147483648
+              - --auto-disalarm
+              - --disalarm-threshold=0.8
+            resources:
+              requests:
+                cpu: 25m
+                memory: 128Mi
+              limits:
+                cpu: 100m
+                memory: 128Mi
+            securityContext:
+              # Talos etcd's client key is root-readable only on the host.
+              privileged: true
+
+    persistence:
+      certs:
+        type: hostPath
+        # Talos EtcdPKIPath.
+        hostPath: /system/secrets/etcd
+        globalMounts:
+          - path: /certs
+            readOnly: true
+      tmpfs:
+        type: emptyDir
+        advancedMounts:
+          etcd-defrag:
+            app:
+              - path: /tmp
+                subPath: tmp

--- a/kubernetes/apps/kube-system/etcd-defrag/app/kustomization.yaml
+++ b/kubernetes/apps/kube-system/etcd-defrag/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrelease.yaml

--- a/kubernetes/apps/kube-system/etcd-defrag/ks.yaml
+++ b/kubernetes/apps/kube-system/etcd-defrag/ks.yaml
@@ -1,0 +1,17 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: etcd-defrag
+  namespace: &namespace kube-system
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/kube-system/etcd-defrag/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  wait: false

--- a/kubernetes/apps/kube-system/kustomization.yaml
+++ b/kubernetes/apps/kube-system/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
   - ./cilium/ks.yaml
   - ./coredns/ks.yaml
   - ./descheduler/ks.yaml
+  - ./etcd-defrag/ks.yaml
   - ./generic-device-plugin/ks.yaml
   - ./metrics-server/ks.yaml
   - ./network-policies/ks.yaml


### PR DESCRIPTION
Resolves `etcdDatabaseHighFragmentationRatio` firing on all three members (57%).

#4290 replaced the daily defrag with hourly auto-compaction and noted a one-time `talosctl etcd defrag` per node was still needed. That never ran.

20 days of data, `max()` across members:

| Date | db total | db in use |
| --- | --- | --- |
| 08-01 | 185MB | 142MB |
| 08-09 | 271MB | 140MB |
| 08-15 | 295MB | 144MB |
| 08-21 | 341MB | 147MB |

Compaction is working: in-use is flat at 137-160MB. It cannot shrink the file, so free space ramps ~8MB/day and crossed the 50% alert on its own. Only defrag reclaims it.

Weekly rather than the daily cadence it ran at pre-#4290, since compaction holds the keyspace flat and `--defrag-rule` only has the fragmentation ramp to clear (`dbSizeFree` crosses its 50MB trigger in ~6 days). Auto-compaction stays. Image `v0.42.0` -> `v0.43.0`.