### PR TITLE
fix(security): stop crowdsec banning jellyfin and jellyseerr clients

### DIFF
--- a/kubernetes/apps/security/crowdsec/app/helmrelease.yaml
+++ b/kubernetes/apps/security/crowdsec/app/helmrelease.yaml
@@ -74,10 +74,11 @@ spec:
               cidr:
                 - "240.0.0.0/4"
           # s02-enrich runs in filename order; this must sort after http-logs.yaml
-          static-image-endpoints.yaml: |-
-            name: hydaz/static-image-endpoints
-            description: "crowdsecurity/http-logs infers static_ressource from the file extension, so extensionless image endpoints read as crawlable content"
-            filter: "evt.Meta.target_fqdn == 'jellyfin.${SECRET_DOMAIN}' && evt.Meta.http_verb in ['GET', 'HEAD'] && evt.Meta.http_path matches '(?i)^/(homescreen/cachedimage|items/[^/]+/images/)'"
+          spa-api-requests.yaml: |-
+            name: hydaz/spa-api-requests
+            description: "One Jellyfin home screen is 46 distinct extensionless API calls in 10s; http-crawl-non_statics caps at 40 per 20s and bans the client"
+            # 2xx only: these endpoints 401 without a token, and enumeration shows up as 4xx for http-probing
+            filter: "evt.Meta.target_fqdn in ['jellyfin.${SECRET_DOMAIN}', 'jellyseerr.${SECRET_DOMAIN}'] && evt.Meta.http_verb in ['GET', 'HEAD'] && evt.Meta.http_status startsWith '2'"
             statics:
               - parsed: static_ressource
                 value: "true"


### PR DESCRIPTION
## Problem

Every alert crowdsec raised recently was the same false positive: `crowdsecurity/http-crawl-non_statics` banning legitimate Jellyfin/Jellyseerr clients for 24h.

| | |
|---|---|
| Scenario filter | `static_ressource == 'false' && verb in ['GET','HEAD']` |
| Bucket | capacity 40, leakspeed 0.5s, distinct on `file_name` |
| Observed | `JellyfinDesktop/2.0.0-dev`, 46 distinct URIs in 10s, all HTTP 200 |
| Alerts in window | 2/2 this scenario (`jellyfin`, `jellyseerr`); nothing else fired |

`crowdsecurity/http-logs` infers `static_ressource` from the file extension, so extensionless JSON API paths (`/HomeScreen/Section/DiscoverTV`, `/LiveTv/Programs`, `/Users/<id>/Items/<id>`) all count as crawlable content. One home screen load overflows the bucket.

## Change

Replaces `static-image-endpoints.yaml` with `spa-api-requests.yaml`, keyed on response code instead of path.

- Path enumeration was already whack-a-mole once (the image rule); response code does not need updating when Jellyfin adds endpoints.
- Subsumes the image rule (images are 2xx GETs on jellyfin), so it is a net deletion.
- 2xx only: these endpoints 401 without a token, and enumeration shows up as 4xx, which `http-probing` catches on status rather than `static_ressource`.
- Only `http-crawl-non_statics` reads `static_ressource`; probing/CVE/appsec/bruteforce untouched.

## Verification

- `evt.Meta.http_status` is available at `s02-enrich` — the existing `envoy-418-whitelist` already filters on it
- `startsWith` already used in `s01-parse`
- `spa-api-requests.yaml` sorts after `http-logs.yaml`, as the stage requires
- False-positive ban on the affected IP deleted; no active decisions

## Rollout

`SecurityPolicy/crowdsec` is currently removed from the live cluster, so the gateway is not enforcing. Restore with `flux reconcile ks envoy-gateway --with-source` after this merges and the agents reload.
