### PR TITLE
chore(renovate): stop flagging shellcheck as abandoned

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -213,6 +213,13 @@
       matchPackageNames: ["/feramance\\/qbitrr/"],
       extractVersion: "^v(?<version>.*)$"
     },
+    {
+      // Last release 2025-08-04, past `abandonments:recommended`, but still used by pre-commit.
+      // matchPackageNames misses: the mise preset rewrites packageName to koalaman/shellcheck.
+      description: "shellcheck releases rarely; not abandoned",
+      matchDepNames: ["aqua:koalaman/shellcheck"],
+      abandonmentThreshold: null
+    },
     // Versioning overrides
     {
       description: "Mixed-segment tags (p2pool v4.15/v4.15.1, hermes v2026.5.29/v2026.5.29.2); docker versioning skips patch bumps",


### PR DESCRIPTION
`abandonments:recommended` flags `aqua:koalaman/shellcheck` (last release 2025-08-04) on the dependency dashboard. It is mature and still run by the pre-commit hook, so the flag is release-cadence noise.

| | |
|---|---|
| Rule | `abandonmentThreshold: null` scoped to the dep |
| Match key | `matchDepNames` — `matchPackageNames` misses because the mise preset rewrites packageName to `koalaman/shellcheck` |
| Verified | local `platform=local` run: `isAbandoned: true` → absent |
| Validator | `renovate-config-validator` passes |

https://claude.ai/code/session_01Quda7fqJyXz3noToVVjX6U