### PR TITLE
fix(container): raise speedtest-exporter resource limits — memory 512Mi, cpu 2

### DIFF
--- a/kubernetes/apps/observability/exporters/speedtest-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/exporters/speedtest-exporter/app/helmrelease.yaml
@@ -27,8 +27,11 @@ spec:
                 cpu: 10m
                 memory: 64Mi
               limits:
-                cpu: 1
-                memory: 256Mi
+                # Speedtest cycle spikes ~254Mi at ~30min intervals (Go download
+                # workers + checksumming); 1 core also saturates (998m), starving
+                # download workers and skewing measured download speed.
+                cpu: 2
+                memory: 512Mi
             securityContext:
               allowPrivilegeEscalation: false
               capabilities: { drop: ["ALL"] }


### PR DESCRIPTION
Speedtest cycles spike to ~254Mi every 30 minutes (Go download workers + checksumming) and saturate a single core (~998m), which starved the download workers and skewed measured download speed. The previous 256Mi limit left no headroom: the prior pod OOMKilled 46 times, exactly one kill per 30-minute test cycle, with the emptyDir cache wiped each restart.

- memory limit 256Mi -> 512Mi (2x observed peak; idle is ~22Mi, request unchanged at 64Mi)
- cpu limit 1 -> 2 so the download phase is not CPU-starved

Evidence: 46 OOMKills, peak 254Mi, 30-min cycle cadence — see cluster-ha-health digests Aug 25-26.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Increased available CPU and memory for the speed test monitoring service.
  * Improved handling of resource usage spikes during speed test cycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->