### PR TITLE
feat(talos): check template variables in CI

### DIFF
--- a/.github/workflows/talos-render.yaml
+++ b/.github/workflows/talos-render.yaml
@@ -1,0 +1,32 @@
+---
+# The render path has no other CI coverage: `render-config` needs the age key, so it only ever
+# runs on a workstation. This check needs no secret -- sops leaves the key structure in
+# cleartext -- so it can run here and catch the one class of regression that would otherwise
+# surface at `apply-node` time, against a live node.
+name: Talos Render
+
+on:
+  pull_request:
+    paths:
+      - talos/**
+      - .justfile
+      - scripts/talos-template-vars.sh
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  template-vars:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
+
+      - name: Check template variables
+        run: scripts/talos-template-vars.sh

--- a/.justfile
+++ b/.justfile
@@ -44,7 +44,6 @@ template file *args:
     kernel_version="$(just kernel-version)"
     # Piped, not <(just talsecret): through a pipe `pipefail` sees a failed decrypt.
     just talsecret | minijinja-cli --strict --format=yaml --autoescape=none \
-        -D "talosVersion=${talos_version}" \
         -D "kubernetesVersion=${kubernetes_version}" \
         -D "kernelVersion=${kernel_version}" \
         -D "pinned=${talos_version}-k${kernel_version}" \

--- a/scripts/talos-template-vars.sh
+++ b/scripts/talos-template-vars.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Every variable a Talos template references must be supplied, and everything supplied must be
+# used. Both directions fail silently otherwise: minijinja --strict only fires at render time on
+# a workstation, and an orphaned -D survives indefinitely (`schematic` did, until #4615).
+#
+# Needs no age key. sops encrypts values and leaves the key structure in cleartext, so the
+# secrets bundle can be read for its shape alone.
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+TALOS="${REPO_ROOT}/talos"
+
+# Dotted leaf paths of the secrets bundle. Leaves only: a template references `certs.os.crt`,
+# never the `certs.os` map above it.
+available="$(yq -r '.. | select(tag != "!!map" and tag != "!!seq") | path | join(".")' \
+    "${TALOS}/talsecret.sops.yaml" | grep -v '^sops' | sort -u)"
+[[ -n "${available}" ]] || { echo "no keys read from talsecret.sops.yaml" >&2; exit 1; }
+
+# Names the render context injects, read from the -D flags themselves so this cannot drift.
+# Both files inject: .justfile passes the versions, talos/mod.just the cluster-wide addresses.
+injected="$(grep -hoP -- '-D "\K[a-zA-Z_][a-zA-Z0-9_]*' \
+    "${REPO_ROOT}/.justfile" "${TALOS}/mod.just" | sort -u)"
+[[ -n "${injected}" ]] || { echo "no -D flags found" >&2; exit 1; }
+
+templates=("${TALOS}"/*.yaml.j2 "${TALOS}"/nodes/*/*.yaml.j2)
+
+# {% set x = %} / {% for x in %} bind locally and are not context variables. Often empty, so the
+# filter below is applied conditionally -- `grep -vxF ""` matches every line and would empty the set.
+local_names="$(grep -hoP '\{%-? *(?:set|for) +\K[a-zA-Z_][a-zA-Z0-9_]*' "${templates[@]}" | sort -u || true)"
+
+used="$(grep -hoP '\{\{-? *\K[a-zA-Z_][a-zA-Z0-9_.]*' "${templates[@]}" | sort -u)"
+[[ -n "${local_names}" ]] && used="$(grep -vxF "${local_names}" <<<"${used}" || true)"
+[[ -n "${used}" ]] || { echo "no {{ }} references found under talos/" >&2; exit 1; }
+
+rc=0
+while IFS= read -r var; do
+    grep -qxF "${var}" <<<"${available}" && continue
+    grep -qxF "${var%%.*}" <<<"${injected}" && continue
+    echo "UNSUPPLIED  {{ ${var} }} is referenced but neither injected nor in the secrets bundle" >&2
+    rc=1
+done <<<"${used}"
+
+while IFS= read -r var; do
+    grep -qE "^${var}(\.|$)" <<<"${used}" && continue
+    echo "ORPHANED    -D ${var} is injected but no template references it" >&2
+    rc=1
+done <<<"${injected}"
+
+((rc)) || echo "ok: $(wc -l <<<"${used}") references resolve, $(wc -l <<<"${injected}") injected and all used"
+exit "${rc}"


### PR DESCRIPTION
A typo'd variable in a Talos template is only caught when someone renders locally. This adds a PR check that verifies both directions, with no age key required: SOPS encrypts values but leaves the key structure in cleartext, so the secrets bundle's leaf paths are readable straight from `talsecret.sops.yaml`.

| direction | catches |
|---|---|
| `UNSUPPLIED` | template references a name that is neither `-D` injected nor a secrets leaf |
| `ORPHANED` | a `-D` is injected that no template references |

`-D` names are read from both `.justfile` and `talos/mod.just`, so `vip`/`gateway` are covered.

Also drops `-D talosVersion`, which the check flags as orphaned: nothing has referenced it since the `pinned` consolidation.

Verified locally:

| case | result |
|---|---|
| clean tree | `ok: 19 references resolve, 5 injected and all used`, exit 0 |
| `kernelVersion` typo'd in control-2 | both `UNSUPPLIED` and `ORPHANED`, exit 1 |