### PR TITLE
fix(flux): enable drift detection fleet-wide, exempt KEDA-scaled replicas

### DIFF
--- a/kubernetes/apps/web3/monero/xmrig/resourceset.yaml
+++ b/kubernetes/apps/web3/monero/xmrig/resourceset.yaml
@@ -19,6 +19,14 @@ spec:
         name: xmrig-<< inputs.node >>
         namespace: web3
       spec:
+        # Not covered by the fleet-wide Kustomization patch: this HelmRelease is created
+        # by flux-operator from a ResourceSet, not rendered by kustomize-controller.
+        driftDetection:
+          mode: enabled
+          ignore:
+            - paths: ["/spec/replicas"]
+              target:
+                kind: Deployment
         chartRef:
           kind: OCIRepository
           name: app-template

--- a/kubernetes/components/nfs-scaler/kustomization.yaml
+++ b/kubernetes/components/nfs-scaler/kustomization.yaml
@@ -4,3 +4,20 @@ apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 resources:
   - scaledobject.yaml
+patches:
+  # This component's ScaledObject drives Deployment/${APP} to 0 replicas; drift
+  # detection must not fight that back to the chart's hardcoded replicas: 1.
+  - patch: |-
+      apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      metadata:
+        name: not-used
+      spec:
+        driftDetection:
+          ignore:
+            - paths: ["/spec/replicas"]
+              target:
+                kind: Deployment
+    target:
+      group: helm.toolkit.fluxcd.io
+      kind: HelmRelease

--- a/kubernetes/flux/cluster/ks.yaml
+++ b/kubernetes/flux/cluster/ks.yaml
@@ -58,6 +58,8 @@ spec:
                 metadata:
                   name: _
                 spec:
+                  driftDetection:
+                    mode: enabled
                   install:
                     crds: CreateReplace
                   rollback:


### PR DESCRIPTION
## Summary
- Fleet-wide `driftDetection.mode: enabled` on all HelmReleases (`kubernetes/flux/cluster/ks.yaml`), so a manually deleted/patched resource gets self-healed on the next reconcile instead of staying gone until a chart/values change. Root cause of the fileflows outage: its Deployment was manually deleted and never came back because helm-controller only re-applies on actual release changes, not on live drift.
- Exempt `/spec/replicas` on `Deployment` from drift detection for every app using the `nfs-scaler` KEDA component (`kubernetes/components/nfs-scaler/kustomization.yaml`) — those ScaledObjects drive replicas to 0 while the chart always renders `replicas: 1`, so unscoped drift detection would fight KEDA every reconcile.
- Same exemption inlined in `xmrig`'s per-node HelmReleases (`kubernetes/apps/web3/monero/xmrig/resourceset.yaml`), since those are templated by a flux-operator `ResourceSet` and never pass through the fleet-wide Kustomization patch.

## Test plan
- [x] `flux build kustomization` against `fileflows` and `immich-server` confirms the `nfs-scaler` component patch renders `driftDetection.ignore` onto the HelmRelease without touching the app's own file.
- [x] `flux build kustomization cluster-apps` confirms `driftDetection.mode: enabled` is present in every child Kustomization's patch spec.
- [ ] Watch fleet reconcile after merge for any unexpected drift corrections on non-KEDA apps.