### PR TITLE
feat(toolhive): add flux-schema MCPServerEntry backend

### DIFF
--- a/kubernetes/apps/ai/toolhive/config/flux-schema.yaml
+++ b/kubernetes/apps/ai/toolhive/config/flux-schema.yaml
@@ -1,0 +1,11 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/toolhive.stacklok.dev/mcpserverentry_v1beta1.json
+apiVersion: toolhive.stacklok.dev/v1beta1
+kind: MCPServerEntry
+metadata:
+  name: flux-schema
+spec:
+  remoteUrl: https://schemas.fluxoperator.dev/mcp
+  transport: streamable-http
+  groupRef:
+    name: all

--- a/kubernetes/apps/ai/toolhive/config/kustomization.yaml
+++ b/kubernetes/apps/ai/toolhive/config/kustomization.yaml
@@ -18,3 +18,4 @@ resources:
   - context7.yaml
   - kubesearch.yaml
   - memini.yaml
+  - flux-schema.yaml


### PR DESCRIPTION
Adds the Flux Schema Catalog MCP server (https://schemas.fluxoperator.dev/) as a ToolHive MCP backend.

- New file: kubernetes/apps/ai/toolhive/config/flux-schema.yaml
- Modified: kubernetes/apps/ai/toolhive/config/kustomization.yaml (adds flux-schema.yaml resource)

Mirrors memini.yaml exactly (same header comment style, same field order).
Transport: streamable-http, no auth, groupRef: all.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the Flux schema MCP server to the ToolHive configuration.
  - The server is available through streamable HTTP and included in the default resource deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->