### PR TITLE
feat(ai): expand hermes PVC from 10Gi to 20Gi

### DIFF
--- a/kubernetes/apps/ai/hermes/ks.yaml
+++ b/kubernetes/apps/ai/hermes/ks.yaml
@@ -19,6 +19,6 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      PVC_CAPACITY: 10Gi
+      PVC_CAPACITY: 20Gi
       KOPIUR_PUID: "10000"
       KOPIUR_PGID: "10000"


### PR DESCRIPTION
## Why

`ai/hermes` PVC is at **95.6% of 10Gi** (9.31 GiB used, 429 MiB free) — `KubePersistentVolumeFillingUp` is firing. The largest active consumer is `state.db` (1.8 GiB, ~500M/mo growth). Pruning regenerable caches recovers ~5.5 GiB but only buys months; this expansion is the durable fix.

## Change

One line: `PVC_CAPACITY: 10Gi -> 20Gi` in `kubernetes/apps/ai/hermes/ks.yaml` (postBuild substitute consumed by the shared `kopiur` component's PVC template, `kubernetes/components/kopiur/restore/pvc.yaml`).

## Why it's safe

- Live StorageClass `ceph-block` has `allowVolumeExpansion: true` (verified via ToolHive read of the live SC).
- Ceph RBD CSI does in-place expansion; ext4 grows online. **No pod restart, no data movement.**
- No other consumer of the `hermes` PVC or the kopiur component is affected — the substitute is scoped to this Kustomization.

## Verification

- `kubectl kustomize` on `kubernetes/apps/ai/hermes/app` renders clean (Secret, HelmRelease, PrometheusRule).
- `github_push_files` output verified by re-reading the raw file from the branch: line 22 is `PVC_CAPACITY: 20Gi`.
- Post-merge, Flux applies the new spec; rook-ceph CSI controller expands the RBD image and the filesystem grows in place. Then confirm via Prometheus: `kubelet_volume_stats_used_bytes{persistentvolumeclaim="hermes"} / kubelet_volume_stats_capacity_bytes{...} * 100` < 50 and the alert cleared.

## Out of scope (follow-up card)

Pruning ~5.5 GiB of regenerable caches (cargo/rustup/uv/pnpm/npm + 4 stale kanban workspaces) as a belt-and-braces second line — handled in the child task.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Increased storage capacity for the Hermes application from 10 GiB to 20 GiB.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->