### PR TITLE
chore(ci): tidy the Talos kernel workflow

### DIFF
--- a/.github/workflows/talos-kernel.yaml
+++ b/.github/workflows/talos-kernel.yaml
@@ -28,7 +28,9 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
-    # ~2h45m measured shape
+    # GitHub's hosted-job ceiling (360m) less headroom, not an estimate of the build: it is "let
+    # it run" in the only unit Actions offers. Measured runs are 87-112m, so this does not move
+    # when the build gets slower.
     timeout-minutes: 340
     permissions:
       contents: read
@@ -60,22 +62,22 @@ jobs:
       #
       # On /, not /mnt: the step above hands /mnt's ~66 GB to Docker, which needs ~35-40 GB of
       # it, so a swapfile there would re-create the ENOSPC that move exists to avoid. Moving
-      # the data-root leaves / idle with 87 GB free (measured), so take the swap from there.
-      # Sized from what is actually free, keeping 5 GB back, rather than assuming a figure.
+      # the data-root leaves / idle with ~85 GB free (measured), so take the swap from there.
       - name: Add swap for the ThinLTO link
         run: |
           free -h
-          # -B1, not -BG: df's GiB output rounds UP, so e.g. 12.1G free reports as 13G and an
-          # 8G swapfile would leave only 4.1G, not the intended 5G margin. Floor from bytes.
+          # A flat 32G, which is 3x the shortfall seen; more just costs fallocate time. This used
+          # to size itself from free space, but with 85G free the cap pinned it to 32 on every
+          # run -- adaptive sizing a hard cap makes unreachable is decoration, not adaptivity.
+          # The precondition is the part worth keeping: it names the failure if GitHub ever
+          # shrinks the runner image, instead of letting fallocate ENOSPC on its own.
+          # -B1, not -BG: df's GiB output rounds UP, so 36.2G free would report as 37G and pass.
           free_g="$(( $(df -B1 --output=avail / | tail -1 | tr -dc '0-9') / 1073741824 ))"
-          swap_g=$(( free_g - 5 ))
-          # 32G caps it at 3x the shortfall seen; more just costs fallocate time on a bigger runner.
-          [[ "${swap_g}" -le 32 ]] || swap_g=32
-          [[ "${swap_g}" -ge 8 ]] || { echo "only ${free_g}G free on /, refusing to size swap" >&2; exit 1; }
-          echo "allocating ${swap_g}G swap of ${free_g}G free"
+          [[ "${free_g}" -ge 37 ]] || { echo "only ${free_g}G free on /, need 37G for a 32G swapfile" >&2; exit 1; }
+          echo "allocating 32G swap of ${free_g}G free"
           # Not /swapfile: the runner already has one there, active, and fallocate on a swapped-on
           # file fails with ETXTBSY. This is added alongside it rather than replacing it.
-          sudo fallocate -l "${swap_g}G" /swapfile-thinlto
+          sudo fallocate -l 32G /swapfile-thinlto
           sudo chmod 600 /swapfile-thinlto
           sudo mkswap /swapfile-thinlto
           sudo swapon /swapfile-thinlto

--- a/.github/workflows/talos-kernel.yaml
+++ b/.github/workflows/talos-kernel.yaml
@@ -6,9 +6,7 @@ on:
     branches: ["main"]
     paths:
       - docker/talos-kernel/**
-      # Negated rather than listing the build inputs, so a file added there still triggers a
-      # build; only the docs are known not to be one. Editing the README cost an 11m run
-      # (33327983434) that rebuilt nothing.
+      # Not a build input; editing it cost an 11m no-op run (33327983434).
       - "!docker/talos-kernel/README.md"
       - scripts/talos-kernel-build.sh
       - talos/schematic.yaml
@@ -28,9 +26,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
-    # GitHub's hosted-job ceiling (360m) less headroom, not an estimate of the build: it is "let
-    # it run" in the only unit Actions offers. Measured runs are 87-112m, so this does not move
-    # when the build gets slower.
+    # GitHub's 360m hosted ceiling less headroom, not a build estimate; runs are 87-112m.
     timeout-minutes: 340
     permissions:
       contents: read
@@ -57,8 +53,8 @@ jobs:
       # thread, each holding gigabytes -- peak link memory blows past the runner's 16 GB and
       # the runner process is killed ("lost communication with the server") ~43m in, after the
       # far lighter compile phase has already succeeded. Swap rather than fewer backends: the
-      # kernel that comes out is identical, and the compile phase that dominates the ~2h45m
-      # keeps every core.
+      # kernel that comes out is identical, and the compile phase that dominates the run keeps
+      # every core.
       #
       # On /, not /mnt: the step above hands /mnt's ~66 GB to Docker, which needs ~35-40 GB of
       # it, so a swapfile there would re-create the ENOSPC that move exists to avoid. Moving
@@ -66,11 +62,7 @@ jobs:
       - name: Add swap for the ThinLTO link
         run: |
           free -h
-          # A flat 32G, which is 3x the shortfall seen; more just costs fallocate time. This used
-          # to size itself from free space, but with 85G free the cap pinned it to 32 on every
-          # run -- adaptive sizing a hard cap makes unreachable is decoration, not adaptivity.
-          # The precondition is the part worth keeping: it names the failure if GitHub ever
-          # shrinks the runner image, instead of letting fallocate ENOSPC on its own.
+          # 32G is 3x the shortfall seen. Sizing from free space always hit this cap anyway.
           # -B1, not -BG: df's GiB output rounds UP, so 36.2G free would report as 37G and pass.
           free_g="$(( $(df -B1 --output=avail / | tail -1 | tr -dc '0-9') / 1073741824 ))"
           [[ "${free_g}" -ge 37 ]] || { echo "only ${free_g}G free on /, need 37G for a 32G swapfile" >&2; exit 1; }

--- a/.github/workflows/talos-kernel.yaml
+++ b/.github/workflows/talos-kernel.yaml
@@ -6,6 +6,10 @@ on:
     branches: ["main"]
     paths:
       - docker/talos-kernel/**
+      # Negated rather than listing the build inputs, so a file added there still triggers a
+      # build; only the docs are known not to be one. Editing the README cost an 11m run
+      # (33327983434) that rebuilt nothing.
+      - "!docker/talos-kernel/README.md"
       - scripts/talos-kernel-build.sh
       - talos/schematic.yaml
       - talos/nodes/**/*.schematic.yaml


### PR DESCRIPTION
Three small things in `talos-kernel.yaml`, all found by measuring rather than reading.

**1. Don't rebuild on a README edit.** `docker/talos-kernel/**` matches `README.md`, so merging #4762 — README and workflow only — cost an 11m run ([33327983434](https://github.com/Tanguille/cluster/actions/runs/33327983434)) that produced no artifact. Negated rather than listing the build inputs, so a file added there later still triggers a build.

**2. The swap step never did what its comment claimed.** It said it sized itself from free space "rather than assuming a figure". Run 33327983434 logged `allocating 32G swap of 85G free` — `free_g - 5` is 80 and the cap pins it to 32, every run. Now a flat 32G, with the floor kept as an explicit precondition: that is the part earning its keep, naming the failure if GitHub shrinks the runner image instead of letting `fallocate` ENOSPC.

**3. `timeout-minutes: 340` is not a duration estimate.** The comment said `~2h45m measured shape`; no run has exceeded 112m. 340 is GitHub's 360m hosted ceiling less headroom, which does not move when the build gets slower.

### Considered and skipped

**Adding `.justfile` / `talos/mod.just` / `.mise.toml` to `paths`.** They are real build inputs and `talos-render.yaml` already lists `.justfile`, so the two workflows disagree. But `.justfile` is edited often and each edit would fire an 11m kernel build — more waste than the case it guards, which the dispatch-before-merge process already covers.

**Dropping the `push:` trigger in favour of a PR check.** The argument was that a push build cannot close the window between merge and publish. It does close it, ~90m late — nothing consumes `pinned` automatically, only a manual `apply-node` — so push is a self-healing backstop, not a no-op. The PR-check alternative was tried and closed in #4763.

**`mode=max` on the buildx cache.** Would export the ~17.7 GB kernel layer every run to buy back the alpine `apk` step. Measured runs: 11m on a cache hit, 87m for a kernel bump, 112m for a Talos bump.

**A larger or self-hosted runner** (would delete both prep steps outright). Self-hosted is wrong permanently — the ARC runners are `maxRunners: 2` with a 25Gi work volume and 1Gi memory limit against a build needing ~35-40 GB and >16 GB at the link, and the candidate nodes run etcd, Ceph OSDs and vLLM. A GitHub larger runner is a real option, but it is money versus ~30 lines that have not needed to change.