### PR TITLE
feat(ai): soak-test ROCM_AITER_UNIFIED_ATTN on qwen38-27b-vllm

### DIFF
--- a/kubernetes/apps/ai/llmkube/models/kustomization.yaml
+++ b/kubernetes/apps/ai/llmkube/models/kustomization.yaml
@@ -8,3 +8,15 @@ resources:
   - qwen3-embedding.yaml
   - qwen35-2b.yaml
   - vmcp-embedding.yaml
+# Out-of-tree vLLM patch mounted into qwen38-27b-vllm; rationale in the .py.
+# Hash suffix disabled because the consumer is an InferenceService (a CRD), and
+# kustomize only rewrites generated names inside built-in types -- a hashed name
+# would leave the CR pointing at a ConfigMap that does not exist. Consequence:
+# editing the .py does NOT roll the pod on its own, so restart it deliberately.
+configMapGenerator:
+  - name: aiter-kvconn-patch
+    files:
+      - zz_aiter_kvconn.pth=./resources/zz_aiter_kvconn.pth
+      - zz_aiter_kvconn_impl.py=./resources/zz_aiter_kvconn_impl.py
+generatorOptions:
+  disableNameSuffixHash: true

--- a/kubernetes/apps/ai/llmkube/models/qwen38-27b-vllm.yaml
+++ b/kubernetes/apps/ai/llmkube/models/qwen38-27b-vllm.yaml
@@ -279,6 +279,10 @@ spec:
       emptyDir:
         medium: Memory
         sizeLimit: 24Gi
+    # SOAK TEST -- see the mounts below and models/resources/zz_aiter_kvconn_impl.py.
+    - name: aiter-kvconn-patch
+      configMap:
+        name: aiter-kvconn-patch
   extraVolumeMounts:
     - name: compile-cache
       mountPath: /cache
@@ -286,6 +290,34 @@ spec:
       mountPath: /kvoffload
     - name: dshm
       mountPath: /dev/shm
+    # SOAK TEST 2026-09-01, time-boxed -- remove or promote after evaluation.
+    #
+    # Selects ROCM_AITER_UNIFIED_ATTN instead of TRITON_ATTN by lifting an
+    # inherited `supports_kv_connector() -> False` that appears to be a missing
+    # override rather than a real exclusion (full argument in the .py).
+    #
+    # Bench says PARITY, not a win: decode conc-16 77.27 vs 77.63 tok/s, engine
+    # prefill 6388.5 vs 6390. It is deployed anyway to get real-traffic hours,
+    # because the published gains (vllm#43615: +56.5% at 512 tok, +72.4% on
+    # 1K-2K) live at short contexts that the synthetic sweeps did not cover,
+    # and production traffic does include them.
+    #
+    # An earlier run measured 1.89 tok/s decode and looked catastrophic. That was
+    # vllm#53821 (AITER's query_start_loc zeroed during graph capture), fixed in
+    # this image. Do NOT reintroduce that number as evidence.
+    #
+    # Verify it actually took effect -- the hook fails open to TRITON_ATTN:
+    #   kubectl logs deploy/qwen38-27b-vllm -c vllm | grep aiter-kvconn-patch
+    #   kubectl logs deploy/qwen38-27b-vllm -c vllm | grep "Overriding with"
+    # Revert = delete these two mounts, the volume above, and the generator.
+    - name: aiter-kvconn-patch
+      mountPath: /usr/local/lib/python3.12/dist-packages/zz_aiter_kvconn.pth
+      subPath: zz_aiter_kvconn.pth
+      readOnly: true
+    - name: aiter-kvconn-patch
+      mountPath: /usr/local/lib/python3.12/dist-packages/zz_aiter_kvconn_impl.py
+      subPath: zz_aiter_kvconn_impl.py
+      readOnly: true
   extraArgs:
     # First name is what vLLM reports back as `model`, so qwen-3.8 stays
     # primary. The second is an alias: the operator derives a LiteLLMModel from

--- a/kubernetes/apps/ai/llmkube/models/resources/zz_aiter_kvconn.pth
+++ b/kubernetes/apps/ai/llmkube/models/resources/zz_aiter_kvconn.pth
@@ -1,0 +1,1 @@
+import zz_aiter_kvconn_impl

--- a/kubernetes/apps/ai/llmkube/models/resources/zz_aiter_kvconn_impl.py
+++ b/kubernetes/apps/ai/llmkube/models/resources/zz_aiter_kvconn_impl.py
@@ -1,0 +1,57 @@
+# Lifts vLLM's refusal to pair ROCM_AITER_UNIFIED_ATTN with a KV connector.
+#
+# backend.py gates on `use_kv_connector and not cls.supports_kv_connector()`.
+# RocmAiterUnifiedAttentionBackend inherits that method as False from
+# RocmAttentionBackend, whose in-code reason is its own (2, num_blocks, ...)
+# packing. That reason does not apply to the subclass: it overrides
+# customize_spec and advertises LBHNC, which is exactly what
+# OffloadingConnector.get_required_kvcache_layout() returns. The inherited False
+# looks like a missing override rather than a deliberate exclusion.
+#
+# Patched via an import hook rather than by overlaying the upstream source file,
+# so this survives the frequent Renovate digest bumps of the nightly image
+# instead of silently going stale against a changed file.
+#
+# If upstream ever adds its own override, or renames the module/class, this hook
+# simply never fires and the engine falls back to TRITON_ATTN. Confirm which
+# backend is live from the startup log rather than assuming this took effect.
+import importlib.abc
+import sys
+
+TARGET = "vllm.v1.attention.backends.rocm_aiter_unified_attn"
+
+
+class _PatchLoader(importlib.abc.Loader):
+    # Hold the ORIGINAL loader, not the spec: find_spec() overwrites spec.loader
+    # with this wrapper, so going back through the spec recurses into itself.
+    def __init__(self, loader):
+        self._loader = loader
+
+    def create_module(self, spec):
+        return self._loader.create_module(spec)
+
+    def exec_module(self, module):
+        self._loader.exec_module(module)
+        module.RocmAiterUnifiedAttentionBackend.supports_kv_connector = classmethod(
+            lambda cls: True
+        )
+        print("[aiter-kvconn-patch] supports_kv_connector -> True",
+              file=sys.stderr, flush=True)
+
+
+class _Finder(importlib.abc.MetaPathFinder):
+    def find_spec(self, name, path=None, target=None):
+        if name != TARGET:
+            return None
+        for finder in sys.meta_path:
+            if finder is self:
+                continue
+            spec = finder.find_spec(name, path, target)
+            if spec and spec.loader:
+                spec.loader = _PatchLoader(spec.loader)
+                return spec
+        return None
+
+
+sys.meta_path.insert(0, _Finder())
+print("[aiter-kvconn-patch] import hook installed", file=sys.stderr, flush=True)


### PR DESCRIPTION
Selects `ROCM_AITER_UNIFIED_ATTN` over `TRITON_ATTN` by lifting an inherited
`supports_kv_connector() -> False` that reads as a missing override.
`RocmAiterUnifiedAttentionBackend` overrides `customize_spec` and advertises
`LBHNC`, which is exactly what `OffloadingConnector.get_required_kvcache_layout()`
returns; the parent's `(2, num_blocks, ...)` justification does not apply to it.

## Bench: parity, not a win

| metric | TRITON_ATTN | AITER_UNIFIED |
|---|---|---|
| decode conc-1 | 31.49, 31.68 | 16.75, 30.21 |
| decode conc-8 | 53.90, 64.97 | 63.45, 61.78 |
| decode conc-16 | **78.22, 77.03** | **77.21, 77.32** |
| engine prefill (50K) | 6390 tok/s | 6388.5 tok/s |

Both arms: one warmup discarded, two measured runs, `dev199+g7c5dc571c`, idle engine.

## Why merge a parity change

- vllm#43615's published R9700 gains (+56.5% @512 tok, +72.4% @1K-2K) sit at short contexts the sweeps above did not cover; production traffic includes them.
- Per-arm power draw unmeasured — GPU was capped at 248W/250W on both arms.
- Synthetic sweeps cannot see real-traffic mix, cache interaction, or stability.

## Not evidence against this

An earlier run measured 1.89 tok/s decode. That was vllm#53821 (AITER's `query_start_loc` zeroed during graph capture), absent from that build, present here.

## Soak criteria

- **Confirm it took effect** — the hook fails open to TRITON_ATTN:
  `kubectl logs deploy/qwen38-27b-vllm -c vllm | grep -E "aiter-kvconn-patch|Overriding with"`
- Watch: `DgpuVramLow`, decode tok/s, TTFT p50/p90, engine restarts.
- Revert: drop the two mounts, the volume, and the generator block.

## Risk

- Out-of-tree source patch, applied by import hook so Renovate digest bumps do not stale it. Fails open.
- `disableNameSuffixHash` is required (CRD consumer; kustomize only rewrites generated names in built-in types). Consequence: editing the `.py` does not roll the pod.
- Restart cost: cold tmpfs CPU tier plus collapsed prefix cache, so admission is degraded for a while after rollout.

Verified: `kustomize build` renders an unhashed ConfigMap, both subPath mounts wire up, embedded Python parses after the YAML round-trip.