### PR TITLE
fix(observability): stop crowdsec alerts repeating themselves in discord

### DIFF
--- a/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
@@ -215,11 +215,11 @@ spec:
 
                   🎯 **Affected targets**
 
-                  {{ range $i, $alert := .Alerts }}{{ if lt $i 5 }}• {{ with $alert.Labels.namespace }}`{{ . }}`/{{ end }}{{ if $alert.Labels.pod }}`{{ $alert.Labels.pod }}`{{ else if $alert.Labels.instance }}`{{ $alert.Labels.instance }}`{{ else if $alert.Labels.node }}`{{ $alert.Labels.node }}`{{ else if $alert.Labels.job }}`{{ $alert.Labels.job }}`{{ else if $alert.Labels.alertname }}`{{ $alert.Labels.alertname }}`{{ else }}`unknown target`{{ end }}
+                  {{ range $i, $alert := .Alerts }}{{ if lt $i 5 }}• {{ with $alert.Labels.namespace }}`{{ . }}`/{{ end }}{{ if $alert.Labels.pod }}`{{ $alert.Labels.pod }}`{{ else if $alert.Labels.instance }}`{{ $alert.Labels.instance }}`{{ else if $alert.Labels.node }}`{{ $alert.Labels.node }}`{{ else if $alert.Labels.job }}`{{ $alert.Labels.job }}`{{ else if $alert.Labels.source_ip }}`{{ $alert.Labels.source_ip }}`{{ else if $alert.Labels.alertname }}`{{ $alert.Labels.alertname }}`{{ else }}`unknown target`{{ end }}
                   ↳ {{ if eq $alert.Status "resolved" }}resolved <t:{{ $alert.EndsAt.Unix }}:R>{{ else }}firing since <t:{{ $alert.StartsAt.Unix }}:R>{{ end }}
                   {{ with $alert.GeneratorURL }}↳ [source]({{ . }}){{ end }}
                   {{ with $alert.Labels.scenario }}↳ `{{ . }}`{{ end }}
-                  {{ with $alert.Annotations.client }}↳ {{ . }}{{ end }}
+                  {{ with $alert.Annotations.origin }}↳ {{ . }}{{ end }}
                   {{ with $alert.Annotations.request }}↳ `{{ printf "%.400s" . }}`{{ end }}
 
                   {{ end }}{{ end }}{{ if gt (len .Alerts) 5 }}…and more alerts in this group.

--- a/kubernetes/apps/security/crowdsec/app/helmrelease.yaml
+++ b/kubernetes/apps/security/crowdsec/app/helmrelease.yaml
@@ -105,7 +105,7 @@ spec:
               "annotations": {
                 "summary": {{$a.GetScenario | toJson}},
                 "description": "crowdsec issued a ban; client and request per alert below",
-                "origin": {{if $a.Source.Cn}}{{printf "%s / %s" $a.Source.Cn $a.Source.AsName | toJson}}{{else}}{{$a.Source.AsName | toJson}}{{end}},
+                "origin": {{if and $a.Source.Cn $a.Source.AsName}}{{printf "%s / %s" $a.Source.Cn $a.Source.AsName | toJson}}{{else}}{{printf "%s%s" $a.Source.Cn $a.Source.AsName | toJson}}{{end}},
                 "request": {{if $a.Events}}{{$e := index $a.Events 0}}{{printf "%s %s%s %s (%s)" ($e.GetMeta "http_verb") ($e.GetMeta "target_fqdn") ($e.GetMeta "http_path") ($e.GetMeta "http_status") ($e.GetMeta "http_user_agent") | toJson}}{{else}}"none"{{end}}
               },
               "startsAt": {{$a.StartAt | toJson}}

--- a/kubernetes/apps/security/crowdsec/app/helmrelease.yaml
+++ b/kubernetes/apps/security/crowdsec/app/helmrelease.yaml
@@ -104,7 +104,8 @@ spec:
               },
               "annotations": {
                 "summary": {{$a.GetScenario | toJson}},
-                "client": {{printf "%s (%s / %s)" $a.Source.IP $a.Source.Cn $a.Source.AsName | toJson}},
+                "description": "crowdsec issued a ban; client and request per alert below",
+                "origin": {{if $a.Source.Cn}}{{printf "%s / %s" $a.Source.Cn $a.Source.AsName | toJson}}{{else}}{{$a.Source.AsName | toJson}}{{end}},
                 "request": {{if $a.Events}}{{$e := index $a.Events 0}}{{printf "%s %s%s %s (%s)" ($e.GetMeta "http_verb") ($e.GetMeta "target_fqdn") ($e.GetMeta "http_path") ($e.GetMeta "http_status") ($e.GetMeta "http_user_agent") | toJson}}{{else}}"none"{{end}}
               },
               "startsAt": {{$a.StartAt | toJson}}


### PR DESCRIPTION
Follow-up to #4826, from the first real ban notification in discord.

## Observed

```
🚨 CrowdsecDecision
No description was provided.
🎯 Affected targets
• CrowdsecDecision
  ↳ crowdsecurity/http-crawl-non_statics
  ↳ 192.0.2.1 (BE / TEST-NET reinject)
  ↳ GET jellyfin.tanguille.site/HomeScreen/... 200 (JellyfinDesktop/2.0.0-dev ...)
• CrowdsecDecision
  ↳ test alert
  ↳ 10.10.10.10 ( / )
  ↳ none
```

| Problem | Cause |
|---|---|
| `No description was provided.` | Two scenarios in one group drop `summary` from `CommonAnnotations` |
| `CrowdsecDecision` three times | Target chain finds no pod/instance/node/job, falls through to `alertname` |
| `10.10.10.10 ( / )` | `printf` renders the separators even when geoip has nothing |

## Change

- `description` annotation is constant across alerts, so it survives grouping and replaces the dead header line.
- Target fallback chain prefers `source_ip` before `alertname`, so the bullet names the banned client. Placed after `job` so no existing alert changes.
- `client` becomes `origin` carrying geo only, since the bullet now carries the IP. Guarded so a missing country renders the AS alone.

## Result

```
• 192.0.2.1
  ↳ firing since 2 minutes ago
  ↳ crowdsecurity/http-crawl-non_statics
  ↳ BE / Proximus NV
  ↳ GET jellyfin.tanguille.site/HomeScreen/... 200 (JellyfinDesktop/2.0.0-dev ...)
```

Not a bug, for the record: "firing since 16 hours ago" in the screenshot is `StartAt` from the archived alert used for `cscli notifications reinject`. A real ban starts seconds before its notification.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Alertmanager Discord notifications now display alert origin details.
  - Notifications use the source IP as a fallback affected-target identifier when available.
  - CrowdSec origin details now format country and ASN information cleanly, omitting unnecessary separators when either value is unavailable.

- **Changes**
  - The previous client annotation display and combined IP, country, and ASN formatting have been removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->