### PR TITLE
feat(ai): switch qwen-3.8 to Qwen3.8-Flash-Next on llama-server

### DIFF
--- a/kubernetes/apps/ai/litellm/instance/models.yaml
+++ b/kubernetes/apps/ai/litellm/instance/models.yaml
@@ -50,7 +50,10 @@ spec:
   proxyRef: litellm
   params:
     model: openai/qwen-3.8
-    apiBase: http://qwen38-27b-vllm.ai.svc.cluster.local:8000/v1
+    # Moves with qwen-3.8 above -- this alias is proxy.yaml's only fallback
+    # target, so leaving it on the suspended vLLM would point the whole
+    # one-deep chain at nothing.
+    apiBase: http://qwen38-flash-next.ai.svc.cluster.local:8080/v1
     apiKey: sk-vllm-noauth
     additional:
       # Hermes compression is a ~100K+ prefill on this alias; under GPU contention
@@ -69,8 +72,8 @@ spec:
           enable_thinking: false
   info:
     mode: chat
-    # 246944 - 8192, as above.
-    maxInputTokens: 238752
+    # 131072 - 8192, as above.
+    maxInputTokens: 122880
     maxOutputTokens: 8192
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/litellm.home-operations.com/litellmmodel_v1alpha1.json

--- a/kubernetes/apps/ai/litellm/instance/models.yaml
+++ b/kubernetes/apps/ai/litellm/instance/models.yaml
@@ -13,8 +13,10 @@ spec:
     # profiles live on the hermes data PVC, so they are edited by hand and no
     # rollback of this repo touches them.
     # Backend swapped to qwen38-27b-vllm 2026-08-16 -- numbers in that file.
+    # Swapped again to qwen38-flash-next (llama-server): port moves 8000 -> 8080
+    # with the engine, so both halves of this line change together.
     model: openai/qwen-3.8
-    apiBase: http://qwen38-27b-vllm.ai.svc.cluster.local:8000/v1
+    apiBase: http://qwen38-flash-next.ai.svc.cluster.local:8080/v1
     # Native vLLM is unauthenticated internally, but LiteLLM's OpenAI provider
     # requires a non-empty api_key.
     apiKey: sk-vllm-noauth
@@ -30,9 +32,12 @@ spec:
           reasoning_effort: medium
   info:
     mode: chat
-    # maxModelLen (246944) minus maxOutputTokens; re-derive if that changes,
-    # nothing enforces it across the two CRDs.
-    maxInputTokens: 238752
+    # contextSize (131072) minus maxOutputTokens; re-derive if that changes,
+    # nothing enforces it across the two CRDs. This drops from 238752 with the
+    # engine swap -- llama-server splits contextSize across parallelSlots and
+    # the card has no room to divide, so the window is the whole budget.
+    # Hermes peaks at 112K, which this clears; nothing else observed goes near it.
+    maxInputTokens: 122880
     maxOutputTokens: 8192
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/litellm.home-operations.com/litellmmodel_v1alpha1.json

--- a/kubernetes/apps/ai/litellm/instance/prometheusrule.yaml
+++ b/kubernetes/apps/ai/litellm/instance/prometheusrule.yaml
@@ -41,14 +41,14 @@ spec:
         # hit means hermes has no local model either.
         - alert: LiteLLMFallbackBackendDown
           expr: |-
-            kube_deployment_status_replicas_available{namespace="ai", deployment="qwen38-27b-vllm"} == 0
+            kube_deployment_status_replicas_available{namespace="ai", deployment="qwen38-flash-next"} == 0
             or
-            absent(kube_deployment_status_replicas_available{namespace="ai", deployment="qwen38-27b-vllm"})
+            absent(kube_deployment_status_replicas_available{namespace="ai", deployment="qwen38-flash-next"})
           # replicas: 1 on a single dGPU node, so every pod roll dips to 0.
           for: 10m
           annotations:
             summary: >-
-              qwen38-27b-vllm has no available replica — litellm's only fallback
+              qwen38-flash-next has no available replica — litellm's only fallback
               target is gone and hermes has no local model
           labels:
             severity: critical

--- a/kubernetes/apps/ai/llmkube/models/kustomization.yaml
+++ b/kubernetes/apps/ai/llmkube/models/kustomization.yaml
@@ -4,6 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - qwen38-27b-vllm.yaml
+  - qwen38-flash-next.yaml
   - qwen3-embedding.yaml
   - qwen35-2b.yaml
   - vmcp-embedding.yaml

--- a/kubernetes/apps/ai/llmkube/models/qwen38-27b-vllm.yaml
+++ b/kubernetes/apps/ai/llmkube/models/qwen38-27b-vllm.yaml
@@ -360,6 +360,14 @@ spec:
     - --kv-transfer-config
     - >-
       {"kv_connector":"OffloadingConnector","kv_role":"kv_both","kv_connector_extra_config":{"spec_name":"TieringOffloadingSpec","cpu_bytes_to_use":23622320128,"blocks_per_chunk":4,"secondary_tiers":[{"type":"fs","root_dir":"/kvoffload","locality":"LOCAL"}]}}
+  # Parked, not deleted: control-1 advertises 4 squat.ai/dri slots and all 4 are
+  # held (this pod, jellyfin x3, fileflows, drm-exporter), so Flash-Next cannot
+  # schedule until this one releases -- and the R9700's 32Gi could not hold both
+  # models even if a slot were free. The whole config below is kept verbatim so
+  # reverting the switch is a one-line change back to false, not a restore from
+  # git history. Every measured tuning value here (mnbt 4096, maxModelLen
+  # 246944, blocks_per_chunk 4) stays valid for that revert.
+  suspend: true
   nodeSelector:
     amd.com/gpu: "true"
   podSecurityContext:

--- a/kubernetes/apps/ai/llmkube/models/qwen38-flash-next.yaml
+++ b/kubernetes/apps/ai/llmkube/models/qwen38-flash-next.yaml
@@ -65,6 +65,16 @@ spec:
   # b10689 = upstream rev 57291f2, the first release tag carrying qwen4exp
   # (ggml-org/llama.cpp#27742). The official ROCm image builds gfx1201, so no
   # custom build is needed.
+  #
+  # BUMP BEFORE VALIDATING. b10689 is the newest container build (all backends
+  # stop there; release tags are already at b10701 and images lag 9-22 tags),
+  # but it predates llama.cpp#27837 by ~10h, and that fix matters here: the old
+  # code gated the lazy decision on `use_mmap`, which is false during the
+  # memory-fit pass (no_alloc, no mmap), so the fit pass counts the whole
+  # 26.82Gi PLE against available memory. On a 32Gi card already spilling to
+  # host RAM that plausibly refuses or silently shrinks contextSize below.
+  # The same build will carry the -lzm rename (#27969), so both changes land
+  # together -- see extraArgs.
   image: ghcr.io/ggml-org/llama.cpp:server-rocm-b10689
   modelCache:
     claimName: qwen38-flash-next-model-cache

--- a/kubernetes/apps/ai/llmkube/models/qwen38-flash-next.yaml
+++ b/kubernetes/apps/ai/llmkube/models/qwen38-flash-next.yaml
@@ -5,37 +5,53 @@ kind: Model
 metadata:
   name: qwen38-flash-next
 spec:
-  # REAP-256: community expert-pruned to 256 of the 512 routed experts. Chosen
-  # over the stock unsloth quants purely on resident footprint -- measured from
-  # the GGUF tensor headers, with the PLE table excluded (it stays on NVMe, see
-  # --tensor-read-lazy below):
+  # Resident footprints measured from the GGUF tensor headers, with the PLE
+  # table excluded -- it stays on NVMe (see --tensor-read-lazy below). "spill"
+  # is what does not fit the ~30Gi of usable VRAM and lands in host RAM via
+  # moeCPULayers:
   #
-  #   GGUF                     PLE (NVMe)  experts  other  RESIDENT  file
-  #   REAP-256 UD-Q3_K_XL         26.82     25.99    4.87   30.9Gi   57.7Gi
-  #   unsloth  UD-IQ1_S           26.82     37.10    3.62   40.7Gi   67.6Gi
-  #   unsloth  UD-Q2_K_XL         26.82     42.92    3.70   46.6Gi   73.5Gi
+  #   GGUF                     PLE(NVMe)  experts  other  RESIDENT  spill  top-1
+  #   REAP-256 UD-Q3_K_XL         26.82    25.99    4.87   30.9Gi    ~1Gi   none
+  #   unsloth  UD-IQ1_S           26.82    37.10    3.62   40.7Gi   ~11Gi  ~79.7%
+  #   unsloth  UD-Q2_K_XL         26.82    42.92    3.70   46.6Gi   ~17Gi   82.7%
+  #   unsloth  UD-IQ3_XXS         26.82    45.29    4.21   49.5Gi   ~20Gi     --
+  #   unsloth  UD-Q3_K_XL         26.82    51.99    4.98   57.0Gi   ~27Gi     --
   #
-  # Only the REAP variant fits the R9700's 32Gi (minus Jellyfin's 2Gi reserve).
+  # The budget is VRAM+RAM, not VRAM alone: parking the vLLM service releases
+  # 27.4Gi, taking control-1 from 15.4Gi to ~42.8Gi available. Q2_K_XL's 17Gi
+  # spill fits that with room left for the node.
+  #
+  # REAP-256 fits VRAM outright but prunes half the 512 routed experts by a
+  # community process with NO published evals -- an unmeasured quality risk
+  # stacked on top of Q3 quantization, which is the wrong basis for a
+  # quality evaluation. Q2_K_XL is the cheapest tier with a published number.
+  #
+  # Spill cost is real but bounded: llama.cpp#27861 measured this exact model
+  # (UD-Q4_K_XL, 28 expert layers host-pinned, 2x3090, one populated RAM
+  # channel per socket) at 18.4 tok/s decode, 24.2 with their GPU LRU cache.
+  # Roughly half of this box's current 31.8-33.9 tok/s, not an order of magnitude.
+  #
   # The PLE tensor is a constant 26.82Gi in every unsloth tier -- they keep it
   # at IQ4_NL regardless of the quant name, so a lower quant does not shrink it.
   #
   # Unsloth's one hard caveat for this architecture is that the PLE/n-gram
   # layers must stay at 4-bit or better -- their random access pattern makes
   # aggressive quantization disproportionately damaging. Verified directly
-  # against this artifact's GGUF header rather than assumed: the Q3_K_XL name
+  # against this artifact's GGUF header rather than assumed: the Q2_K_XL name
   # refers to the expert tiers only, and per_layer_token_embd.weight is
   # type 20 (IQ4_NL, 4.5 bpw). It clears the floor.
   #
   # Revision-pinned: HF repos re-upload fixed GGUFs under the same filename, so
   # `main` is not immutable. Renovate bumps this via the git-refs manager.
-  source: hf://AnonimousA/Qwen3.8-Flash-Next-REAP-256-duo-GGUF@829b8ec59549492c8db50305517c39231cabd33c
-  # Two shards; the first is the primary passed to llama-server, which resolves
-  # the rest itself.
+  source: hf://unsloth/Qwen3.8-Flash-Next-GGUF@c8b5954a88c2775c546b92593eda40ea041d3176
+  # Three shards; the first is the primary passed to llama-server, which
+  # resolves the rest itself.
   files:
-    - Qwen3.8-Flash-Next-UD-Q3_K_XL-reap256-00001-of-00002.gguf
-    - Qwen3.8-Flash-Next-UD-Q3_K_XL-reap256-00002-of-00002.gguf
+    - UD-Q2_K_XL/Qwen3.8-Flash-Next-UD-Q2_K_XL-00001-of-00003.gguf
+    - UD-Q2_K_XL/Qwen3.8-Flash-Next-UD-Q2_K_XL-00002-of-00003.gguf
+    - UD-Q2_K_XL/Qwen3.8-Flash-Next-UD-Q2_K_XL-00003-of-00003.gguf
   format: gguf
-  quantization: UD-Q3_K_XL
+  quantization: UD-Q2_K_XL
   refreshPolicy: OnChange
   hardware:
     accelerator: rocm
@@ -65,17 +81,21 @@ spec:
   # a tuning choice. llama.cpp splits contextSize across parallelSlots, hence
   # slots=1 -- this is a single-GPU box with no room to divide.
   # 131072 is chosen to clear Hermes's peak, NOT because the KV footprint has
-  # been measured: 26.0Gi of experts already spills 8 layers to host RAM, and
+  # been measured: half the expert layers already spill to host RAM, and
   # whatever QSA's cache costs at this depth comes out of the same 32Gi card.
   # Measure at validation and reconcile with moeCPULayers before merging.
   contextSize: 131072
   parallelSlots: 1
   jinja: true
-  # 26.0Gi of routed experts against ~30Gi usable VRAM leaves no room for the
-  # 4.9Gi of always-resident tensors plus KV, so some expert layers spill to
-  # host RAM. 8 is a starting point to be tuned against real VRAM headroom at
-  # validation time -- lower it if the card has room, raise it if it OOMs.
-  moeCPULayers: 8
+  # 42.92Gi of routed experts over 48 layers is ~0.9Gi/layer. Usable VRAM is
+  # ~30Gi (32 minus Jellyfin's 2Gi reserve); subtract the 3.7Gi of
+  # always-resident tensors and leave ~4Gi for KV and compute, so ~22Gi holds
+  # roughly 24 expert layers on the card and the other 24 (~21Gi) go to host
+  # RAM -- inside the ~42.8Gi freed by parking vLLM.
+  # A starting point, not a measured optimum: lower it if VRAM has room, raise
+  # it if the server OOMs. Tune together with contextSize, which competes for
+  # the same 4Gi of KV headroom.
+  moeCPULayers: 24
   extraArgs:
     # The reason this model is runnable here at all. The PLE n-gram table is a
     # single 26.82Gi tensor ([160, 320001536], 51.2B of the model's 176.9B
@@ -117,7 +137,8 @@ spec:
       type: Unconfined
   resources:
     cpu: "4"
-    # Host-side room for the 8 spilled expert layers plus the page cache the
-    # lazy PLE reads depend on -- that cache is what keeps the on-demand row
-    # gathers off the disk hot path.
-    memory: 24Gi
+    # Host-side room for the ~21Gi of spilled expert layers plus the page cache
+    # the lazy PLE reads depend on -- that cache is what keeps the on-demand row
+    # gathers off the disk hot path. Fits the ~42.8Gi freed by parking vLLM,
+    # which requested 32Gi for the same reason.
+    memory: 32Gi

--- a/kubernetes/apps/ai/llmkube/models/qwen38-flash-next.yaml
+++ b/kubernetes/apps/ai/llmkube/models/qwen38-flash-next.yaml
@@ -1,0 +1,123 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/inference.llmkube.dev/model_v1alpha1.json
+apiVersion: inference.llmkube.dev/v1alpha1
+kind: Model
+metadata:
+  name: qwen38-flash-next
+spec:
+  # REAP-256: community expert-pruned to 256 of the 512 routed experts. Chosen
+  # over the stock unsloth quants purely on resident footprint -- measured from
+  # the GGUF tensor headers, with the PLE table excluded (it stays on NVMe, see
+  # --tensor-read-lazy below):
+  #
+  #   GGUF                     PLE (NVMe)  experts  other  RESIDENT  file
+  #   REAP-256 UD-Q3_K_XL         26.82     25.99    4.87   30.9Gi   57.7Gi
+  #   unsloth  UD-IQ1_S           26.82     37.10    3.62   40.7Gi   67.6Gi
+  #   unsloth  UD-Q2_K_XL         26.82     42.92    3.70   46.6Gi   73.5Gi
+  #
+  # Only the REAP variant fits the R9700's 32Gi (minus Jellyfin's 2Gi reserve).
+  # The PLE tensor is a constant 26.82Gi in every unsloth tier -- they keep it
+  # at IQ4_NL regardless of the quant name, so a lower quant does not shrink it.
+  #
+  # Unsloth's one hard caveat for this architecture is that the PLE/n-gram
+  # layers must stay at 4-bit or better -- their random access pattern makes
+  # aggressive quantization disproportionately damaging. Verified directly
+  # against this artifact's GGUF header rather than assumed: the Q3_K_XL name
+  # refers to the expert tiers only, and per_layer_token_embd.weight is
+  # type 20 (IQ4_NL, 4.5 bpw). It clears the floor.
+  #
+  # Revision-pinned: HF repos re-upload fixed GGUFs under the same filename, so
+  # `main` is not immutable. Renovate bumps this via the git-refs manager.
+  source: hf://AnonimousA/Qwen3.8-Flash-Next-REAP-256-duo-GGUF@829b8ec59549492c8db50305517c39231cabd33c
+  # Two shards; the first is the primary passed to llama-server, which resolves
+  # the rest itself.
+  files:
+    - Qwen3.8-Flash-Next-UD-Q3_K_XL-reap256-00001-of-00002.gguf
+    - Qwen3.8-Flash-Next-UD-Q3_K_XL-reap256-00002-of-00002.gguf
+  format: gguf
+  quantization: UD-Q3_K_XL
+  refreshPolicy: OnChange
+  hardware:
+    accelerator: rocm
+    gpu:
+      enabled: true
+      count: 1
+      vendor: amd
+      runtime: rocm
+      layers: -1
+      resourceName: squat.ai/dri
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/inference.llmkube.dev/inferenceservice_v1alpha1.json
+apiVersion: inference.llmkube.dev/v1alpha1
+kind: InferenceService
+metadata:
+  name: qwen38-flash-next
+spec:
+  modelRef: qwen38-flash-next
+  # b10689 = upstream rev 57291f2, the first release tag carrying qwen4exp
+  # (ggml-org/llama.cpp#27742, merged 2026-08-27). The official ROCm image
+  # builds gfx1201 in its target list, so no custom build is needed:
+  #   gfx908;gfx90a;gfx942;gfx1030;gfx1100;gfx1101;gfx1102;gfx1151;gfx1150;gfx1200;gfx1201
+  image: ghcr.io/ggml-org/llama.cpp:server-rocm-b10689
+  bindAddress: 0.0.0.0
+  # UNVALIDATED. The outgoing vLLM config serves 246944 and Hermes peaks at
+  # 112K, so anything below ~131072 is a functional regression for it, not just
+  # a tuning choice. llama.cpp splits contextSize across parallelSlots, hence
+  # slots=1 -- this is a single-GPU box with no room to divide.
+  # 131072 is chosen to clear Hermes's peak, NOT because the KV footprint has
+  # been measured: 26.0Gi of experts already spills 8 layers to host RAM, and
+  # whatever QSA's cache costs at this depth comes out of the same 32Gi card.
+  # Measure at validation and reconcile with moeCPULayers before merging.
+  contextSize: 131072
+  parallelSlots: 1
+  jinja: true
+  # 26.0Gi of routed experts against ~30Gi usable VRAM leaves no room for the
+  # 4.9Gi of always-resident tensors plus KV, so some expert layers spill to
+  # host RAM. 8 is a starting point to be tuned against real VRAM headroom at
+  # validation time -- lower it if the card has room, raise it if it OOMs.
+  moeCPULayers: 8
+  extraArgs:
+    # The reason this model is runnable here at all. The PLE n-gram table is a
+    # single 26.82Gi tensor ([160, 320001536], 51.2B of the model's 176.9B
+    # params); llama.cpp reads its rows from disk on demand instead of keeping
+    # it resident. Upstream calls this out explicitly in the loader:
+    # "keep PLE / engrams embd tensors on disk, read them on demand".
+    #
+    # `auto` (the default) would also catch it, since it lazies any marked
+    # tensor over 4Gi -- set explicitly so the behaviour is stated, not
+    # inherited. Requires mmap, so do not combine with --load-mode none.
+    #
+    # NOTE: renamed to -lzm/--lazy-mode in llama.cpp#27969, which landed two
+    # hours after b10689 was built. Rename this when the image is next bumped.
+    - "--tensor-read-lazy"
+    - "on"
+    - "--alias"
+    - "qwen-3.8-flash-next"
+    # Unsloth's thinking-mode values (unsloth.ai/docs/models/qwen3.8-next). Set
+    # here for the same reason qwen35-2b does: the LiteLLM alias carries no
+    # sampling params, so without these the server defaults apply. The outgoing
+    # qwen-3.8 alias runs thinking (reasoning_effort medium), so these are the
+    # matching set -- non-thinking would be temp 0.7 / top-p 0.80 / presence 1.5.
+    - "--temp"
+    - "1.0"
+    - "--top-p"
+    - "0.95"
+    - "--top-k"
+    - "20"
+    - "--min-p"
+    - "0.0"
+  nodeSelector:
+    amd.com/gpu: "true"
+  # Mirrors the vLLM pod's GPU access: root plus video(44)/render(226).
+  podSecurityContext:
+    runAsUser: 0
+    runAsGroup: 0
+    supplementalGroups: [44, 226]
+    seccompProfile:
+      type: Unconfined
+  resources:
+    cpu: "4"
+    # Host-side room for the 8 spilled expert layers plus the page cache the
+    # lazy PLE reads depend on -- that cache is what keeps the on-demand row
+    # gathers off the disk hot path.
+    memory: 24Gi

--- a/kubernetes/apps/ai/llmkube/models/qwen38-flash-next.yaml
+++ b/kubernetes/apps/ai/llmkube/models/qwen38-flash-next.yaml
@@ -1,51 +1,43 @@
 ---
+# Node-local NVMe, NOT the shared llmkube modelCache. That one is 8Gi of CephFS
+# sized for the ~2.1Gi of embedding models, and its own comment assumes
+# "read-once at load, so CephFS latency never touches inference" -- which is
+# exactly false here: --tensor-read-lazy reads PLE rows from this volume on
+# every token, so it has to be local disk. Same pattern as qwen38-27b-vllm.
+# 85Gi holds the 73.5Gi three-shard GGUF with room to re-stage on a bump.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: qwen38-flash-next-model-cache
+spec:
+  accessModes: [ReadWriteOnce]
+  storageClassName: openebs-hostpath
+  resources:
+    requests:
+      storage: 85Gi
+---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/inference.llmkube.dev/model_v1alpha1.json
 apiVersion: inference.llmkube.dev/v1alpha1
 kind: Model
 metadata:
   name: qwen38-flash-next
 spec:
-  # Resident footprints measured from the GGUF tensor headers, with the PLE
-  # table excluded -- it stays on NVMe (see --tensor-read-lazy below). "spill"
-  # is what does not fit the ~30Gi of usable VRAM and lands in host RAM via
-  # moeCPULayers:
+  # Measured from the GGUF tensor headers. RESIDENT excludes the PLE table,
+  # which stays on NVMe (see --tensor-read-lazy); "spill" is what exceeds the
+  # ~30Gi of usable VRAM and lands in host RAM via moeCPULayers:
+  #   UD-Q2_K_XL  experts 42.92Gi + other 3.70Gi = 46.6Gi resident, ~17Gi spill
+  # Parking vLLM frees 27.4Gi of host RAM (15.4Gi -> ~42.8Gi), which is what
+  # makes that spill fit. Rationale for this tier over the others is in #4764.
   #
-  #   GGUF                     PLE(NVMe)  experts  other  RESIDENT  spill  top-1
-  #   REAP-256 UD-Q3_K_XL         26.82    25.99    4.87   30.9Gi    ~1Gi   none
-  #   unsloth  UD-IQ1_S           26.82    37.10    3.62   40.7Gi   ~11Gi  ~79.7%
-  #   unsloth  UD-Q2_K_XL         26.82    42.92    3.70   46.6Gi   ~17Gi   82.7%
-  #   unsloth  UD-IQ3_XXS         26.82    45.29    4.21   49.5Gi   ~20Gi     --
-  #   unsloth  UD-Q3_K_XL         26.82    51.99    4.98   57.0Gi   ~27Gi     --
+  # PLE/n-gram layers must stay at 4-bit or better -- their random access
+  # pattern makes aggressive quantization disproportionately damaging. Checked,
+  # not assumed: Q2_K_XL names only the expert tiers, and
+  # per_layer_token_embd.weight is type 20 (IQ4_NL, 4.5 bpw).
   #
-  # The budget is VRAM+RAM, not VRAM alone: parking the vLLM service releases
-  # 27.4Gi, taking control-1 from 15.4Gi to ~42.8Gi available. Q2_K_XL's 17Gi
-  # spill fits that with room left for the node.
-  #
-  # REAP-256 fits VRAM outright but prunes half the 512 routed experts by a
-  # community process with NO published evals -- an unmeasured quality risk
-  # stacked on top of Q3 quantization, which is the wrong basis for a
-  # quality evaluation. Q2_K_XL is the cheapest tier with a published number.
-  #
-  # Spill cost is real but bounded: llama.cpp#27861 measured this exact model
-  # (UD-Q4_K_XL, 28 expert layers host-pinned, 2x3090, one populated RAM
-  # channel per socket) at 18.4 tok/s decode, 24.2 with their GPU LRU cache.
-  # Roughly half of this box's current 31.8-33.9 tok/s, not an order of magnitude.
-  #
-  # The PLE tensor is a constant 26.82Gi in every unsloth tier -- they keep it
-  # at IQ4_NL regardless of the quant name, so a lower quant does not shrink it.
-  #
-  # Unsloth's one hard caveat for this architecture is that the PLE/n-gram
-  # layers must stay at 4-bit or better -- their random access pattern makes
-  # aggressive quantization disproportionately damaging. Verified directly
-  # against this artifact's GGUF header rather than assumed: the Q2_K_XL name
-  # refers to the expert tiers only, and per_layer_token_embd.weight is
-  # type 20 (IQ4_NL, 4.5 bpw). It clears the floor.
-  #
-  # Revision-pinned: HF repos re-upload fixed GGUFs under the same filename, so
+  # Revision-pinned: HF re-uploads fixed GGUFs under the same filename, so
   # `main` is not immutable. Renovate bumps this via the git-refs manager.
   source: hf://unsloth/Qwen3.8-Flash-Next-GGUF@c8b5954a88c2775c546b92593eda40ea041d3176
-  # Three shards; the first is the primary passed to llama-server, which
-  # resolves the rest itself.
+  # First entry is the primary passed to llama-server; it resolves the rest.
   files:
     - UD-Q2_K_XL/Qwen3.8-Flash-Next-UD-Q2_K_XL-00001-of-00003.gguf
     - UD-Q2_K_XL/Qwen3.8-Flash-Next-UD-Q2_K_XL-00002-of-00003.gguf
@@ -71,53 +63,43 @@ metadata:
 spec:
   modelRef: qwen38-flash-next
   # b10689 = upstream rev 57291f2, the first release tag carrying qwen4exp
-  # (ggml-org/llama.cpp#27742, merged 2026-08-27). The official ROCm image
-  # builds gfx1201 in its target list, so no custom build is needed:
-  #   gfx908;gfx90a;gfx942;gfx1030;gfx1100;gfx1101;gfx1102;gfx1151;gfx1150;gfx1200;gfx1201
+  # (ggml-org/llama.cpp#27742). The official ROCm image builds gfx1201, so no
+  # custom build is needed.
   image: ghcr.io/ggml-org/llama.cpp:server-rocm-b10689
+  modelCache:
+    claimName: qwen38-flash-next-model-cache
   bindAddress: 0.0.0.0
-  # UNVALIDATED. The outgoing vLLM config serves 246944 and Hermes peaks at
-  # 112K, so anything below ~131072 is a functional regression for it, not just
-  # a tuning choice. llama.cpp splits contextSize across parallelSlots, hence
-  # slots=1 -- this is a single-GPU box with no room to divide.
-  # 131072 is chosen to clear Hermes's peak, NOT because the KV footprint has
-  # been measured: half the expert layers already spill to host RAM, and
-  # whatever QSA's cache costs at this depth comes out of the same 32Gi card.
-  # Measure at validation and reconcile with moeCPULayers before merging.
+  # llama.cpp splits contextSize across parallelSlots, so slots=1 gives the
+  # whole window to one stream. 131072 clears Hermes's 112K peak; it is NOT
+  # derived from a measured KV footprint, and competes with moeCPULayers for
+  # the same VRAM.
   contextSize: 131072
   parallelSlots: 1
   jinja: true
-  # 42.92Gi of routed experts over 48 layers is ~0.9Gi/layer. Usable VRAM is
-  # ~30Gi (32 minus Jellyfin's 2Gi reserve); subtract the 3.7Gi of
-  # always-resident tensors and leave ~4Gi for KV and compute, so ~22Gi holds
-  # roughly 24 expert layers on the card and the other 24 (~21Gi) go to host
-  # RAM -- inside the ~42.8Gi freed by parking vLLM.
-  # A starting point, not a measured optimum: lower it if VRAM has room, raise
-  # it if the server OOMs. Tune together with contextSize, which competes for
-  # the same 4Gi of KV headroom.
+  # 42.92Gi of experts over 48 layers is ~0.9Gi/layer. Usable VRAM ~30Gi (32
+  # minus Jellyfin's 2Gi reserve), less 3.7Gi always-resident and ~4Gi for KV,
+  # leaves ~22Gi -- about 24 layers on the card, 24 (~21Gi) in host RAM.
   moeCPULayers: 24
+  # A 73.5Gi mmap load with on-demand PLE row reads has a long, disk-bound
+  # cold start, and warmup would fault in exactly the pages --tensor-read-lazy
+  # exists to keep off the resident path. First request pays instead.
+  noWarmup: true
   extraArgs:
-    # The reason this model is runnable here at all. The PLE n-gram table is a
-    # single 26.82Gi tensor ([160, 320001536], 51.2B of the model's 176.9B
-    # params); llama.cpp reads its rows from disk on demand instead of keeping
-    # it resident. Upstream calls this out explicitly in the loader:
-    # "keep PLE / engrams embd tensors on disk, read them on demand".
-    #
-    # `auto` (the default) would also catch it, since it lazies any marked
-    # tensor over 4Gi -- set explicitly so the behaviour is stated, not
-    # inherited. Requires mmap, so do not combine with --load-mode none.
-    #
-    # NOTE: renamed to -lzm/--lazy-mode in llama.cpp#27969, which landed two
-    # hours after b10689 was built. Rename this when the image is next bumped.
+    # The reason this model runs here at all: the PLE n-gram table is a single
+    # 26.82Gi tensor (51.2B of the model's 176.9B params) that llama.cpp reads
+    # from disk on demand rather than keeping resident. `auto` would also catch
+    # it (>4Gi), but this deployment's whole viability rests on the behaviour,
+    # so it is pinned rather than inherited.
+    # Renamed to -lzm/--lazy-mode in llama.cpp#27969, which post-dates b10689 --
+    # rename on the next image bump.
     - "--tensor-read-lazy"
     - "on"
     - "--alias"
     - "qwen-3.8-flash-next"
     # Unsloth's thinking-mode values (unsloth.ai/docs/models/qwen3.8-next). Set
     # here for the same reason qwen35-2b does: the LiteLLM alias carries no
-    # sampling params, so without these the server defaults apply. The outgoing
-    # qwen-3.8 alias runs thinking (reasoning_effort medium), so these are the
-    # matching set -- non-thinking would be temp 0.7 / top-p 0.80 / presence 1.5.
+    # sampling params. qwen-3.8-fast overrides these per-request for its
+    # non-thinking mode; client-set params win.
     - "--temp"
     - "1.0"
     - "--top-p"
@@ -136,9 +118,31 @@ spec:
     seccompProfile:
       type: Unconfined
   resources:
-    cpu: "4"
-    # Host-side room for the ~21Gi of spilled expert layers plus the page cache
-    # the lazy PLE reads depend on -- that cache is what keeps the on-demand row
-    # gathers off the disk hot path. Fits the ~42.8Gi freed by parking vLLM,
-    # which requested 32Gi for the same reason.
+    # 3, not 4: control-1 has 11 cores and 7665m stays requested once vLLM is
+    # suspended, so 4 would not schedule. No CPU limit is set, so the 24 CPU
+    # expert layers can still burst past this -- but if decode is slower than
+    # llama.cpp#27861's 18.4 tok/s, CPU contention is the first thing to check.
+    cpu: "3"
+    # ~21Gi of spilled expert layers plus page cache for the on-demand PLE
+    # reads. Fits the 35.5Gi that frees up when vLLM is suspended.
     memory: 32Gi
+  endpoint:
+    port: 8080
+  probeOverrides:
+    # Cold start reads 73.5Gi off NVMe through mmap. The sibling vLLM config
+    # budgets ~60min for its load for the same reason; without an override the
+    # operator default kills the pod mid-load and restarts the whole read.
+    startup:
+      httpGet:
+        path: /health
+        port: 8080
+      initialDelaySeconds: 60
+      periodSeconds: 15
+      failureThreshold: 240
+    # Startup owns the load window, so this only ever sees a serving engine.
+    liveness:
+      httpGet:
+        path: /health
+        port: 8080
+      periodSeconds: 30
+      failureThreshold: 20

--- a/kubernetes/apps/ai/llmkube/models/qwen38-flash-next.yaml
+++ b/kubernetes/apps/ai/llmkube/models/qwen38-flash-next.yaml
@@ -2,7 +2,7 @@
 # Node-local NVMe, NOT the shared llmkube modelCache. That one is 8Gi of CephFS
 # sized for the ~2.1Gi of embedding models, and its own comment assumes
 # "read-once at load, so CephFS latency never touches inference" -- which is
-# exactly false here: --tensor-read-lazy reads PLE rows from this volume on
+# exactly false here: -lzm on reads PLE rows from this volume on
 # every token, so it has to be local disk. Same pattern as qwen38-27b-vllm.
 # 85Gi holds the 73.5Gi three-shard GGUF with room to re-stage on a bump.
 apiVersion: v1
@@ -23,7 +23,7 @@ metadata:
   name: qwen38-flash-next
 spec:
   # Measured from the GGUF tensor headers. RESIDENT excludes the PLE table,
-  # which stays on NVMe (see --tensor-read-lazy); "spill" is what exceeds the
+  # which stays on NVMe (see -lzm on); "spill" is what exceeds the
   # ~30Gi of usable VRAM and lands in host RAM via moeCPULayers:
   #   UD-Q2_K_XL  experts 42.92Gi + other 3.70Gi = 46.6Gi resident, ~17Gi spill
   # Parking vLLM frees 27.4Gi of host RAM (15.4Gi -> ~42.8Gi), which is what
@@ -62,20 +62,20 @@ metadata:
   name: qwen38-flash-next
 spec:
   modelRef: qwen38-flash-next
-  # b10689 = upstream rev 57291f2, the first release tag carrying qwen4exp
-  # (ggml-org/llama.cpp#27742). The official ROCm image builds gfx1201, so no
-  # custom build is needed.
+  # b10711 = upstream rev 9723942, built 2026-08-31T05:52Z. The official ROCm
+  # image builds gfx1201, so no custom build is needed.
   #
-  # BUMP BEFORE VALIDATING. b10689 is the newest container build (all backends
-  # stop there; release tags are already at b10701 and images lag 9-22 tags),
-  # but it predates llama.cpp#27837 by ~10h, and that fix matters here: the old
-  # code gated the lazy decision on `use_mmap`, which is false during the
-  # memory-fit pass (no_alloc, no mmap), so the fit pass counts the whole
-  # 26.82Gi PLE against available memory. On a 32Gi card already spilling to
-  # host RAM that plausibly refuses or silently shrinks contextSize below.
-  # The same build will carry the -lzm rename (#27969), so both changes land
-  # together -- see extraArgs.
-  image: ghcr.io/ggml-org/llama.cpp:server-rocm-b10689
+  # This tag, not the earlier b10689, because two fixes land in it (verified by
+  # `git compare 2578138...9723942`: ahead 6, behind 0):
+  #   #27837 -- the memory-fit pass now excludes the lazy PLE. The old code
+  #     gated the lazy decision on `use_mmap`, false during the fit pass
+  #     (no_alloc, no mmap), so the whole 26.82Gi PLE counted against available
+  #     memory; on a 32Gi card already spilling to host RAM that refuses or
+  #     silently shrinks contextSize.
+  #   #27969 -- `--tensor-read-lazy` renamed to `-lzm/--lazy-mode` and given a
+  #     MODE argument. The old spelling no longer parses at all, so the image
+  #     and the flag below have to move together.
+  image: ghcr.io/ggml-org/llama.cpp:server-rocm-b10711
   modelCache:
     claimName: qwen38-flash-next-model-cache
   bindAddress: 0.0.0.0
@@ -91,7 +91,7 @@ spec:
   # leaves ~22Gi -- about 24 layers on the card, 24 (~21Gi) in host RAM.
   moeCPULayers: 24
   # A 73.5Gi mmap load with on-demand PLE row reads has a long, disk-bound
-  # cold start, and warmup would fault in exactly the pages --tensor-read-lazy
+  # cold start, and warmup would fault in exactly the pages -lzm on
   # exists to keep off the resident path. First request pays instead.
   noWarmup: true
   extraArgs:
@@ -99,10 +99,9 @@ spec:
     # 26.82Gi tensor (51.2B of the model's 176.9B params) that llama.cpp reads
     # from disk on demand rather than keeping resident. `auto` would also catch
     # it (>4Gi), but this deployment's whole viability rests on the behaviour,
-    # so it is pinned rather than inherited.
-    # Renamed to -lzm/--lazy-mode in llama.cpp#27969, which post-dates b10689 --
-    # rename on the next image bump.
-    - "--tensor-read-lazy"
+    # so it is pinned rather than inherited. `on` requires mmap, which is the
+    # loader default here (no --load-mode override).
+    - "-lzm"
     - "on"
     - "--alias"
     - "qwen-3.8-flash-next"


### PR DESCRIPTION
> **DO NOT MERGE — blocked on validation.** Flash-Next has never been started on gfx1201 by anyone, here or upstream. Merging this parks production and points the alias at a model with zero measured evidence on this hardware. Every open item in "Blockers" must close first.

## What changes

| | before | after |
|---|---|---|
| engine | vLLM (ROCm nightly) | llama.cpp `server-rocm-b10711` |
| model | Qwen3.8-27B FP8 | Qwen3.8-Flash-Next **unsloth UD-Q2_K_XL** |
| params | 27B | 176.9B total / 6B active |
| context | 246944 | 131072 |
| `qwen-3.8` apiBase | `qwen38-27b-vllm:8000` | `qwen38-flash-next:8080` |

vLLM is parked with `suspend: true`, not deleted — every measured tuning value in that file (mnbt 4096, maxModelLen 246944, `blocks_per_chunk: 4`) stays valid, so reverting is a one-line change.

## Why it fits at all

The PLE n-gram table is a single `[160, 320001536]` tensor — 26.82Gi, holding 51.2B of the 176.9B params. llama.cpp's `-lzm on` (formerly `--tensor-read-lazy`) reads its rows from disk on demand instead of keeping it resident; upstream states the intent in the loader verbatim: *"keep PLE / engrams embd tensors on disk, read them on demand"*. Merged 2026-08-27 (ggml-org/llama.cpp#27742), maintained since (#27794, #27837, #27969). **#27837 is load-bearing** and is why this PR now pins `b10711`: before it, the memory-fit pass gated the lazy decision on `use_mmap` (false during the fit pass), counting the full 26.82Gi PLE against available memory and shrinking or refusing `contextSize` on a 32Gi card.

Unsloth's published table (75GB at 1-bit, 96GB recommended) assumes a **resident** PLE. That assumption is what this lifts.

## Quant choice

The budget is **VRAM+RAM, not VRAM alone** — parking vLLM releases 27.4Gi, taking control-1 from 15.4Gi to ~42.8Gi available, and `moeCPULayers` spills experts there. Resident footprints measured from the GGUF tensor headers, PLE excluded:

Accuracy columns are unsloth's own per-quant table for **this model** ([unsloth.ai/docs/models/qwen3.8-next](https://unsloth.ai/docs/models/qwen3.8-next)), not carried over from the 27B. Artifact sizes are the HF tree totals; resident is artifact minus the 26.8Gi PLE.

| GGUF | artifact | resident | spill to RAM | top-1 % | mean KLD |
|---|---:|---:|---:|---:|---:|
| REAP-256 UD-Q3_K_XL | — | 30.9Gi | ~1Gi | **none** | — |
| unsloth UD-IQ1_S | 67.6Gi | 40.8Gi | ~11Gi | 77.33 | 0.396 |
| unsloth UD-IQ1_M | 69.4Gi | 42.6Gi | ~13Gi | 79.69 | 0.315 |
| **unsloth UD-Q2_K_XL** | **73.5Gi** | **46.6Gi** | **~17Gi** | **82.72** | **0.225** |
| unsloth UD-IQ3_XXS | 76.3Gi | 49.5Gi | ~20Gi | 85.41 | 0.165 |
| unsloth UD-Q3_K_XL | 83.8Gi | 57.0Gi | ~27Gi | 88.32 | 0.107 |
| unsloth UD-IQ4_XS | 87.2Gi | 60.4Gi | ~30Gi | 89.55 | 0.084 |

Two corrections to an earlier revision of this table. The 79.7% previously shown against `UD-IQ1_S` is **`UD-IQ1_M`'s** number; `IQ1_S` is 77.33. And `UD-IQ1_M` and `UD-IQ4_XS` were missing entirely.

An earlier revision of this PR used REAP-256, sized against VRAM alone. That was wrong twice over: the budget is larger than VRAM, and REAP prunes half the 512 routed experts by a community process with **no published evals** — an unmeasured quality risk stacked on Q3 quantization, which is the wrong basis for a quality evaluation.

**Why Q2_K_XL and not higher: disk, not quality.** The PVC is 85Gi and control-1's kv-offload guard floors free space at 160Gi. `UD-Q3_K_XL` (83.8Gi) would push below that floor, and `UD-IQ4_XS` (87.2Gi) does not fit the PVC at all. `UD-IQ3_XXS` fits but cuts the disk margin from 5.4Gi to ~2.6Gi for +2.7 top-1 points. Q2_K_XL is the best accuracy that clears both limits with margin.

**Why not lower:** `UD-IQ1_M` is the escape hatch if decode is too slow — 4.1Gi less artifact and ~4Gi less spill for −3.0 top-1 points. Worth testing only if the HIP decode cliff below turns out to bite, since spill volume is what decode pays for.

Spill cost is real but bounded. llama.cpp#27861 measured **this exact model** (UD-Q4_K_XL, 28 expert layers host-pinned, 2×3090, one populated RAM channel per socket) at **18.4 tok/s decode**, 24.2 with their GPU LRU cache — against this box's current 31.8-33.9.

Unsloth's one hard caveat is that PLE/n-gram layers stay ≥4-bit. Verified against the artifact, not assumed: `Q2_K_XL` names the expert tiers only, and `per_layer_token_embd.weight` is type 20 (IQ4_NL, 4.5 bpw). Clears it.

The official ROCm image already builds gfx1201, so no custom build.

## Blockers

- [ ] **Never run on RDNA4.** No gfx1201 report exists upstream for this arch.
- [ ] **HIP decode cliff.** ggml-org/llama.cpp#27856: on gfx1151, decode collapses 19-21 → 5.5-6.1 tok/s past ~1K context (3.5-4×). CUDA degrades only mildly on the same quant, so it reads as HIP-path. Partly addressed since: **#27466 (ROCm radix TOP_K) merged 2026-08-31T13:00Z**, seven hours *after* b10711 was built, so this image does not carry it; #28032 is the Vulkan equivalent and does not apply. #27977, #27992, #28023 remain open. If RDNA4 shares the cliff, the switch is a large regression.
- [ ] **`contextSize: 131072` is a guess.** Chosen to clear Hermes's 112K peak, not derived from a measured KV footprint. Reconcile with `moeCPULayers` at validation.
- [ ] **`moeCPULayers: 24` is arithmetic, not measurement** — 42.92Gi of experts over 48 layers, ~22Gi of VRAM for experts. Tune against real headroom.
- [ ] **Requires a GPU slot.** control-1 advertises 4 `squat.ai/dri` and all 4 are held; this cannot schedule until vLLM releases one, and 32Gi could not hold both regardless.
- [ ] **Disk margin is thin.** The 73.5Gi artifact takes control-1 from 238.9Gi to ~165.4Gi free, against the kv-offload guard's 160Gi floor — **5.4Gi of margin**. Fine while vLLM is parked (the KV tier stops growing), tight if both are staged at once.
- [x] **Flag rename.** Closed by the b10711 bump: `--tensor-read-lazy` became `-lzm/--lazy-mode` (with a `MODE` argument) in #27969, and the old spelling no longer parses. Image and flag moved together.

## Validation plan

Baseline for the current model is captured: `bench/perf` at 31.8-33.9 tok/s decode, 173-273 ms TTFT shallow, 6.75-6.82 s TTFT at 48.6K. Flash-Next runs the same suite before this merges.

## Not done here

vLLM and SGLang both gained real PLE offload in the last week — SGLang's `io_uring` NVMe path (#36567) is the best implementation anywhere. Neither is usable here.

vLLM re-checked against its own published recipe ([recipes.vllm.ai/Qwen/Qwen3.8-Flash-Next](https://recipes.vllm.ai/Qwen/Qwen3.8-Flash-Next)), because it does support this model and the earlier one-line dismissal understated why that does not help:

| recipe says | here |
|---|---|
| smallest checkpoint is **FP8, 172.78 GiB** — no sub-8-bit quant published | 32Gi card |
| **TP2 minimum** (GB300, ~86 GiB/GPU); TP4 recommended, TEP8 on H200 | 1 GPU; pipeline parallel unsupported |
| AMD target is **4x MI355X** (CDNA4/gfx950), `VLLM_ROCM_USE_AITER=1` | RDNA4/gfx1201 — not mentioned anywhere in the recipe |
| `VLLM_PLE_CPU_OFFLOAD=1` moves the 51B n-gram table to **host RAM**, needs ≥51 GB there | ~42.8Gi host RAM free with vLLM parked |
| MoE expert offload to host RAM or disk: **not offered** | the entire reason this fits on llama.cpp |

Even granting the PLE offload, ~47.5 GiB of the 172.78 GiB checkpoint is the n-gram table, leaving **~125 GiB that must stay resident across GPUs** — four times the card, before KV. The gap is not the PLE, which vLLM does handle; it is that llama.cpp will also push MoE expert layers to host RAM (`moeCPULayers`) and vLLM will not. No single-GPU or consumer configuration is published, and the recipe requires a dedicated `vllm/vllm-openai:qwen38-flash-next` image on vLLM 0.29.0+.

The earlier "78Gi backbone" figure in this PR was wrong; ~125 GiB is the number from the recipe's own checkpoint size.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for serving the Qwen3.8-Flash-Next model with optimized GPU and local cache configuration.
  * Updated model routing to use the new Flash-Next backend.
  * Adjusted input limits to match the new model’s context window.

* **Bug Fixes**
  * Updated availability monitoring to alert on the active Flash-Next deployment.

* **Operations**
  * Suspended the previous Qwen3.8 backend to prevent resource contention while preserving its configuration for easy restoration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
