### PR TITLE
refactor(ci): build the Talos kernel from the bump branch, not after the merge

### DIFF
--- a/.github/workflows/talos-kernel.yaml
+++ b/.github/workflows/talos-kernel.yaml
@@ -10,14 +10,15 @@ on:
       - talos/schematic.yaml
       - talos/nodes/**/*.schematic.yaml
       - kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
+  # Dispatch against the bump branch to build BEFORE merging it — the only way to have the
+  # installer exist by the time main starts naming it:
+  #     gh workflow run talos-kernel.yaml --ref <branch>
+  # No version input: the ref already selects both versions, from that branch's Dockerfile ARG
+  # and its tuppr CR, so an input could only disagree with the tree being built.
   workflow_dispatch:
-    inputs:
-      talos-version:
-        description: "Talos version to build against; defaults to the tuppr CR's"
-        required: false
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -87,16 +88,9 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # The script derives everything else itself: the kernel version from the Renovate-managed
-      # ARG, and TOOLS/PKGS from the Talos release's own Makefile.
+      # Everything is derived from the tree: the Talos version from the tuppr CR, the kernel from
+      # the Renovate-managed Dockerfile ARG, TOOLS/PKGS from the Talos release's own Makefile,
+      # and the node list from talos/nodes/. The script writes its own job summary naming every
+      # ref it published. Same entrypoint as a workstation build, so the two cannot drift.
       - name: Build and publish installers
-        # Through env, not interpolated into the shell: a workflow_dispatch input expanded
-        # directly into a run block is a code-injection vector.
-        env:
-          TALOS_VERSION_INPUT: ${{ inputs.talos-version }}
-        run: |
-          talos_version="${TALOS_VERSION_INPUT}"
-          [ -n "${talos_version}" ] || talos_version="$(just tuppr-version talos)"
-          # The node list comes from talos/nodes/, and the script writes its own job summary
-          # naming every ref it published.
-          scripts/talos-kernel-build.sh "${talos_version}" $(just talos nodes)
+        run: just talos kernel-build

--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -22,14 +22,19 @@
     // (7.1.x -> 7.2.x) with no config change. Not a git mirror: gregkh/linux carries mainline
     // and -rc tags in the same stream, so Renovate would offer -rc builds as updates.
     // Feed shape verified against the live endpoint: {"releases":[{"moniker","version",
-    // "changelog","iseol",...}], "latest_stable":{...}}, exactly one moniker=="stable" entry.
+    // "changelog","iseol",...}], "latest_stable":{...}}.
     // Re-check with: curl -s https://www.kernel.org/releases.json | jq '.releases[]|select(.moniker=="stable")'
     // If the shape ever changes the transform yields zero releases and bumps stop SILENTLY.
+    //
+    // There can be TWO stable entries while a series hands over — 7.2.2 and 7.1.12 both appeared
+    // on 2026-08-28 — so this is not a single-row feed and Renovate picks the highest. iseol is
+    // filtered because a dead series lingers in the feed with its final version: without it, a
+    // hold on the older series would sit on an unpatched kernel and look current.
     "linux-kernel": {
       defaultRegistryUrlTemplate: "https://www.kernel.org/releases.json",
       format: "json",
       transformTemplates: [
-        '{"releases":[releases[moniker="stable"].{"version": version, "changelogUrl": changelog}], "homepage": "https://www.kernel.org"}'
+        '{"releases":[releases[moniker="stable" and iseol=false].{"version": version, "changelogUrl": changelog}], "homepage": "https://www.kernel.org"}'
       ]
     }
   },

--- a/docker/talos-kernel/README.md
+++ b/docker/talos-kernel/README.md
@@ -151,6 +151,18 @@ hardcode one.
 
 ## Per-bump maintenance
 
+Build from the bump branch **before** merging it:
+
+```sh
+gh workflow run talos-kernel.yaml --ref renovate/linux-7.x
+```
+
+The push trigger builds on merge, but the build takes ~2h45m and `pinned` becomes
+`v<talos>-k<new-kernel>` the moment the merge lands — so between the two, every rendered config
+names an installer tag that does not exist yet. Dispatching on the branch closes that window:
+the workflow checks out that ref, so it builds that branch's `ARG KERNEL_VERSION` against that
+branch's tuppr CR, and the merge only ratifies an image that is already published.
+
 Renovate opens a PR bumping `ARG KERNEL_VERSION`. The tarball is verified by Greg KH's
 committed PGP key, so there is no second field to update. The key's fingerprint was
 cross-checked against the one kernel.org publishes on <https://www.kernel.org/signature.html>:

--- a/docker/talos-kernel/README.md
+++ b/docker/talos-kernel/README.md
@@ -154,7 +154,14 @@ hardcode one.
 Build from the bump branch **before** merging it:
 
 ```sh
-gh workflow run talos-kernel.yaml --ref renovate/linux-7.x
+branch=renovate/linux-7.x
+gh workflow run talos-kernel.yaml --ref "${branch}"
+# Dispatch returns immediately and the build is ~2h45m, so watch it rather than merging on the
+# assumption it worked. --exit-status is what makes a failed build a failed command; without it
+# `gh run watch` exits 0 whatever the run concluded. Filtered by branch AND event so a push
+# build of main cannot be picked up as this one.
+gh run watch --exit-status "$(gh run list --workflow talos-kernel.yaml --branch "${branch}" \
+    --event workflow_dispatch --limit 1 --json databaseId -q '.[0].databaseId')"
 ```
 
 The push trigger builds on merge, but the build takes ~2h45m and `pinned` becomes


### PR DESCRIPTION
The kernel build could only be started by merging. `pull_request` was dropped in #4679, and `workflow_dispatch`'s `talos-version` input still builds **main**'s `ARG KERNEL_VERSION` — so there was no way to produce 7.2.2's installer without first merging 7.2.2.

| | before | after |
|---|---|---|
| build a bump before merging | impossible | `gh workflow run talos-kernel.yaml --ref <branch>` |
| window where `pinned` names an unbuilt tag | ~2h45m | none |
| run step | 5 lines re-deriving the defaults | `just talos kernel-build` |
| dispatch input interpolated into a shell | yes (guarded) | removed |

`--ref` already selects both versions from that branch's tree, so the input could only ever disagree with what was checked out.

Datasource: `iseol` is now filtered. The feed carries **two** `moniker="stable"` rows during a series handover — 7.2.2 and 7.1.12 both landed 2026-08-28 — and an EOL series lingers with its final version, so holding the older one would look current while being unpatched. Transform re-verified against the live endpoint:

```
{"releases":[{"version":"7.2.2",...},{"version":"7.1.12",...}],"homepage":"https://www.kernel.org"}
```

Not done: pinning the datasource to 7.1.y to stop the ~9-week series treadmill. 7.1.12 is alive today, but the series EOLs weeks after 7.2 promotes, and that trades a migration for an unpatched kernel. Making each bump cheap is the better lever.

Follow-up in the next PR: a CI gate that fails when a PR names an installer tag nobody built.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Kernel update automation now excludes end-of-life stable kernel series.
  - Kernel builds consistently use the same process and version sources, improving reliability.

- **Documentation**
  - Added maintenance guidance to validate kernel images before merging updates.
  - Clarified the workflow for preventing temporary mismatches between rendered configurations and published installer images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->