### PR TITLE
fix(rook-ceph): disable drift detection for rook-ceph-cluster

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -5,6 +5,12 @@ kind: HelmRelease
 metadata:
   name: rook-ceph-cluster
 spec:
+  # Overrides the fleet-wide default: drift detection's dry-run can't diff
+  # CephBlockPool/CephFilesystem, whose live spec.replicated.minSize isn't
+  # declared in the installed CRD schema, which puts this release into a
+  # permanent StateError instead of just skipping that one field.
+  driftDetection:
+    mode: disabled
   chartRef:
     kind: OCIRepository
     name: rook-ceph-cluster


### PR DESCRIPTION
## Summary
- Follow-up to #4654 (fleet-wide `driftDetection.mode: enabled`). It broke `rook-ceph-cluster`'s HelmRelease: `Ready: False, reason: StateError` because the drift-detection dry-run can't diff `CephBlockPool`/`CephFilesystem` — their live `spec.replicated.minSize` isn't declared in the installed `ceph.rook.io/v1` CRD schema.
- `warn` mode hits the same dry-run failure (it still computes the diff, just skips correction), so `disabled` is the only override that avoids it for this release.
- No data-plane impact: `CephBlockPool`/`CephFilesystem` themselves stayed `Ready` throughout — only the HelmRelease's own reconciliation was blocked.

## Test plan
- [x] `flux build kustomization rook-ceph-cluster` confirms `driftDetection.mode: disabled` renders on the HelmRelease.
- [ ] After merge: reconcile and confirm `rook-ceph-cluster` HelmRelease returns to `Ready: True`.

The underlying CRD-schema gap (`spec.replicated.minSize` undeclared) is a separate issue, not addressed here.