### PR TITLE
fix(alerts): silence xmrig Pending instead of blackholing it

### DIFF
--- a/kubernetes/apps/observability/silence-operator/silences/silences.yaml
+++ b/kubernetes/apps/observability/silence-operator/silences/silences.yaml
@@ -35,3 +35,37 @@ spec:
   matchers:
     - name: alertname
       value: KubeMemoryOvercommit
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/observability.giantswarm.io/silence_v1alpha2.json
+apiVersion: observability.giantswarm.io/v1alpha2
+kind: Silence
+metadata:
+  # Structural: priority -1000 with a hard per-node pin makes Pending on a full node
+  # xmrig's designed resting state. Nothing sits below it to preempt, and its
+  # ScaledObject reads only that node's thermal verdict so the pod cannot move.
+  name: xmrig-pending-on-full-node
+spec:
+  matchers:
+    - name: alertname
+      value: KubePodNotReady
+    - name: namespace
+      value: web3
+    - name: pod
+      value: xmrig-.*
+      matchType: "=~"
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/observability.giantswarm.io/silence_v1alpha2.json
+apiVersion: observability.giantswarm.io/v1alpha2
+kind: Silence
+metadata:
+  # Same cause as xmrig-pending-on-full-node, seen from the Deployment side.
+  name: xmrig-replicas-mismatch-on-full-node
+spec:
+  matchers:
+    - name: alertname
+      value: KubeDeploymentReplicasMismatch
+    - name: namespace
+      value: web3
+    - name: deployment
+      value: xmrig-.*
+      matchType: "=~"

--- a/kubernetes/apps/observability/silence-operator/silences/silences.yaml
+++ b/kubernetes/apps/observability/silence-operator/silences/silences.yaml
@@ -40,9 +40,8 @@ spec:
 apiVersion: observability.giantswarm.io/v1alpha2
 kind: Silence
 metadata:
-  # Structural: priority -1000 with a hard per-node pin makes Pending on a full node
-  # xmrig's designed resting state. Nothing sits below it to preempt, and its
-  # ScaledObject reads only that node's thermal verdict so the pod cannot move.
+  # Structural: at priority -1000 with a hard node pin, xmrig has nothing below it to
+  # preempt and nowhere to move, so Pending on a full node is its resting state.
   name: xmrig-pending-on-full-node
 spec:
   matchers:

--- a/kubernetes/apps/observability/silence-operator/silences/silences.yaml
+++ b/kubernetes/apps/observability/silence-operator/silences/silences.yaml
@@ -57,7 +57,8 @@ spec:
 apiVersion: observability.giantswarm.io/v1alpha2
 kind: Silence
 metadata:
-  # Same cause as xmrig-pending-on-full-node, seen from the Deployment side.
+  # Same cause, Deployment side: KEDA scales to 1, the pod stays Pending, so spec.replicas
+  # outruns available for as long as the node is full.
   name: xmrig-replicas-mismatch-on-full-node
 spec:
   matchers:


### PR DESCRIPTION
xmrig runs at priority `-1000` with a hard `nodeSelector` pin, so Pending on a full node is its designed resting state: nothing sits below it to preempt, and its ScaledObject reads only that node’s thermal verdict, so the pod cannot move to a node with room.

Uses the existing giantswarm silence-operator rather than an Alertmanager blackhole route. A Silence keeps the alert visible and inspectable in Alertmanager; a blackhole route drops it with no trace. Same precedent as `kube-memory-overcommit-homelab`.

Two CRs because the matchers differ per alert (`pod` vs `deployment`), and both are scoped to `xmrig-.*` in `web3` so monerod / p2pool / dashboard / guard still alert normally.

| check | result |
|---|---|
| `kubectl apply --dry-run=server` | all 5 Silences validate |
| operator reconcile path | `silence-v2` controller syncs CRs to Alertmanager (confirmed in logs for the existing 3) |
| live Silence CRs | `keda-hpa-maxed-out`, `kube-memory-overcommit-homelab`, `truenas-memory-high-utilization` present and `active` in Alertmanager |
| alert labels | `KubePodNotReady` groups on `namespace,pod`; `KubeDeploymentReplicasMismatch` on `namespace,deployment` |
| deployment names | `xmrig-control-1/2/3`, currently `0/0` (scaled down by the thermal guard) |