### PR TITLE
fix(kernel)!: revert to 7.1.10 and hold, 7.2 breaks Cilium

### DIFF
--- a/docker/talos-kernel/Dockerfile
+++ b/docker/talos-kernel/Dockerfile
@@ -13,7 +13,7 @@
 # `ARG KERNEL_VERSION`. Two declarations with only one default silently produced an SPDX
 # document with an empty version and an unmatchable CPE on any build not passing --build-arg.
 # renovate: datasource=custom.linux-kernel depName=linux
-ARG KERNEL_VERSION=7.2.2
+ARG KERNEL_VERSION=7.1.10
 
 # Passed by scripts/talos-kernel-build.sh, read out of the Talos release's own Makefile. No
 # default on purpose: a stale one would silently build against the wrong toolchain.

--- a/docker/talos-kernel/README.md
+++ b/docker/talos-kernel/README.md
@@ -181,18 +181,19 @@ kernel.org:  647F 2865 4894 E3BD 4571  99BE 38DB BDC8 6092 693E
 
 Re-check it with `gpg --show-keys --with-fingerprint` if the key is ever replaced. Then rebuild and read the log:
 
-| surface                                 | measured, 6.18.44 -> 7.1.9                 |
-|-----------------------------------------|--------------------------------------------|
-| `olddefconfig` delta                    | +206 / -149                                |
-| `hack/modules-amd64.txt` reconciliation | 3 entries (1.13) / 3 + 1 dependency (1.14) |
+| surface                                 | 6.18.44 -> 7.1.9                           | 7.1.10 -> 7.2.2         |
+|-----------------------------------------|--------------------------------------------|-------------------------|
+| `olddefconfig` delta                    | +206 / -149                                | +241 / -164             |
+| `hack/modules-amd64.txt` reconciliation | 3 entries (1.13) / 3 + 1 dependency (1.14) | 5 entries + 3 (1.14)    |
 
 The delta is not cosmetic: the 6.18.44 -> 7.1.9 one flipped `CONFIG_PREEMPT_NONE` to
 `CONFIG_PREEMPT`, changing the scheduling profile of a Ceph and etcd node without anyone
 choosing it. Read it, and pin anything load-bearing on the cmdline rather than relying on a
 compiled-in default that upstream can move.
 
-That is one measurement spanning three feature releases (6.19, 7.0, 7.1); a single-minor bump
-has not been measured yet, so treat it as an upper bound rather than a per-bump expectation.
+The two columns bracket the range: the first spans three feature releases (6.19, 7.0, 7.1), the
+second is a single minor. They are close, so the delta tracks the series handover rather than
+the number of releases crossed — a minor bump is not the cheap case.
 
 Talos **1.14 added a second gate**: `depmod --errsyms` must print nothing at all, so a listed
 module whose dependency is absent now fails the build. 7.x split `stmmac_libpci.ko` out of
@@ -206,6 +207,68 @@ fails the build on any listed module the config did not produce. The 7.1.9 recon
 was `kernel/crypto/xor.ko` -> `kernel/lib/raid/xor/xor.ko` (moved), and dropping
 `kernel/crypto/hkdf.ko` (`CONFIG_CRYPTO_HKDF` deleted upstream) and
 `kernel/drivers/watchdog/iTCO_vendor_support.ko` (removed in 7.0).
+
+### Hold: 7.2 is blocked on Cilium, do not merge the bump
+
+**A green build does not mean a bootable fleet.** 7.2.2 built, published and booted cleanly;
+the node was still lost, because the break is in userspace and the pipeline cannot see it.
+
+Cilium's feature probe passes a *pointer* to `bpf_set_retval`, which has always taken an
+integer. The kernel tolerated it until [`b1f7f67b74c2e`][k-commit] ("bpf: Add validation for
+bpf_set_retval argument") landed in **7.2-rc1**. The agent now dies at startup and never writes
+a CNI config, so the node stays `NotReady` with no network:
+
+```text
+level=fatal msg="failed to probe helper"
+  error="detect support for FnSetRetval for program type CGroupSock: load program:
+         invalid argument: 0: (85) call bpf_set_retval#187: R1 is not a scalar"
+  progType=CGroupSock helper=FnSetRetval
+```
+
+Tracked as [cilium/cilium#48016][issue]. It is a Cilium bug the kernel exposed, not a kernel
+regression, and it is **not** version-specific to our 1.20: upstream reports 1.18, 1.19, 1.20
+and 1.21.0-pre.0 all failing on 7.2 while the same builds run fine on 7.1.
+
+The fix is [`67c619c`][fix] (probe via `bpf_core_enum_value_exists()` instead of emitting the
+call). Measured on 2026-08-30: present on the `v1.20` branch as `b73ca6e8d` (2026-08-28), absent
+from `v1.19` and `v1.18`, and in **no release** — 1.20.1 shipped 2026-08-18, ten days before the
+backport. Re-check with:
+
+```sh
+gh api "repos/cilium/cilium/commits?sha=v1.20&per_page=100" \
+    -q '[.[] | select(.commit.message | test("HAVE_SET_RETVAL"))] | length'
+gh release list --repo cilium/cilium --limit 5
+```
+
+**Lift the hold when a Cilium release containing that commit is deployed here** — 1.20.2 or
+later. Until then `ARG KERNEL_VERSION` stays on 7.1.y and Renovate's 7.2.x PR stays open and
+unmerged; the open PR is the reminder. It is deliberately not pinned via `allowedVersions`:
+combined with the `iseol=false` filter in `.renovaterc.json5`, a `<7.2` bound empties the feed
+once 7.1 leaves `moniker=stable`, and bumps then stop **silently** — which is worse than a PR
+someone has to decline. The cost of the hold is that 7.1.y patch bumps stop too, since Renovate
+only ever offers the highest stable.
+
+[k-commit]: https://github.com/torvalds/linux/commit/b1f7f67b74c2e
+[issue]: https://github.com/cilium/cilium/issues/48016
+[fix]: https://github.com/cilium/cilium/commit/67c619cb0a43c7178bf843c9281fc77fe64fe13f
+
+### Rolling a bump back
+
+Reverting the *running* kernel is one command, but it leaves the node's **stored config** still
+naming the new installer and carrying the new `tuppr.home-operations.com/version` annotation.
+tuppr reads that annotation: a node running 7.1.10 while annotated 7.2.2 is a node tuppr may
+upgrade straight back into the break. Re-apply the config from the pre-bump tree as well:
+
+```sh
+talosctl -n <ip> upgrade -i ghcr.io/tanguille/installer/<schematic>:<old-version> \
+    -m powercycle --timeout=15m
+git checkout <bump-commit>~1        # renders the old pinned
+just --yes talos apply-node <node> <ip>
+kubectl get nodes \
+    -o custom-columns=NAME:.metadata.name,TUPPR:'.metadata.annotations.tuppr\.home-operations\.com/version'
+```
+
+The last command is the check that matters — all nodes must report the same version.
 
 ## What is deliberately not carried
 
@@ -250,6 +313,16 @@ talosctl -n <ip> upgrade --image ghcr.io/tanguille/installer/<node>:<version> \
 
 Do one node at a time and confirm `etcd` rejoins between each — the fleet is three
 control-plane nodes and etcd tolerates exactly one down.
+
+`etcd` is not a sufficient check. Every Talos service can report `Running/OK` on a node that
+has no working network: the first node on 7.2.2 did exactly that, with `cilium` in
+`CrashLoopBackOff` and `Ready=False / cni plugin not initialized`. Wait for the node to reach
+`Ready` and confirm its agent pod is up before touching the next one:
+
+```sh
+kubectl get node <node>
+kubectl -n kube-system get pods -o wide | grep "cilium.*<node>"
+```
 
 ### The rollout is not self-closing
 


### PR DESCRIPTION
Reverts #4733. Kernel 7.2 makes every current Cilium release fatal at startup, so the fleet stays on 7.1.y.

## Evidence

control-2 was upgraded to `v1.14.0-rc.2-k7.2.2` on 2026-08-30 and lost its network. Rolled back the same evening; cluster is `HEALTH_OK`, all three nodes `Ready`, tuppr annotations consistent.

```
level=fatal msg="failed to probe helper"
  error="detect support for FnSetRetval for program type CGroupSock: load program:
         invalid argument: 0: (85) call bpf_set_retval#187: R1 is not a scalar"
```

| | |
|---|---|
| cause | kernel `b1f7f67b74c2e` (bpf_set_retval arg validation) landed 7.2-rc1 |
| verdict | Cilium bug exposed by the kernel, not a kernel regression |
| upstream | cilium/cilium#48016 (open) |
| scope | 1.18, 1.19, 1.20, 1.21.0-pre.0 all fail on 7.2; same builds fine on 7.1 |

Fix is `67c619c`, measured 2026-08-30:

| branch | fix present |
|---|---|
| `v1.20` | yes (`b73ca6e8d`, 08-28) |
| `v1.19` | no |
| `v1.18` | no |
| any release | no (1.20.1 shipped 08-18) |

Lift the hold when Cilium >= 1.20.2 is deployed.

## Also

- 7.1.10 -> 7.2.2 build measurements added: `olddefconfig` +241/-164, 5 module entries + 3 deps. Retires the doc's claim that a single-minor bump was unmeasured and that the old numbers were an upper bound; the single-minor delta is larger.
- Rollback procedure documented: reverting the running kernel leaves the stored config and tuppr annotation naming the broken installer.
- Rollout section: `etcd` alone is not a sufficient gate. Every Talos service read `Running/OK` on the broken node.

No Renovate `allowedVersions` pin: with the `iseol=false` filter a `<7.2` bound empties the feed once 7.1 leaves `moniker=stable` and bumps stop silently. The re-opened 7.2.x PR is the reminder instead.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Updated the default Talos-compatible kernel version to 7.1.10.
  * Documented the current hold on upgrading to the 7.2 kernel series due to networking compatibility.
  * Added guidance for safely reverting a kernel update and restoring the corresponding configuration.
  * Improved rollout checks to verify node readiness and networking health, rather than relying only on service status.
* **Documentation**
  * Updated kernel comparison data and clarified how release deltas are measured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->