### PR TITLE
fix(cnpg): restore vchord.so's search path after the vector image swap

### DIFF
--- a/kubernetes/apps/database/cloudnative-pg/cluster/cluster.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/cluster.yaml
@@ -134,6 +134,14 @@ spec:
       - name: vchord
         image:
           reference: ghcr.io/tensorchord/vchord-scratch:pg18-v1.1.1
+        # vchord-scratch mirrors the base image's real install tree (usr/lib/postgresql/18/lib,
+        # usr/share/postgresql/18/extension) instead of CNPG's default extension-image layout
+        # (lib/, share/ at the image root), so the default search path never finds vchord.so.
+        # These paths are resolved relative to this extension's own mount.
+        dynamic_library_path:
+          - /usr/lib/postgresql/18/lib
+        extension_control_path:
+          - /usr/share/postgresql/18/
       - name: vector
         image:
           reference: ghcr.io/cloudnative-pg/pgvector:0.8.6-18-trixie

--- a/kubernetes/apps/database/cloudnative-pg/cluster/cluster.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/cluster.yaml
@@ -141,7 +141,7 @@ spec:
         dynamic_library_path:
           - /usr/lib/postgresql/18/lib
         extension_control_path:
-          - /usr/share/postgresql/18/
+          - /usr/share/postgresql/18
       - name: vector
         image:
           reference: ghcr.io/cloudnative-pg/pgvector:0.8.6-18-trixie


### PR DESCRIPTION
## Summary
Fixes a production regression from #4676: replicas rolled to the new spec crash-loop with `FATAL: could not access file "vchord.so": No such file or directory`.

Root cause: `vchord-scratch` mirrors the base postgresql image's real install tree (`usr/lib/postgresql/18/lib`, `usr/share/postgresql/18/extension`) instead of CNPG's default extension-image layout (`lib/`, `share/` at the image root), so the default `dynamic_library_path`/`extension_control_path` for the `vchord` extension entry never resolved to `vchord.so`. That path was only ever supplied because the old `vector` entry happened to point at the same image with an explicit override — CNPG unions every extension entry's paths into one global GUC, so it worked by coincidence. #4676 replaced `vector`'s image with the official pgvector one, deleting the only entry that carried that override.

Fix: move the override onto the `vchord` entry, where it actually belongs — confirmed against the real image contents (`docker export` shows `usr/lib/postgresql/18/lib/vchord.so`) and CNPG's docs (paths are resolved relative to `/extensions/<name>`, confirmed via cloudnative-pg.io/docs/devel/imagevolume_extensions).

## Current impact
- Primary (`postgres16-1`) and one replica still run the pre-#4676 spec and are healthy — no outage.
- One replica (`postgres16-8`) is crash-looping on the new spec; CNPG won't switch over to an unhealthy target, so the rolling update is stuck, not progressing to primary.

## Test plan
- [ ] YAML validated (`yaml.safe_load_all`)
- [ ] Flux reconciles, CNPG rolls the crash-looping instance, comes up healthy with vchord.so loaded
- [ ] Rolling update proceeds to primary without crash-looping
- [ ] `vchord`/`vector` extensions both functional post-rollout (memini's live vchordrq indexes depend on both)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed vchord extension discovery in PostgreSQL 18 database deployments.
  * Updated extension paths so the database can correctly locate required libraries and control files when using the vchord-scratch image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->