### PR TITLE
fix(flux): actually disable drift detection for rook-ceph-cluster

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -5,12 +5,6 @@ kind: HelmRelease
 metadata:
   name: rook-ceph-cluster
 spec:
-  # Overrides the fleet-wide default: drift detection's dry-run can't diff
-  # CephBlockPool/CephFilesystem, whose live spec.replicated.minSize isn't
-  # declared in the installed CRD schema, which puts this release into a
-  # permanent StateError instead of just skipping that one field.
-  driftDetection:
-    mode: disabled
   chartRef:
     kind: OCIRepository
     name: rook-ceph-cluster

--- a/kubernetes/flux/cluster/ks.yaml
+++ b/kubernetes/flux/cluster/ks.yaml
@@ -78,3 +78,43 @@ spec:
       target:
         group: kustomize.toolkit.fluxcd.io
         kind: Kustomization
+    # Kustomization-level patches replace the whole spec.patches list, so a rook-ceph-cluster
+    # HelmRelease patch can't just add driftDetection.mode: disabled on top of the one above -
+    # it must replace it wholesale, defaults included. Its dry-run diff can't handle
+    # CephBlockPool/CephFilesystem, whose live spec.replicated.minSize isn't declared in the
+    # installed CRD schema, which puts the release into a permanent StateError otherwise.
+    - patch: |-
+        apiVersion: kustomize.toolkit.fluxcd.io/v1
+        kind: Kustomization
+        metadata:
+          name: not-used
+        spec:
+          patches:
+            - patch: |-
+                apiVersion: helm.toolkit.fluxcd.io/v2
+                kind: HelmRelease
+                metadata:
+                  name: _
+                spec:
+                  driftDetection:
+                    mode: disabled
+                  install:
+                    crds: CreateReplace
+                  rollback:
+                    cleanupOnFail: true
+                  upgrade:
+                    cleanupOnFail: true
+                    crds: CreateReplace
+                    strategy:
+                      name: RemediateOnFailure
+                    remediation:
+                      remediateLastFailure: true
+                      retries: 2
+              target:
+                group: helm.toolkit.fluxcd.io
+                kind: HelmRelease
+      target:
+        group: kustomize.toolkit.fluxcd.io
+        kind: Kustomization
+        name: rook-ceph-cluster
+        namespace: rook-ceph


### PR DESCRIPTION
## Summary
- #4656 added `driftDetection.mode: disabled` directly on `rook-ceph-cluster`'s own HelmRelease file, but it never took effect: the fleet-wide patch (#4654) injects into each child Kustomization's own `spec.patches`, applied *after* the base file builds, so its `mode: enabled` always won the same-map-key collision. Confirmed live: HelmRelease stayed `Ready: False (StateError)` after merging #4656 and force-reconciling.
- Also confirmed live that `driftDetection.ignore` doesn't help either — the schema-validation dry-run fails on the whole object before any path-level filtering happens.
- Kustomization-level `patches` replace the whole list rather than merging entries (verified via `flux build`), so the fix is a second, name-scoped patch (`target: {name: rook-ceph-cluster, namespace: rook-ceph}`) that reconstructs the full HelmRelease patch — install/rollback/upgrade defaults included — with `mode: disabled` instead of layering one field on top.

## Test plan
- [x] `flux build kustomization cluster-apps` confirms the rook-ceph-cluster Kustomization's `spec.patches` is fully replaced with the override (verified render output).
- [x] `flux build kustomization rook-ceph-cluster` with that patches content confirms the final HelmRelease renders `driftDetection.mode: disabled` with install/rollback/upgrade intact.
- [x] Confirmed no other Kustomization's injected patch changed (`fileflows`, `sonarr`, `rook-ceph-csi` still get `mode: enabled`).
- [ ] After merge: reconcile and confirm `rook-ceph-cluster` HelmRelease returns to `Ready: True`.