### PR TITLE
fix(rook-ceph): drop the retained gen-3 aes csi keys

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -57,9 +57,8 @@ spec:
             # aes256k needs ceph-csi >= v3.17.1 (librados 20.2.4); v3.17.0's 20.2.1 fails
             # provisioning with `rados: ret=-22`. Pin is in ../app/helmrelease.yaml.
             keyType: aes256k
-            # The retained gen-3 keys are the cluster's last aes keys and the only cause of
-            # AUTH_INSECURE_CLIENT_KEY_TYPE. 0 drops them, and the rollback they offered.
-            keepPriorKeyCountMax: 0
+            # keepPriorKeyCountMax unset is 0: no prior key retained. The gen-3 keys it used
+            # to hold were the cluster's last aes keys, and the only AUTH_INSECURE_CLIENT_KEY_TYPE cause.
           rbdMirrorPeer: *cephxKey
       cephConfig:
         global:

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -45,8 +45,6 @@ spec:
       # in-kernel client from Linux 7.0. keyType does nothing unless keyRotationPolicy is set.
       security:
         cephx:
-          # allowedCiphers ["aes256k"] is the follow-up, safe only once Rook has purged the
-          # retained gen-3 csi keys below.
           daemon: &cephxKey
             keyRotationPolicy: KeyGeneration
             keyGeneration: 2
@@ -57,8 +55,6 @@ spec:
             # aes256k needs ceph-csi >= v3.17.1 (librados 20.2.4); v3.17.0's 20.2.1 fails
             # provisioning with `rados: ret=-22`. Pin is in ../app/helmrelease.yaml.
             keyType: aes256k
-            # keepPriorKeyCountMax unset is 0: no prior key retained. The gen-3 keys it used
-            # to hold were the cluster's last aes keys, and the only AUTH_INSECURE_CLIENT_KEY_TYPE cause.
           rbdMirrorPeer: *cephxKey
       cephConfig:
         global:

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -56,9 +56,9 @@ spec:
             # aes256k needs ceph-csi >= v3.17.1 (librados 20.2.4); v3.17.0's 20.2.1 fails
             # provisioning with `rados: ret=-22`. Pin is in ../app/helmrelease.yaml.
             keyType: aes256k
-            # Keeps the prior-gen key as rollback. Those retained gen-3 keys are aes, so
-            # AUTH_INSECURE_CLIENT_KEY_TYPE stays until this drops back to 0.
-            keepPriorKeyCountMax: 1
+            # Gen-4 aes256k has been serving CSI since 2026-08-26; the gen-3 aes rollback
+            # keys are what kept AUTH_INSECURE_CLIENT_KEY_TYPE up, so drop them.
+            keepPriorKeyCountMax: 0
           rbdMirrorPeer: *cephxKey
       cephConfig:
         global:

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -52,8 +52,6 @@ spec:
           csi:
             keyRotationPolicy: KeyGeneration
             keyGeneration: 4
-            # aes256k needs ceph-csi >= v3.17.1 (librados 20.2.4); v3.17.0's 20.2.1 fails
-            # provisioning with `rados: ret=-22`. Pin is in ../app/helmrelease.yaml.
             keyType: aes256k
           rbdMirrorPeer: *cephxKey
       cephConfig:

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -45,7 +45,8 @@ spec:
       # in-kernel client from Linux 7.0. keyType does nothing unless keyRotationPolicy is set.
       security:
         cephx:
-          # allowedCiphers ["aes256k"] omitted while the retained gen-3 csi keys are still aes.
+          # allowedCiphers ["aes256k"] is the follow-up, safe only once Rook has purged the
+          # retained gen-3 csi keys below.
           daemon: &cephxKey
             keyRotationPolicy: KeyGeneration
             keyGeneration: 2
@@ -56,8 +57,8 @@ spec:
             # aes256k needs ceph-csi >= v3.17.1 (librados 20.2.4); v3.17.0's 20.2.1 fails
             # provisioning with `rados: ret=-22`. Pin is in ../app/helmrelease.yaml.
             keyType: aes256k
-            # Gen-4 aes256k has been serving CSI since 2026-08-26; the gen-3 aes rollback
-            # keys are what kept AUTH_INSECURE_CLIENT_KEY_TYPE up, so drop them.
+            # The retained gen-3 keys are the cluster's last aes keys and the only cause of
+            # AUTH_INSECURE_CLIENT_KEY_TYPE. 0 drops them, and the rollback they offered.
             keepPriorKeyCountMax: 0
           rbdMirrorPeer: *cephxKey
       cephConfig:


### PR DESCRIPTION
`security.cephx.csi.keepPriorKeyCountMax: 1 -> 0`. Clears `AUTH_INSECURE_CLIENT_KEY_TYPE`.

The four retained gen-3 `client.csi-*` keys are the only `aes`-cipher cephx keys left in the cluster; every other entity is already `aes256k`:

| entity | cipher |
|---|---|
| `client.csi-{rbd,cephfs}-{node,provisioner}.3` | aes (retained rollback) |
| `client.csi-{rbd,cephfs}-{node,provisioner}.4` | aes256k |
| mon., mgr.{a,b}, osd.{0,1,3}, mds.ceph-filesystem-{a,b} | aes256k |
| client.admin, client.crash, client.ceph-exporter, client.rbd-mirror-peer | aes256k |

Gen-4 has served all four CSI entities for 3d23h on ceph-csi v3.17.1 (librados 20.2.4) with no `ProvisioningFailed` events, so the librados-version blocker behind the 2026-08-21 outage is cleared and the rollback keys have no remaining job.

Follow-ups, deliberately not bundled because both are only safe once Rook has actually purged the gen-3 keys:
- `allowedCiphers: ["aes256k"]` -> clears `AUTH_INSECURE_KEYS_ALLOWED` + `AUTH_INSECURE_KEYS_CREATABLE`
- removing `keyType` from the `daemon` anchor -> clears `AUTH_EMERGENCY_CIPHERS_SET`; Rook hardcodes `--mon-auth-emergency-allowed-ciphers=aes,aes256k` whenever `daemon.keyType` is set at all (`pkg/operator/ceph/cluster/mon/spec.go:403-410`), so the field has to go. Rolls the mons.