### PR TITLE
perf(ai): fix W4A16 decode cliff at 2+ concurrent requests

### DIFF
--- a/kubernetes/apps/ai/llmkube/models/kustomization.yaml
+++ b/kubernetes/apps/ai/llmkube/models/kustomization.yaml
@@ -18,5 +18,9 @@ configMapGenerator:
     files:
       - zz_aiter_kvconn.pth=./resources/zz_aiter_kvconn.pth
       - zz_aiter_kvconn_impl.py=./resources/zz_aiter_kvconn_impl.py
+  - name: lds-gate-patch
+    files:
+      - zz_lds_gate.pth=./resources/zz_lds_gate.pth
+      - zz_lds_gate_impl.py=./resources/zz_lds_gate_impl.py
 generatorOptions:
   disableNameSuffixHash: true

--- a/kubernetes/apps/ai/llmkube/models/qwen38-27b-vllm.yaml
+++ b/kubernetes/apps/ai/llmkube/models/qwen38-27b-vllm.yaml
@@ -192,9 +192,15 @@ spec:
   modelRef: qwen38-27b-vllm
   runtime: vllm
   replicas: 1
-  # TPOT probe 08-21: kernel-dispatch cliff at M=6 (MAX_SKINNY_BATCH_SIZE=5
-  # in rdna_hybrid_w4a16.py), 23.6 -> 13.3 tok/s/stream. Operator -> --max-num-seqs.
-  parallelSlots: 6
+  # 5, not 6: MAX_SKINNY_BATCH_SIZE=5 in rdna_hybrid_w4a16.py sends ALL four
+  # W4A16 projections to the slow Triton path at M=6 (and drops the bf16 lm_head
+  # to torch.linear), so slot 6 is strictly worse per stream than slot 5.
+  # Measured 2026-09-02, M=1..5 with one graph per size:
+  #   before (slots 6, capture [1,2,4,6]): 31.06 28.64 39.30 52.15 52.22 61.99
+  #   after  (slots 5, capture [1,2,3,4,5]): 31.11 56.33 64.95 76.10 102.87
+  # Peak aggregate 61.99 -> ~99 tok/s. Pairs with the LDS gate patch below;
+  # neither change alone produces those numbers.
+  parallelSlots: 5
   bindAddress: 0.0.0.0
   # Rolling `nightly` tag pinned by digest, same shape as
   # kubesearch-mcp:master@sha256:. The digest is what gets pulled, so this is
@@ -283,6 +289,10 @@ spec:
     - name: aiter-kvconn-patch
       configMap:
         name: aiter-kvconn-patch
+    # Raises the W4A16 skinny-GEMM LDS gate to the C++ kernel's real limit.
+    - name: lds-gate-patch
+      configMap:
+        name: lds-gate-patch
   extraVolumeMounts:
     - name: compile-cache
       mountPath: /cache
@@ -318,6 +328,28 @@ spec:
       mountPath: /usr/local/lib/python3.12/dist-packages/zz_aiter_kvconn_impl.py
       subPath: zz_aiter_kvconn_impl.py
       readOnly: true
+    # rdna_hybrid_w4a16.py gates the fast HIP skinny GEMM on
+    # `K * M <= LDS_CAPACITY_ELEMENTS` (32768). The C++ kernel actually accepts
+    # `K_in * N_in <= max_lds_len * 1.2` (39321) and switches to a medium
+    # variant above the plain LDS size. down_proj (K=17408) at M=2 is 34816:
+    # legal for the kernel, refused by Python, so it fell to a ~2x slower Triton
+    # path -- which is why per-stream decode halved at 2 concurrent requests.
+    #
+    # Verified on gfx1201 before deploying: at M=2 the HIP kernel is correct
+    # (rel err 0.0014 vs an fp32 reference, BETTER than Triton's 0.0093) and
+    # ~1.8x faster; M=3 (52224) is refused by the kernel itself with a clean
+    # RuntimeError, so an over-large gate fails loudly, not silently.
+    #
+    # Same one-line change as upstream vllm PR #52619. Drop this mount and the
+    # generator entry once that lands in the nightly.
+    - name: lds-gate-patch
+      mountPath: /usr/local/lib/python3.12/dist-packages/zz_lds_gate.pth
+      subPath: zz_lds_gate.pth
+      readOnly: true
+    - name: lds-gate-patch
+      mountPath: /usr/local/lib/python3.12/dist-packages/zz_lds_gate_impl.py
+      subPath: zz_lds_gate_impl.py
+      readOnly: true
   extraArgs:
     # First name is what vLLM reports back as `model`, so qwen-3.8 stays
     # primary. The second is an alias: the operator derives a LiteLLMModel from
@@ -338,7 +370,11 @@ spec:
     # avoids the mamba cache's 71-block limit vLLM's default max-num-seqs
     # (256) would overshoot.
     - --compilation-config
-    - '{"cudagraph_capture_sizes": [1, 2, 4, 6]}'
+    # One capture per real batch size. vLLM pads any batch to the NEXT capture
+    # size (v1/cudagraph_dispatcher.py), so [1,2,4,6] silently ran M=3 as 4 and
+    # M=5 as 6 -- the M=5 point was measuring the all-Triton M=6 path. With
+    # max_num_seqs 5 there is no padding left to pay for.
+    - '{"cudagraph_capture_sizes": [1, 2, 3, 4, 5]}'
     # Keep prior-turn reasoning in context; matches production qwen36 config.
     - --default-chat-template-kwargs
     - '{"preserve_thinking": true}'

--- a/kubernetes/apps/ai/llmkube/models/resources/zz_lds_gate.pth
+++ b/kubernetes/apps/ai/llmkube/models/resources/zz_lds_gate.pth
@@ -1,0 +1,1 @@
+import zz_lds_gate_impl

--- a/kubernetes/apps/ai/llmkube/models/resources/zz_lds_gate_impl.py
+++ b/kubernetes/apps/ai/llmkube/models/resources/zz_lds_gate_impl.py
@@ -1,0 +1,62 @@
+# TEST ONLY -- raises the W4A16 skinny-GEMM LDS gate to match the C++ kernel.
+#
+# rdna_hybrid_w4a16.py dispatches:
+#     if M <= MAX_SKINNY_BATCH_SIZE and K * M <= LDS_CAPACITY_ELEMENTS:
+#         ops.wvSplitK_int4_g(...)   # fast HIP skinny GEMM
+#     else:
+#         triton_w4a16_skinny_fmt_gemm(...)   # ~2x slower
+#
+# LDS_CAPACITY_ELEMENTS is 32768 (64 KiB / 2). But csrc/rocm/skinny_gemms_int4.cu
+# checks `K_in * N_in <= max_lds_len * 1.2` (= 39321) and selects a "medium"
+# kernel variant above the plain LDS size, keeping the activation prefix in LDS
+# and streaming the remainder from global.
+#
+# So the Python gate is stricter than the kernel. down_proj (K=17408) at M=2 is
+# K*M = 34816: inside the C++ medium window, outside the Python gate. Verified
+# in-container on gfx1201: the HIP kernel at M=2 returns correct results
+# (relative error 0.0014 vs an fp32 reference, BETTER than Triton's 0.0093) and
+# is ~1.8x faster. M=3 (52224) is refused by the kernel itself with a clean
+# RuntimeError, so an over-relaxed gate fails loudly rather than silently.
+#
+# Equivalent to upstream vllm PR #52619 (one-line, unreviewed), which measured
+# 1.66x kernel / +63% e2e decode on gfx1151.
+import importlib.abc
+import sys
+
+TARGET = "vllm.model_executor.kernels.linear.mixed_precision.rdna_hybrid_w4a16"
+NEW_LIMIT = int(32768 * 1.2)  # 39321, matches max_lds_len * 1.2 in the C++
+
+
+class _PatchLoader(importlib.abc.Loader):
+    def __init__(self, loader):
+        self._loader = loader
+
+    def create_module(self, spec):
+        return self._loader.create_module(spec)
+
+    def exec_module(self, module):
+        self._loader.exec_module(module)
+        old = getattr(module, "LDS_CAPACITY_ELEMENTS", None)
+        module.LDS_CAPACITY_ELEMENTS = NEW_LIMIT
+        print(
+            "[lds-gate-patch] LDS_CAPACITY_ELEMENTS %s -> %s" % (old, NEW_LIMIT),
+            file=sys.stderr, flush=True,
+        )
+
+
+class _Finder(importlib.abc.MetaPathFinder):
+    def find_spec(self, name, path=None, target=None):
+        if name != TARGET:
+            return None
+        for finder in sys.meta_path:
+            if finder is self:
+                continue
+            spec = finder.find_spec(name, path, target)
+            if spec and spec.loader:
+                spec.loader = _PatchLoader(spec.loader)
+                return spec
+        return None
+
+
+sys.meta_path.insert(0, _Finder())
+print("[lds-gate-patch] import hook installed", file=sys.stderr, flush=True)


### PR DESCRIPTION
Decode per-stream halved the moment a second request arrived, and aggregate throughput went **down** from 1 to 2 concurrent. Two dispatch-side causes, neither a hardware limit.

## Measured (warm engine, two runs, aggregate tok/s)

| M | 1 | 2 | 3 | 4 | 5 | 6 |
|---|---|---|---|---|---|---|
| before | 31.06 | **28.64** | 39.30 | 52.15 | 52.22 | 61.99 |
| after | 31.11 | **56.33** | 64.95 | 76.10 | **102.87** | - |
| after | 30.79 | 55.34 | 65.13 | 84.39 | 94.72 | - |

Per-stream at M=2: **14.32 → ~28**. Peak aggregate **61.99 → ~99 (+60%)**, at a *lower* slot count. M=1 unchanged — it was already on the fast path, at ~72% of the card's 640 GB/s roofline.

## Cause 1 — Python LDS gate stricter than the kernel

`rdna_hybrid_w4a16.py` gates the fast HIP skinny GEMM on `K * M <= 32768`. The C++ accepts `K_in * N_in <= max_lds_len * 1.2` (**39321**) and switches to a medium variant above the plain LDS size. `down_proj` (K=17408) at M=2 is 34816 — legal for the kernel, refused by Python, so it fell to a ~2x slower Triton path. It is the **only** projection affected; qkv/o/gate_up (K=5120/6144) stay under 32768.

Verified on gfx1201 before deploying:
- M=2 HIP result is correct: rel err **0.0014** vs an fp32 reference, **better** than Triton's 0.0093
- ~1.8x faster on that GEMM
- M=3 (52224) is refused by the kernel itself with a clean `RuntimeError` — an over-large gate fails loudly, not silently

Same one-line change as upstream [vllm#52619](https://github.com/vllm-project/vllm/pull/52619).

## Cause 2 — cudagraph padding hid the real curve

`cudagraph_capture_sizes [1,2,4,6]` with `max_num_seqs 6`: vLLM pads any batch to the **next** capture size, so M=3 ran as 4 and M=5 ran as 6. At M=6, `MAX_SKINNY_BATCH_SIZE=5` sends *all four* projections to Triton and drops the bf16 lm_head to `torch.linear` — so slot 6 is strictly worse per stream than slot 5. Now one capture per real batch size, slots at 5.

## Correctness

Outputs verified after the change: `17x23=391`, capital of Japan, exact-match prompts, all `finish_reason=stop`. The patched kernel is numerically *more* accurate than the Triton path it replaces.

## Risk

- Applied by import hook, not by overlaying upstream's file, so Renovate digest bumps of the nightly tag don't stale it. If the module or constant is renamed the hook never fires and the old gate stands (fails safe).
- `disableNameSuffixHash` is required (CRD consumer); editing the `.py` does not roll the pod by itself.
- Drop this mount and the generator entry once vllm#52619 lands in the nightly.

## Not measured

Synthetic short-prompt decode only — no prefill/TTFT on the patched config, and quality is smoke prompts rather than an eval.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added deployment support for the LDS gate adjustment used by W4A16 model execution.
  - Updated the Qwen 3.8 27B vLLM service to support five parallel inference slots.
  - Expanded CUDA graph capture coverage for batch sizes 1 through 5.

- **Performance**
  - Improved compatibility between Python and C++ kernel limits for supported W4A16 workloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->