### PR TITLE
fix(cnpg): correct pgvector version pin source and drift

### DIFF
--- a/.github/workflows/cnpg-vector-version.yaml
+++ b/.github/workflows/cnpg-vector-version.yaml
@@ -10,6 +10,10 @@ on:
       - kubernetes/apps/database/cloudnative-pg/cluster/cluster.yaml
       - kubernetes/apps/database/cloudnative-pg/databases/resourceset.yaml
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/cnpg-vector-version.yaml
+++ b/.github/workflows/cnpg-vector-version.yaml
@@ -1,0 +1,25 @@
+---
+# Catches the class of bug fixed in #4653: the vector extension pin in resourceset.yaml can
+# only drift from what the pinned CNPG postgresql image actually bundles when one of these two
+# files changes, so that's the only time this needs to run.
+name: CNPG Vector Version
+
+on:
+  pull_request:
+    paths:
+      - kubernetes/apps/database/cloudnative-pg/cluster/cluster.yaml
+      - kubernetes/apps/database/cloudnative-pg/databases/resourceset.yaml
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
+
+      - run: scripts/check-cnpg-vector-version.sh

--- a/docs/database/cnpg-app-database-onboarding.md
+++ b/docs/database/cnpg-app-database-onboarding.md
@@ -100,9 +100,14 @@ Then remove the app's `init-db` container and its `INIT_POSTGRES_*` Secret keys 
   ```
 - **Extensions.** Declare them by name and version on `Database.spec.extensions` (memini:
   `vchord` + `vector`; crowdsec: `vector`). `vchord` versions are Renovate-grouped with the
-  cluster's vchord-scratch image; `vector` is the pgvector bundled in that image, so read its
-  version from the pinned image (not an upstream pgvector release) and bump it in the same PR
-  as the image. A wrong pin fails visibly — CNPG marks the Database CR not-Ready.
+  cluster's vchord-scratch image. `vector` is pgvector, which ships in the base CNPG postgresql
+  image, **not** vchord-scratch (that image contains only `vchord.so`) — Renovate doesn't track
+  it, so bump it manually whenever the base image bumps, reading the true version from the
+  image itself rather than assuming it moved:
+  ```
+  docker run --rm --entrypoint cat <cluster.yaml imageName> /usr/share/postgresql/18/extension/vector.control
+  ```
+  A wrong pin fails visibly — CNPG marks the Database CR not-Ready.
 - **YAML anchor trap.** Some app-template HelmReleases define the secret `envFrom` anchor
   (`&envFrom` / `&secret`) **on the `init-db` container** and alias it on the app container. Deleting
   the init-db block also deletes the anchor and breaks the alias — relocate an explicit `secretRef`

--- a/docs/database/cnpg-app-database-onboarding.md
+++ b/docs/database/cnpg-app-database-onboarding.md
@@ -103,7 +103,7 @@ Then remove the app's `init-db` container and its `INIT_POSTGRES_*` Secret keys 
   ```
 
 - **Extensions.** Declare them by name and version on `Database.spec.extensions` (memini:
-  `vchord` + `vector`; crowdsec: `vector`). `vchord` versions are Renovate-grouped with the
+  `vchord` + `vector`; crowdsec, ghostfolio, litellm: `vector`). `vchord` versions are Renovate-grouped with the
   cluster's vchord-scratch image. `vector` is pgvector, which ships in the base CNPG postgresql
   image, **not** vchord-scratch (that image contains only `vchord.so`) — Renovate doesn't track
   it, so bump it manually whenever the base image bumps, reading the true version from the
@@ -111,7 +111,8 @@ Then remove the app's `init-db` container and its `INIT_POSTGRES_*` Secret keys 
 
   ```sh
   img=$(yq '.spec.imageName' kubernetes/apps/database/cloudnative-pg/cluster/cluster.yaml)
-  docker run --rm --entrypoint cat "$img" /usr/share/postgresql/18/extension/vector.control
+  pg=$(sed -E 's/.*:([0-9]+)\..*/\1/' <<<"$img")
+  docker run --rm --entrypoint cat "$img" "/usr/share/postgresql/$pg/extension/vector.control"
   ```
 
   A wrong pin fails visibly — CNPG marks the Database CR not-Ready.
@@ -132,7 +133,7 @@ Then remove the app's `init-db` container and its `INIT_POSTGRES_*` Secret keys 
 
 | App | DB | Role | Host | Extensions | Live owner was |
 |-----|----|------|------|------------|----------------|
-| litellm | litellm | litellm | pgbouncer-rw | – | role |
+| litellm | litellm | litellm | pgbouncer-rw | vector | role |
 | jellystat | jfstat | jellystat | pgbouncer-rw | – | `postgres` (ALTERed) |
 | radarr | radarr | radarr | pgbouncer-rw | – | role |
 | bazarr | bazarr | bazarr | pgbouncer-rw | – | role |
@@ -144,6 +145,7 @@ Then remove the app's `init-db` container and its `INIT_POSTGRES_*` Secret keys 
 | spoolman | spoolman | spoolman | pgbouncer-rw | – | role |
 | memini | memini | memini | pgbouncer-rw | vchord, vector | role |
 | crowdsec | crowdsec | crowdsec | pgbouncer-rw | vector | role |
+| ghostfolio | ghostfolio | ghostfolio | pgbouncer-rw | vector | role |
 
 ## Not onboarded
 

--- a/docs/database/cnpg-app-database-onboarding.md
+++ b/docs/database/cnpg-app-database-onboarding.md
@@ -94,19 +94,26 @@ Then remove the app's `init-db` container and its `INIT_POSTGRES_*` Secret keys 
   `Database` CR's `owner:` triggers a one-time, idempotent `ALTER DATABASE … OWNER TO <role>` on
   first reconcile, then converges. `owner:` is required and stays as declarative state — there is
   nothing to remove afterward. After first apply, confirm convergence:
+
+  ```sh
+  db=memini
+  primary=$(kubectl -n database get cluster postgres16 -o jsonpath='{.status.currentPrimary}')
+  kubectl -n database exec "$primary" -c postgres -- psql -U postgres -tAc \
+    "SELECT datname, pg_catalog.pg_get_userbyid(datdba) FROM pg_database WHERE datname = '$db';"
   ```
-  kubectl -n database exec postgres16-<primary> -c postgres -- psql -U postgres -tAc \
-    "SELECT datname, pg_catalog.pg_get_userbyid(datdba) FROM pg_database WHERE datname = '<db>';"
-  ```
+
 - **Extensions.** Declare them by name and version on `Database.spec.extensions` (memini:
   `vchord` + `vector`; crowdsec: `vector`). `vchord` versions are Renovate-grouped with the
   cluster's vchord-scratch image. `vector` is pgvector, which ships in the base CNPG postgresql
   image, **not** vchord-scratch (that image contains only `vchord.so`) — Renovate doesn't track
   it, so bump it manually whenever the base image bumps, reading the true version from the
   image itself rather than assuming it moved:
+
+  ```sh
+  img=$(yq '.spec.imageName' kubernetes/apps/database/cloudnative-pg/cluster/cluster.yaml)
+  docker run --rm --entrypoint cat "$img" /usr/share/postgresql/18/extension/vector.control
   ```
-  docker run --rm --entrypoint cat <cluster.yaml imageName> /usr/share/postgresql/18/extension/vector.control
-  ```
+
   A wrong pin fails visibly — CNPG marks the Database CR not-Ready.
 - **YAML anchor trap.** Some app-template HelmReleases define the secret `envFrom` anchor
   (`&envFrom` / `&secret`) **on the `init-db` container** and alias it on the app container. Deleting

--- a/kubernetes/apps/database/cloudnative-pg/databases/resourceset.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/databases/resourceset.yaml
@@ -12,10 +12,12 @@ spec:
     - name: bazarr
     - name: crowdsec
       extensions:
-        # vector is the pgvector bundled in the cluster's vchord-scratch image — bump manually
-        # when the image bumps; a wrong pin fails visibly via the Database CR going not-Ready.
+        # vector is the pgvector bundled in the base CNPG postgresql image (not vchord-scratch,
+        # which ships only vchord.so) — bump manually when that image bumps; a wrong pin fails
+        # visibly via the Database CR going not-Ready. Check with:
+        #   docker run --rm --entrypoint cat <cluster.yaml imageName> /usr/share/postgresql/18/extension/vector.control
         - name: vector
-          version: "0.8.5"
+          version: "0.8.6"
     - name: gatus
     - name: ghostfolio
     - name: grafana
@@ -26,11 +28,12 @@ spec:
       extensions:
         # Keep vchord and vector paired; Memini's live vchordrq indexes require both.
         # vchord version is Renovate-tracked with the cluster's vchord-scratch image;
-        # vector is the pgvector bundled in that image — bump manually when the image bumps.
+        # vector is the pgvector bundled in the base CNPG postgresql image (see crowdsec's
+        # extensions comment above for how to check it) — bump manually when that bumps.
         - name: vchord
           version: "1.1.1"
         - name: vector
-          version: "0.8.5"
+          version: "0.8.6"
     - name: nextcloud
     - name: prowlarr
     - name: radarr

--- a/kubernetes/apps/database/cloudnative-pg/databases/resourceset.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/databases/resourceset.yaml
@@ -20,10 +20,20 @@ spec:
           version: "0.8.6"
     - name: gatus
     - name: ghostfolio
+      extensions:
+        # vector is the pgvector bundled in the base CNPG postgresql image (see crowdsec's
+        # extensions comment above for how to check it) — bump manually when that bumps.
+        - name: vector
+          version: "0.8.6"
     - name: grafana
     - name: jellystat
       db: jfstat
     - name: litellm
+      extensions:
+        # vector is the pgvector bundled in the base CNPG postgresql image (see crowdsec's
+        # extensions comment above for how to check it) — bump manually when that bumps.
+        - name: vector
+          version: "0.8.6"
     - name: memini
       extensions:
         # Keep vchord and vector paired; Memini's live vchordrq indexes require both.

--- a/kubernetes/apps/database/cloudnative-pg/databases/resourceset.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/databases/resourceset.yaml
@@ -12,39 +12,31 @@ spec:
     - name: bazarr
     - name: crowdsec
       extensions:
-        # vector is the pgvector bundled in the base CNPG postgresql image (not vchord-scratch,
-        # which ships only vchord.so) — bump manually when that image bumps; a wrong pin fails
-        # visibly via the Database CR going not-Ready. Check with:
+        # pgvector ships in the base CNPG postgresql image, not vchord-scratch, so Renovate does
+        # not track it; bump manually when that image bumps. A wrong pin fails visibly via the
+        # Database CR going not-Ready. Check with:
         #   img=$(yq '.spec.imageName' kubernetes/apps/database/cloudnative-pg/cluster/cluster.yaml)
         #   docker run --rm --entrypoint cat "$img" /usr/share/postgresql/18/extension/vector.control
-        - name: vector
+        - &vector
+          name: vector
           version: "0.8.6"
     - name: gatus
     - name: ghostfolio
       extensions:
-        # vector is the pgvector bundled in the base CNPG postgresql image (see crowdsec's
-        # extensions comment above for how to check it) — bump manually when that bumps.
-        - name: vector
-          version: "0.8.6"
+        - *vector
     - name: grafana
     - name: jellystat
       db: jfstat
     - name: litellm
       extensions:
-        # vector is the pgvector bundled in the base CNPG postgresql image (see crowdsec's
-        # extensions comment above for how to check it) — bump manually when that bumps.
-        - name: vector
-          version: "0.8.6"
+        - *vector
     - name: memini
       extensions:
         # Keep vchord and vector paired; Memini's live vchordrq indexes require both.
-        # vchord version is Renovate-tracked with the cluster's vchord-scratch image;
-        # vector is the pgvector bundled in the base CNPG postgresql image (see crowdsec's
-        # extensions comment above for how to check it) — bump manually when that bumps.
+        # vchord is Renovate-tracked with the cluster's vchord-scratch image.
         - name: vchord
           version: "1.1.1"
-        - name: vector
-          version: "0.8.6"
+        - *vector
     - name: nextcloud
     - name: prowlarr
     - name: radarr

--- a/kubernetes/apps/database/cloudnative-pg/databases/resourceset.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/databases/resourceset.yaml
@@ -15,7 +15,8 @@ spec:
         # vector is the pgvector bundled in the base CNPG postgresql image (not vchord-scratch,
         # which ships only vchord.so) — bump manually when that image bumps; a wrong pin fails
         # visibly via the Database CR going not-Ready. Check with:
-        #   docker run --rm --entrypoint cat <cluster.yaml imageName> /usr/share/postgresql/18/extension/vector.control
+        #   img=$(yq '.spec.imageName' kubernetes/apps/database/cloudnative-pg/cluster/cluster.yaml)
+        #   docker run --rm --entrypoint cat "$img" /usr/share/postgresql/18/extension/vector.control
         - name: vector
           version: "0.8.6"
     - name: gatus

--- a/kubernetes/apps/database/cloudnative-pg/databases/resourceset.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/databases/resourceset.yaml
@@ -16,7 +16,8 @@ spec:
         # not track it; bump manually when that image bumps. A wrong pin fails visibly via the
         # Database CR going not-Ready. Check with:
         #   img=$(yq '.spec.imageName' kubernetes/apps/database/cloudnative-pg/cluster/cluster.yaml)
-        #   docker run --rm --entrypoint cat "$img" /usr/share/postgresql/18/extension/vector.control
+        #   pg=$(sed -E 's/.*:([0-9]+)\..*/\1/' <<<"$img")
+        #   docker run --rm --entrypoint cat "$img" "/usr/share/postgresql/$pg/extension/vector.control"
         - &vector
           name: vector
           version: "0.8.6"

--- a/scripts/check-cnpg-vector-version.sh
+++ b/scripts/check-cnpg-vector-version.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Fails if any `vector` extension pin in resourceset.yaml doesn't match the pgvector version
+# actually bundled in the pinned CNPG postgresql image. Renovate can't catch this itself: the
+# base image's own tag/digest carries no signal about which pgvector version it ships, so a
+# bump can drift the pin silently (see kubernetes/apps/database/cloudnative-pg/databases/
+# resourceset.yaml's vector comment for how this is normally checked by hand).
+set -euo pipefail
+
+CLUSTER_FILE="kubernetes/apps/database/cloudnative-pg/cluster/cluster.yaml"
+DATABASES_FILE="kubernetes/apps/database/cloudnative-pg/databases/resourceset.yaml"
+
+image="$(yq '.spec.imageName' "$CLUSTER_FILE")"
+control="$(docker run --rm --entrypoint cat "$image" /usr/share/postgresql/18/extension/vector.control)"
+actual="$(grep '^default_version' <<<"$control" | sed -E "s/.*= *'([^']+)'.*/\1/")"
+
+echo "pinned image: ${image}"
+echo "bundled vector version: ${actual}"
+
+status=0
+while IFS= read -r pin; do
+  if [[ "$pin" != "$actual" ]]; then
+    echo "::error file=${DATABASES_FILE}::vector pin '${pin}' does not match ${actual} bundled in ${image}"
+    status=1
+  fi
+done < <(yq '.spec.inputs[].extensions[]? | select(.name == "vector") | .version' "$DATABASES_FILE")
+
+exit "$status"

--- a/scripts/check-cnpg-vector-version.sh
+++ b/scripts/check-cnpg-vector-version.sh
@@ -10,11 +10,18 @@ CLUSTER_FILE="kubernetes/apps/database/cloudnative-pg/cluster/cluster.yaml"
 DATABASES_FILE="kubernetes/apps/database/cloudnative-pg/databases/resourceset.yaml"
 
 image="$(yq '.spec.imageName' "$CLUSTER_FILE")"
-control="$(docker run --rm --entrypoint cat "$image" /usr/share/postgresql/18/extension/vector.control)"
+# Tag looks like "18.6-standard-trixie" — the extension path is keyed by PG major, not the
+# full version, so a PG19 image must not silently check PG18's (nonexistent) path.
+pg_major="$(sed -E 's/.*:([0-9]+)\..*/\1/' <<<"$image")"
+control="$(docker run --rm --entrypoint cat "$image" "/usr/share/postgresql/${pg_major}/extension/vector.control")"
 actual="$(grep '^default_version' <<<"$control" | sed -E "s/.*= *'([^']+)'.*/\1/")"
 
 echo "pinned image: ${image}"
 echo "bundled vector version: ${actual}"
+
+# Capture to a variable first: a process substitution's exit status never reaches `set -e`
+# (see scripts/talos-kernel-build.sh for the same convention).
+pins="$(yq '.spec.inputs[].extensions[]? | select(.name == "vector") | .version' "$DATABASES_FILE")"
 
 status=0
 while IFS= read -r pin; do
@@ -22,6 +29,6 @@ while IFS= read -r pin; do
     echo "::error file=${DATABASES_FILE}::vector pin '${pin}' does not match ${actual} bundled in ${image}"
     status=1
   fi
-done < <(yq '.spec.inputs[].extensions[]? | select(.name == "vector") | .version' "$DATABASES_FILE")
+done <<<"$pins"
 
 exit "$status"


### PR DESCRIPTION
## Summary
- vector's Database.spec.extensions version pin was tracked against the vchord-scratch image, but that image only ships vchord.so — no vector files at all
- pgvector actually ships in the base CNPG postgresql image; the pin had drifted (0.8.5 pinned vs 0.8.6 actually bundled in the currently-pinned image digest)
- Corrected the pin and the misleading comments/docs pointing at the wrong image
- ghostfolio and litellm also had a live but undeclared vector extension (drifted to 0.8.1) — added version pins so CNPG tracks them too

Not fixed: the reserved `postgres` maintenance database also has a drifted vector (0.8.2), but CNPG's Database CR cannot target the reserved `postgres` db (already tried and reverted in #4007) — needs a manual `ALTER EXTENSION vector UPDATE;`.

## Test plan
- [ ] Confirm crowdsec, memini, ghostfolio, litellm Database CRs go Ready after CNPG runs `ALTER EXTENSION vector UPDATE`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded CNPG onboarding guidance for Ghostfolio and LiteLLM with Vector support.
  * Updated version inspection instructions to derive the PostgreSQL major version from the configured image.

* **Maintenance**
  * Standardized the Vector extension version across database configurations and removed duplicate definitions.
  * Added automated pull request checks to detect mismatches between configured and bundled Vector versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->