### PR TITLE
feat(security): alert on crowdsec bans with the request that caused them

### DIFF
--- a/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
@@ -218,6 +218,9 @@ spec:
                   {{ range $i, $alert := .Alerts }}{{ if lt $i 5 }}• {{ with $alert.Labels.namespace }}`{{ . }}`/{{ end }}{{ if $alert.Labels.pod }}`{{ $alert.Labels.pod }}`{{ else if $alert.Labels.instance }}`{{ $alert.Labels.instance }}`{{ else if $alert.Labels.node }}`{{ $alert.Labels.node }}`{{ else if $alert.Labels.job }}`{{ $alert.Labels.job }}`{{ else if $alert.Labels.alertname }}`{{ $alert.Labels.alertname }}`{{ else }}`unknown target`{{ end }}
                   ↳ {{ if eq $alert.Status "resolved" }}resolved <t:{{ $alert.EndsAt.Unix }}:R>{{ else }}firing since <t:{{ $alert.StartsAt.Unix }}:R>{{ end }}
                   {{ with $alert.GeneratorURL }}↳ [source]({{ . }}){{ end }}
+                  {{ with $alert.Labels.scenario }}↳ `{{ . }}`{{ end }}
+                  {{ with $alert.Annotations.client }}↳ {{ . }}{{ end }}
+                  {{ with $alert.Annotations.request }}↳ `{{ printf "%.400s" . }}`{{ end }}
 
                   {{ end }}{{ end }}{{ if gt (len .Alerts) 5 }}…and more alerts in this group.
                   {{ end }}

--- a/kubernetes/apps/security/crowdsec/app/helmrelease.yaml
+++ b/kubernetes/apps/security/crowdsec/app/helmrelease.yaml
@@ -32,10 +32,12 @@ spec:
                 expression: evt.Unmarshaled.envoy["x-envoy-origin-path"]
               - parsed: http_version
                 expression: TrimPrefix(evt.Unmarshaled.envoy["protocol"], "HTTP/")
+              # %v not %.0f: the envoy access-log schema is Envoy Gateway's implicit default,
+              # so a future release emitting these as strings would silently corrupt status
               - parsed: status
-                expression: Sprintf('%.0f', evt.Unmarshaled.envoy["response_code"])
+                expression: Sprintf('%v', evt.Unmarshaled.envoy["response_code"])
               - parsed: body_bytes_sent
-                expression: Sprintf('%.0f', evt.Unmarshaled.envoy["bytes_sent"])
+                expression: Sprintf('%v', evt.Unmarshaled.envoy["bytes_sent"])
               - parsed: http_user_agent
                 expression: evt.Unmarshaled.envoy["user-agent"]
               - parsed: target_fqdn

--- a/kubernetes/apps/security/crowdsec/app/helmrelease.yaml
+++ b/kubernetes/apps/security/crowdsec/app/helmrelease.yaml
@@ -82,6 +82,37 @@ spec:
             statics:
               - parsed: static_ressource
                 value: "true"
+      notifications:
+        alertmanager.yaml: |-
+          type: http
+          name: alertmanager
+          log_level: info
+          # A single client burst is one alert; batch so a noisy scenario cannot flood the webhook
+          group_wait: 30s
+          group_threshold: 10
+          max_retry: 3
+          timeout: 10s
+          # models.Alert fields are pointers: print them directly (text/template indirects) and never
+          # via printf, which would render the address. toJson handles escaping for attacker-controlled values.
+          format: |
+            [{{range $i, $a := .}}{{if $i}},{{end}}{
+              "labels": {
+                "alertname": "CrowdsecDecision",
+                "severity": "warning",
+                "scenario": {{$a.Scenario | toJson}},
+                "source_ip": {{$a.Source.IP | toJson}}
+              },
+              "annotations": {
+                "summary": "{{$a.Source.IP}} banned by {{$a.Scenario}}",
+                "origin": "{{$a.Source.Cn}} / {{$a.Source.AsName}}",
+                "request": {{if $a.Events}}{{(index $a.Events 0).Meta | toJson | toJson}}{{else}}"none"{{end}}
+              },
+              "startsAt": {{$a.StartAt | toJson}}
+            }{{end}}]
+          url: http://vmalertmanager-victoria-metrics.observability.svc.cluster.local:9093/api/v2/alerts
+          method: POST
+          headers:
+            Content-Type: application/json
       config.yaml.local: |-
         api:
           server:
@@ -105,6 +136,9 @@ spec:
         decisions:
           - type: ban
             duration: 24h
+        # Only locally-generated alerts reach profiles; CAPI blocklist pulls (15k IPs every 2h) do not
+        notifications:
+          - alertmanager
         on_success: break
     tls:
       enabled: true

--- a/kubernetes/apps/security/crowdsec/app/helmrelease.yaml
+++ b/kubernetes/apps/security/crowdsec/app/helmrelease.yaml
@@ -92,8 +92,9 @@ spec:
           group_threshold: 10
           max_retry: 3
           timeout: 10s
-          # models.Alert fields are pointers: print them directly (text/template indirects) and never
-          # via printf, which would render the address. toJson handles escaping for attacker-controlled values.
+          # Every interpolated value goes through toJson; no hand-quoted JSON strings.
+          # Alert.Scenario is a pointer, so it is piped to toJson directly: printf "%s" would render
+          # the address. Source.IP/Cn/AsName are plain strings and are safe to printf before toJson.
           format: |
             [{{range $i, $a := .}}{{if $i}},{{end}}{
               "labels": {
@@ -103,8 +104,8 @@ spec:
                 "source_ip": {{$a.Source.IP | toJson}}
               },
               "annotations": {
-                "summary": "{{$a.Source.IP}} banned by {{$a.Scenario}}",
-                "origin": "{{$a.Source.Cn}} / {{$a.Source.AsName}}",
+                "summary": {{$a.Scenario | toJson}},
+                "client": {{printf "%s (%s / %s)" $a.Source.IP $a.Source.Cn $a.Source.AsName | toJson}},
                 "request": {{if $a.Events}}{{(index $a.Events 0).Meta | toJson | toJson}}{{else}}"none"{{end}}
               },
               "startsAt": {{$a.StartAt | toJson}}

--- a/kubernetes/apps/security/crowdsec/app/helmrelease.yaml
+++ b/kubernetes/apps/security/crowdsec/app/helmrelease.yaml
@@ -68,6 +68,8 @@ spec:
           pseudo-ipv4-whitelist.yaml: |-
             name: hydaz/pseudo-ipv4-whitelist
             description: "Cloudflare Pseudo IPv4 rewrites IPv6 clients to class E; a ban on one synthetic address blocks every IPv6 client sharing it"
+            # Dormant guard: Pseudo IPv4 is off as of 2026-09-02 (XFF carries real IPv6).
+            # While it was on, the cost of this whitelist was that no IPv6 client was policed at all.
             filter: "evt.Meta.service == 'http' && evt.Meta.log_type == 'http_access-log'"
             whitelist:
               reason: "synthetic address, not a real client"
@@ -192,8 +194,11 @@ spec:
         requests:
           cpu: 100m
       acquisition:
+        # Only the gateway the SecurityPolicy enforces on: envoy-internal/-tls and the
+        # envoy-gateway controller have no bouncer, so alerts from them ban at the
+        # external gateway only, which reads as an unexplainable ban
         - namespace: network
-          podName: envoy-*
+          podName: envoy-external-*
           program: envoy
           poll_without_inotify: true
       env:
@@ -212,6 +217,10 @@ spec:
       enabled: true
       deployAnnotations:
         reloader.stakater.com/auto: "true"
+      # CPU only, as for lapi/agent: chart default 500m vs 3m observed
+      resources:
+        requests:
+          cpu: 100m
       # Serves the envoy bouncer's WAF calls on crowdsec-appsec-service:7422
       acquisitions:
         - source: appsec

--- a/kubernetes/apps/security/crowdsec/app/helmrelease.yaml
+++ b/kubernetes/apps/security/crowdsec/app/helmrelease.yaml
@@ -88,27 +88,22 @@ spec:
         alertmanager.yaml: |-
           type: http
           name: alertmanager
-          log_level: info
-          # A single client burst is one alert; batch so a noisy scenario cannot flood the webhook
-          group_wait: 30s
-          group_threshold: 10
+          # Alertmanager already groups before anything reaches discord, so no plugin-side
+          # batching; max_retry stays because a dropped ban notification is a lost signal
           max_retry: 3
-          timeout: 10s
-          # Every interpolated value goes through toJson; no hand-quoted JSON strings.
-          # Alert.Scenario is a pointer, so it is piped to toJson directly: printf "%s" would render
-          # the address. Source.IP/Cn/AsName are plain strings and are safe to printf before toJson.
+          # Every value goes through toJson: the URL and user-agent are attacker-controlled
           format: |
             [{{range $i, $a := .}}{{if $i}},{{end}}{
               "labels": {
                 "alertname": "CrowdsecDecision",
                 "severity": "warning",
-                "scenario": {{$a.Scenario | toJson}},
+                "scenario": {{$a.GetScenario | toJson}},
                 "source_ip": {{$a.Source.IP | toJson}}
               },
               "annotations": {
-                "summary": {{$a.Scenario | toJson}},
+                "summary": {{$a.GetScenario | toJson}},
                 "client": {{printf "%s (%s / %s)" $a.Source.IP $a.Source.Cn $a.Source.AsName | toJson}},
-                "request": {{if $a.Events}}{{(index $a.Events 0).Meta | toJson | toJson}}{{else}}"none"{{end}}
+                "request": {{if $a.Events}}{{$e := index $a.Events 0}}{{printf "%s %s%s %s (%s)" ($e.GetMeta "http_verb") ($e.GetMeta "target_fqdn") ($e.GetMeta "http_path") ($e.GetMeta "http_status") ($e.GetMeta "http_user_agent") | toJson}}{{else}}"none"{{end}}
               },
               "startsAt": {{$a.StartAt | toJson}}
             }{{end}}]
@@ -194,9 +189,8 @@ spec:
         requests:
           cpu: 100m
       acquisition:
-        # Only the gateway the SecurityPolicy enforces on: envoy-internal/-tls and the
-        # envoy-gateway controller have no bouncer, so alerts from them ban at the
-        # external gateway only, which reads as an unexplainable ban
+        # Only the gateway the SecurityPolicy enforces on; envoy-internal/-tls have no
+        # bouncer, so their alerts would ban at the external gateway only
         - namespace: network
           podName: envoy-external-*
           program: envoy

--- a/kubernetes/apps/security/crowdsec/app/prometheusrule.yaml
+++ b/kubernetes/apps/security/crowdsec/app/prometheusrule.yaml
@@ -8,6 +8,20 @@ spec:
   groups:
     - name: crowdsec.rules
       rules:
+        # The envoy parser reads Envoy Gateway's implicit default JSON access-log schema.
+        # A release that renames a field parses nothing while every liveness probe stays green.
+        - alert: CrowdsecEnvoyParserYieldZero
+          expr: |-
+            sum(rate(cs_node_hits_ok_total{name="crowdsecurity/cri-logs"}[15m])) > 0.05
+            and
+            (sum(rate(cs_node_hits_ok_total{name="hydaz/envoy-logs"}[15m])) or vector(0)) == 0
+          for: 15m
+          annotations:
+            summary: >-
+              Crowdsec is reading envoy container logs but parsing none of them — detection is blind
+              while the agent, lapi and bouncer all report healthy
+          labels:
+            severity: critical
         - alert: CrowdsecAppsecAbsent
           expr: |-
             absent(up{job="crowdsec-appsec-service"})


### PR DESCRIPTION
## Problem

Existing rules cover bouncer/appsec *health* (`CrowdsecBouncerLAPIDisconnected`, `CrowdsecBouncerAbsent`, `CrowdsecWAFFailingOpen`, `CrowdsecAppsecAbsent`). A ban itself is silent — both lockouts this year (2026-08-01 Pseudo IPv4, 2026-09-01 #4817) were discovered by being locked out of Jellyfin.

## Why not a PrometheusRule

`cs_active_decisions` only carries `action`/`origin`/`reason`:

```
cs_active_decisions{action="ban",origin="CAPI",reason="http:crawl"} 26414
```

No client, no URL — structurally cannot answer "is this a false positive?". crowdsec's http notification plugin receives the full `models.Alert`, so it can.

## Change

`config.notifications.alertmanager.yaml` posts to the existing alertmanager `/api/v2/alerts`, reusing the discord receiver, grouping and silence-operator rather than adding a second notification path and a second webhook secret.

| Field | Source |
|---|---|
| `summary` | source IP + scenario |
| `origin` | country / AS |
| `request` | first event's meta — `http_path`, `target_fqdn`, `http_user_agent`, `http_status` |

Wired via `profiles.yaml` `notifications:` rather than firing on every alert — CAPI blocklist pulls land 15000 IPs every 2h and do not pass through profiles.

Template notes: `models.Alert` fields are pointers, so values are printed directly (text/template indirects) and never via `printf`, which renders the address. `toJson` handles escaping on the attacker-controlled URL and user-agent.

## Verification status

Verified:
- `notification-http` plugin present in the lapi image, `config.notifications` supported by chart 0.20.1
- lapi → alertmanager reachable (`/api/v2/status` returns), no netpol in the path
- Plugin `name: alertmanager` matches the `profiles.yaml` reference; YAML renders correctly

**Not yet verified — the Go template has not been executed.** Staging a config inside the pod to run `cscli notifications test` was blocked locally. After merge:

```
kubectl -n security exec deploy/crowdsec-lapi -- cscli notifications test alertmanager
kubectl -n security exec deploy/crowdsec-lapi -- cscli notifications reinject <alert-id>
```

A broken template fails the notification silently, which is the current behaviour anyway — so this is not a regression, but it should not be assumed working until one of the above is run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Alertmanager notifications for CrowdSec security decisions.
  * CrowdSec remediation alerts are now forwarded to the vmalertmanager service in Prometheus-compatible format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->