### PR TITLE
feat(k8s-gateway): alert on a replica silently serving a stale zone

### DIFF
--- a/kubernetes/apps/network/k8s-gateway/app/kustomization.yaml
+++ b/kubernetes/apps/network/k8s-gateway/app/kustomization.yaml
@@ -4,4 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - helmrelease.yaml
+  - observability.yaml
   - ocirepository.yaml

--- a/kubernetes/apps/network/k8s-gateway/app/observability.yaml
+++ b/kubernetes/apps/network/k8s-gateway/app/observability.yaml
@@ -30,9 +30,9 @@ spec:
             # serving an empty zone (informer synced against an empty initial LIST, so /ready
             # never flips) while its sibling stays healthy. A fleet-aggregate rate hides that,
             # since roughly half of requests still succeed via the good replica.
-            sum by (pod) (rate(coredns_dns_responses_total{namespace="network", rcode="NXDOMAIN"}[10m]))
+            sum by (pod) (rate(coredns_dns_responses_total{namespace="network", pod=~"k8s-gateway-.*", rcode="NXDOMAIN"}[10m]))
               /
-            sum by (pod) (rate(coredns_dns_responses_total{namespace="network"}[10m]))
+            sum by (pod) (rate(coredns_dns_responses_total{namespace="network", pod=~"k8s-gateway-.*"}[10m]))
               > 0.5
           for: 10m
           annotations:

--- a/kubernetes/apps/network/k8s-gateway/app/observability.yaml
+++ b/kubernetes/apps/network/k8s-gateway/app/observability.yaml
@@ -1,0 +1,43 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/monitoring.coreos.com/podmonitor_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: k8s-gateway
+spec:
+  jobLabel: app.kubernetes.io/name
+  namespaceSelector:
+    matchNames:
+      - network
+  podMetricsEndpoints:
+    - port: metrics
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: k8s-gateway
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: k8s-gateway-rules
+spec:
+  groups:
+    - name: k8s-gateway.rules
+      rules:
+        - alert: K8sGatewayReplicaStale
+          expr: |-
+            # Per-pod, not fleet-wide: the failure mode this catches is one replica silently
+            # serving an empty zone (informer synced against an empty initial LIST, so /ready
+            # never flips) while its sibling stays healthy. A fleet-aggregate rate hides that,
+            # since roughly half of requests still succeed via the good replica.
+            sum by (pod) (rate(coredns_dns_responses_total{namespace="network", rcode="NXDOMAIN"}[10m]))
+              /
+            sum by (pod) (rate(coredns_dns_responses_total{namespace="network"}[10m]))
+              > 0.5
+          for: 10m
+          annotations:
+            summary: >-
+              k8s-gateway pod {{ $labels.pod }} is returning NXDOMAIN for over half its
+              responses -- likely serving a stale/empty zone; restart the pod
+          labels:
+            severity: warning


### PR DESCRIPTION
## Summary
- Adds a PodMonitor for k8s-gateway (its metrics weren't being scraped at all before this)
- Adds a PrometheusRule alerting per-pod when a k8s-gateway replica returns NXDOMAIN for >50% of responses over 10m

## Why
During tonight's rolling kernel cutover, one k8s-gateway replica got recreated on a node right as it rejoined the cluster, and its Kubernetes informer's initial LIST came back empty. `HasSynced()` still flipped true permanently, so the readiness probe stayed green while that pod served NXDOMAIN for every `*.tanguille.site` hostname behind it -- roughly half of all lookups failed for ~50 minutes, since the Service round-robins across both replicas. No probe can catch this class of failure (confirmed: chart's `/ready` only reflects informer HasSynced, not zone freshness; the image is distroless so an exec-based content probe isn't possible either). A per-pod NXDOMAIN-rate alert is the only lever that sees it.

## Test plan
- [x] `kustomize build` renders cleanly
- [x] Manually applied the PodMonitor+PrometheusRule directly to verify scrape target/rule syntax before committing (Flux pruned them immediately since they weren't in git yet, confirming `prune: true` behaves as expected)
- [ ] Confirm PodMonitor target comes up healthy in vmagent after Flux reconciles
- [ ] Confirm PrometheusRule loads in vmalert with no syntax errors