### PR TITLE
fix(rook-ceph): restrict cephx to aes256k and drop the mon emergency ciphers

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -45,10 +45,12 @@ spec:
       # in-kernel client from Linux 7.0. keyType does nothing unless keyRotationPolicy is set.
       security:
         cephx:
+          allowedCiphers: ["aes256k"]
+          # daemon.keyType omitted: Rook already defaults to aes256k, and any value set here makes
+          # it pass --mon-auth-emergency-allowed-ciphers to the mons.
           daemon: &cephxKey
             keyRotationPolicy: KeyGeneration
             keyGeneration: 2
-            keyType: aes256k
           csi:
             keyRotationPolicy: KeyGeneration
             keyGeneration: 4


### PR DESCRIPTION
Clears the last three `AUTH_*` HEALTH_WARNs. Follow-up to #4765, which removed the final aes keys from the cluster.

| change | clears |
|---|---|
| `allowedCiphers: ["aes256k"]` | `AUTH_INSECURE_KEYS_ALLOWED`, `AUTH_INSECURE_KEYS_CREATABLE` |
| drop `daemon.keyType` | `AUTH_EMERGENCY_CIPHERS_SET` |

`allowedCiphers` is safe now and was not before: `ceph auth ls` returns zero aes-cipher keys post-#4765, so nothing can be locked out. Rook applies it as `ceph mon set auth_allowed_ciphers aes256k` (`pkg/operator/ceph/cluster/cephx.go:105-117`).

Dropping `daemon.keyType` is a no-op on cipher selection: `setDefaultCephxKeyType` and `setRotatingServiceKeyType` fall back to `PreferredCephxKeyType()`, which is the last of `KnownCephxKeyTypes` = `aes256k`, so `auth_preferred_cipher` and `auth_service_cipher` are unchanged. The field was always redundant with Rook's default. It has to go because `pkg/operator/ceph/cluster/mon/spec.go:403-410` appends `--mon-auth-emergency-allowed-ciphers=aes,aes256k` whenever `daemon.KeyType != ""`, with no way to narrow the list.

`csi.keyType: aes256k` stays: the chart's own values default it to `aes` (values.yaml:158).

No key rotation is triggered - `keyGeneration` is unchanged at 2 and the resolved cipher is identical. Runtime effect is a rolling mon restart.