### PR TITLE
feat(tuppr): drive node upgrades from the CR, not a per-node annotation

### DIFF
--- a/.github/workflows/flate.yaml
+++ b/.github/workflows/flate.yaml
@@ -121,7 +121,9 @@ jobs:
         run: |
           set -euo pipefail
           # yq -e, not yq: a plain yq prints "null" and exits 0 for a missing key.
-          TALOS_VERSION="$(yq -e '.spec.talos.version' \
+          # .spec.talosctl.image.tag, NOT .spec.talos.version: the latter carries the -k<kernel>
+          # suffix, which siderolabs never published a release for, so the download 404s.
+          TALOS_VERSION="$(yq -e '.spec.talosctl.image.tag' \
             kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml)"
           echo "talosctl ${TALOS_VERSION} (from talosupgrade.yaml)"
           base="https://github.com/siderolabs/talos/releases/download/${TALOS_VERSION}"

--- a/.justfile
+++ b/.justfile
@@ -41,16 +41,14 @@ talsecret:
 template file *args:
     talos_version="$(just tuppr-version talos)"
     kubernetes_version="$(just tuppr-version kubernetes)"
-    kernel_version="$(just kernel-version)"
     # pinned comes from the tuppr CR verbatim -- it is the one place the v<talos>-k<kernel>
     # string is composed, so the tag a node is told to install cannot disagree with the tag
-    # tuppr asks for. Guarded rather than trusted: the kernel half of the CR and the Dockerfile
-    # ARG are bumped by the same Renovate branch, and a half-applied tree would otherwise render
-    # a config pinning a kernel the `kernelVersion` comment above it contradicts.
-    [[ "${talos_version#*-k}" == "${kernel_version}" ]] || {
-        echo "tuppr CR names k${talos_version#*-k}, Dockerfile builds ${kernel_version}" >&2
-        exit 1
-    }
+    # tuppr asks for. kernelVersion is SPLIT off it rather than read from the Dockerfile ARG and
+    # reconciled: its only consumer is a prose comment in control-2.yaml.j2, so deriving makes
+    # that comment correct by construction and leaves nothing to check. The ARG is still
+    # compared against the CR in scripts/talos-kernel-build.sh, where a mismatch would publish
+    # an installer whose tag lies about its contents -- that is the one that has to fail loudly.
+    kernel_version="${talos_version#*-k}"
     # Piped, not <(just talsecret): through a pipe `pipefail` sees a failed decrypt.
     just talsecret | minijinja-cli --strict --format=yaml --autoescape=none \
         -D "kubernetesVersion=${kubernetes_version}" \

--- a/.justfile
+++ b/.justfile
@@ -42,11 +42,20 @@ template file *args:
     talos_version="$(just tuppr-version talos)"
     kubernetes_version="$(just tuppr-version kubernetes)"
     kernel_version="$(just kernel-version)"
+    # pinned comes from the tuppr CR verbatim -- it is the one place the v<talos>-k<kernel>
+    # string is composed, so the tag a node is told to install cannot disagree with the tag
+    # tuppr asks for. Guarded rather than trusted: the kernel half of the CR and the Dockerfile
+    # ARG are bumped by the same Renovate branch, and a half-applied tree would otherwise render
+    # a config pinning a kernel the `kernelVersion` comment above it contradicts.
+    [[ "${talos_version#*-k}" == "${kernel_version}" ]] || {
+        echo "tuppr CR names k${talos_version#*-k}, Dockerfile builds ${kernel_version}" >&2
+        exit 1
+    }
     # Piped, not <(just talsecret): through a pipe `pipefail` sees a failed decrypt.
     just talsecret | minijinja-cli --strict --format=yaml --autoescape=none \
         -D "kubernetesVersion=${kubernetes_version}" \
         -D "kernelVersion=${kernel_version}" \
-        -D "pinned=${talos_version}-k${kernel_version}" \
+        -D "pinned=${talos_version}" \
         {{ args }} "{{ file }}" -
 
 [doc('Force Flux to pull in changes from the Git repository')]

--- a/.justfile
+++ b/.justfile
@@ -41,13 +41,10 @@ talsecret:
 template file *args:
     talos_version="$(just tuppr-version talos)"
     kubernetes_version="$(just tuppr-version kubernetes)"
-    # pinned comes from the tuppr CR verbatim -- it is the one place the v<talos>-k<kernel>
-    # string is composed, so the tag a node is told to install cannot disagree with the tag
-    # tuppr asks for. kernelVersion is SPLIT off it rather than read from the Dockerfile ARG and
-    # reconciled: its only consumer is a prose comment in control-2.yaml.j2, so deriving makes
-    # that comment correct by construction and leaves nothing to check. The ARG is still
-    # compared against the CR in scripts/talos-kernel-build.sh, where a mismatch would publish
-    # an installer whose tag lies about its contents -- that is the one that has to fail loudly.
+    # pinned is the CR value verbatim: the tag a node installs cannot disagree with the one tuppr
+    # asks for. kernelVersion is split off it, not read from the Dockerfile ARG -- its only
+    # consumer is a comment in control-2.yaml.j2, so deriving leaves nothing to reconcile. The
+    # ARG is checked against the CR in scripts/talos-kernel-build.sh, where a mismatch ships.
     kernel_version="${talos_version#*-k}"
     # Piped, not <(just talsecret): through a pipe `pipefail` sees a failed decrypt.
     just talsecret | minijinja-cli --strict --format=yaml --autoescape=none \

--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -40,13 +40,9 @@
   },
   customManagers: [
     {
-      // The tuppr target is one string carrying two independently-bumped versions, so it needs
-      // two managers rather than the annotation manager, which would capture the whole value and
-      // read -k7.1.13 as a semver prerelease of 1.14.0 -- "upgrading" it to v1.14.0 and eating
-      // the kernel half. Each manager owns one half; auto-replace rewrites only its own span.
-      // The prerelease group is not dead weight: this repo ran v1.14.0-rc.2 in prod for weeks,
-      // and a manager that silently matches nothing on an rc pin is the exact failure this
-      // whole split exists to avoid. It costs one clause; a no-match costs a missed bump.
+      // One string, two independently-bumped versions, so one manager per half -- an inline
+      // annotation captures the whole value and reads the -k suffix as a semver prerelease.
+      // The optional prerelease group matches an rc pin; this repo ran v1.14.0-rc.2 for weeks.
       description: "tuppr target v<talos>-k<kernel>: Talos half",
       customType: "regex",
       managerFilePatterns: ["/tuppr/upgrades/talosupgrade\\.yaml$/"],
@@ -57,15 +53,12 @@
       datasourceTemplate: "github-releases"
     },
     {
-      // Deliberately NOT anchored on the Talos prefix. Renovate rewrites currentValue inside the
-      // matched span, so the span has to contain the kernel version and nothing that looks like
-      // it: "version: v1.17.3-k7.3" with the bare-series currentValue "7.3" that
-      // `versioning: loose` exists to allow also contains "7.3" inside v1.17.3. "-k7.3" does not.
-      // The cost of unanchoring is that a literal -k<digits> ANYWHERE in the target file is
-      // extracted as another dep -- a dry-run found three, from two comments carrying example
-      // versions. talosupgrade.yaml carries a warning about that; keep it.
-      // depName linux matches the Dockerfile ARG, so both files land in one branch -- which is
-      // what the -k guard in scripts/talos-kernel-build.sh relies on.
+      // Span is "-k<version>", not the whole version line: Renovate rewrites currentValue inside
+      // the span, and "version: v1.17.3-k7.3" also contains "7.3" inside v1.17.3 (bare series is
+      // what versioning:loose allows). Cost of unanchoring: every literal -k<digits> in the file
+      // is its own dep, so talosupgrade.yaml's comments must not carry one.
+      // depName linux matches the Dockerfile ARG, so both land in one branch -- the -k guard in
+      // scripts/talos-kernel-build.sh relies on that.
       description: "tuppr target v<talos>-k<kernel>: kernel half",
       customType: "regex",
       managerFilePatterns: ["/tuppr/upgrades/talosupgrade\\.yaml$/"],

--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -44,6 +44,9 @@
       // two managers rather than the annotation manager, which would capture the whole value and
       // read -k7.1.13 as a semver prerelease of 1.14.0 -- "upgrading" it to v1.14.0 and eating
       // the kernel half. Each manager owns one half; auto-replace rewrites only its own span.
+      // The prerelease group is not dead weight: this repo ran v1.14.0-rc.2 in prod for weeks,
+      // and a manager that silently matches nothing on an rc pin is the exact failure this
+      // whole split exists to avoid. It costs one clause; a no-match costs a missed bump.
       description: "tuppr target v<talos>-k<kernel>: Talos half",
       customType: "regex",
       managerFilePatterns: ["/tuppr/upgrades/talosupgrade\\.yaml$/"],

--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -40,6 +40,35 @@
   },
   customManagers: [
     {
+      // The tuppr target is one string carrying two independently-bumped versions, so it needs
+      // two managers rather than the annotation manager, which would capture the whole value and
+      // read -k7.1.13 as a semver prerelease of 1.14.0 -- "upgrading" it to v1.14.0 and eating
+      // the kernel half. Each manager owns one half; auto-replace rewrites only its own span.
+      description: "tuppr target v<talos>-k<kernel>: Talos half",
+      customType: "regex",
+      managerFilePatterns: ["/tuppr/upgrades/talosupgrade\\.yaml$/"],
+      matchStrings: [
+        "version:\\s+(?<currentValue>v\\d+\\.\\d+\\.\\d+(?:-[a-z]+\\.\\d+)?)-k"
+      ],
+      depNameTemplate: "siderolabs/talos",
+      datasourceTemplate: "github-releases"
+    },
+    {
+      // Deliberately NOT anchored on the Talos prefix. Renovate auto-replace does
+      // replaceString.replace(escape(currentValue), newValue) -- first occurrence, non-global,
+      // over the whole matched span. A span of "version: v1.17.3-k7.3" with the bare-series
+      // currentValue "7.3" that `versioning: loose` exists to allow would hit the "7.3" inside
+      // v1.17.3 first and rewrite the Talos half. "-k7.3" has exactly one occurrence.
+      // depName linux matches the Dockerfile ARG, so both files land in one branch -- which is
+      // what the -k guard in scripts/talos-kernel-build.sh relies on.
+      description: "tuppr target v<talos>-k<kernel>: kernel half",
+      customType: "regex",
+      managerFilePatterns: ["/tuppr/upgrades/talosupgrade\\.yaml$/"],
+      matchStrings: ["-k(?<currentValue>\\d+\\.\\d+(?:\\.\\d+)?)"],
+      depNameTemplate: "linux",
+      datasourceTemplate: "custom.linux-kernel"
+    },
+    {
       description: "GrafanaDashboard spec.url pinned to GitHub release tags",
       customType: "regex",
       managerFilePatterns: ["/grafanadashboard\\.yaml(?:\\.j2)?$/"],

--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -57,11 +57,13 @@
       datasourceTemplate: "github-releases"
     },
     {
-      // Deliberately NOT anchored on the Talos prefix. Renovate auto-replace does
-      // replaceString.replace(escape(currentValue), newValue) -- first occurrence, non-global,
-      // over the whole matched span. A span of "version: v1.17.3-k7.3" with the bare-series
-      // currentValue "7.3" that `versioning: loose` exists to allow would hit the "7.3" inside
-      // v1.17.3 first and rewrite the Talos half. "-k7.3" has exactly one occurrence.
+      // Deliberately NOT anchored on the Talos prefix. Renovate rewrites currentValue inside the
+      // matched span, so the span has to contain the kernel version and nothing that looks like
+      // it: "version: v1.17.3-k7.3" with the bare-series currentValue "7.3" that
+      // `versioning: loose` exists to allow also contains "7.3" inside v1.17.3. "-k7.3" does not.
+      // The cost of unanchoring is that a literal -k<digits> ANYWHERE in the target file is
+      // extracted as another dep -- a dry-run found three, from two comments carrying example
+      // versions. talosupgrade.yaml carries a warning about that; keep it.
       // depName linux matches the Dockerfile ARG, so both files land in one branch -- which is
       // what the -k guard in scripts/talos-kernel-build.sh relies on.
       description: "tuppr target v<talos>-k<kernel>: kernel half",

--- a/docker/talos-kernel/README.md
+++ b/docker/talos-kernel/README.md
@@ -254,21 +254,27 @@ only ever offers the highest stable.
 
 ### Rolling a bump back
 
-Reverting the *running* kernel is one command, but it leaves the node's **stored config** still
-naming the new installer and carrying the new `tuppr.home-operations.com/version` annotation.
-tuppr reads that annotation: a node running 7.1.10 while annotated 7.2.2 is a node tuppr may
-upgrade straight back into the break. Re-apply the config from the pre-bump tree as well:
+Revert the PR. `spec.talos.version` goes back to the older string and tuppr rolls each node to
+it — that is a live downgrade command, not a no-op, so for a Talos *minor* revert suspend the CR
+first and decide deliberately whether the Kubernetes and CNPG state tolerates going backwards.
+The older installer tag is still published; tags in `ghcr.io/tanguille/installer/*` are never
+reused.
+
+To pull a single node back out of band, without waiting for tuppr:
 
 ```sh
 talosctl -n <ip> upgrade -i ghcr.io/tanguille/installer/<schematic>:<old-version> \
     -m powercycle --timeout=15m
-git checkout <bump-commit>~1        # renders the old pinned
-just --yes talos apply-node <node> <ip>
-kubectl get nodes \
-    -o custom-columns=NAME:.metadata.name,TUPPR:'.metadata.annotations.tuppr\.home-operations\.com/version'
+# ...then pin it there, or tuppr will roll it forward again on the next reconcile:
+kubectl annotate node <node> tuppr.home-operations.com/version=<old-version>
+kubectl get nodes -o custom-columns=NAME:.metadata.name,\
+RUNNING:'.status.nodeInfo.osImage',HOLD:'.metadata.annotations.tuppr\.home-operations\.com/version'
 ```
 
-The last command is the check that matters — all nodes must report the same version.
+`getTargetVersion` still prefers a node annotation over the CR, and since the annotation is no
+longer part of machine config, Talos does not re-enforce or clear it. `kubectl annotate node
+<node> tuppr.home-operations.com/version-` releases the hold. The `HOLD` column is empty on a
+normally-managed node — a non-empty value means that node is pinned and is NOT tracking the CR.
 
 ## What is deliberately not carried
 
@@ -346,14 +352,25 @@ Two things have to be true for a node. All three nodes satisfy both as of 2026-0
    `factory.talos.dev`, tuppr's bare `<repo>:<targetVersion>` substitution silently reinstalls
    the stock kernel.
 2. **A version string tuppr will actually ask for.** It compares one value, so the node has to
-   advertise `v<talos>-k<kernel>`. `spec.talos.version` cannot carry it — that field is
-   Renovate-managed against `siderolabs/talos` and would rewrite `v1.13.9-k7.1.9` to
-   `v1.13.10`, eating the suffix. So the kernel half lives in a per-node
-   `machine.nodeAnnotations."tuppr.home-operations.com/version"`, which `getTargetVersion`
-   prefers over the CR (`upgrade.go:855`).
+   advertise `v<talos>-k<kernel>` — which it does, because the installer is built with
+   `TAG="${VERSION}"`. That string now lives in `spec.talos.version` itself.
 
-Keep the annotation per-node rather than hoisting it to a shared layer: it is what allows one
-node to move while the others stay put, which is how all three were rolled.
+   It used to live in a per-node `machine.nodeAnnotations."tuppr.home-operations.com/version"`,
+   because the CR field was Renovate-managed by an inline annotation that captures the whole
+   value and would rewrite `v1.13.9-k7.1.9` to `v1.13.10`, eating the suffix. That is a property
+   of the *manager*, not the field: two file-scoped regex managers in `.renovaterc.json5` now own
+   one half each, so the field can carry it. See `docs/tuppr-cr-version-target-plan.md`.
+
+   The annotation mattered because only `just talos apply-node` could change it, so merging a
+   bump PR rolled nothing. With the target in the CR, Flux carries it and a merge is the whole
+   procedure.
+
+To hold one node back while the rest move, use `spec.nodeSelector` on the CR — it is a full
+`LabelSelector`, so `kubernetes.io/hostname NotIn [control-1]` parks that node declaratively, in
+the same file as the version and under review like any other change. `getTargetVersion` still
+prefers a node annotation over the CR (`upgrade.go:855`) and Talos no longer owns that key, so
+`kubectl annotate node <node> tuppr.home-operations.com/version=<string>` is the imperative
+fallback when you want a hold that leaves no diff — see "Rolling a bump back".
 
 **A third thing is true for the CR.** Once a node reports `v<talos>-k<kernel>`, tuppr derives the
 talosctl job image tag from that same string and pulls
@@ -362,6 +379,7 @@ ImagePullBackOff until `policy.timeout`. Measured on control-2 on 2026-08-21. `s
 is pinned to the plain upstream version to stop it. It only bites on the *second* roll of a node,
 because the first still has an unsuffixed version at the moment the job is built.
 
-Since every node now runs a custom kernel, no node is left on stock as a fallback, and a Talos bump
-still means "re-run the build, then re-cut the nodes" — `just talos upgrade-node <node> <ip>` reads
-the pinned image straight out of the rendered config.
+Since every node now runs a custom kernel, no node is left on stock as a fallback. A Talos bump is
+merge-only: the push-to-main build publishes the installer, and tuppr rolls the fleet once the CR
+target and the published tag agree. `just talos upgrade-node <node> <ip>` remains for cutting a
+node by hand; it reads the pinned image straight out of the rendered config.

--- a/docker/talos-kernel/README.md
+++ b/docker/talos-kernel/README.md
@@ -362,15 +362,23 @@ Two things have to be true for a node. All three nodes satisfy both as of 2026-0
    one half each, so the field can carry it. See `docs/tuppr-cr-version-target-plan.md`.
 
    The annotation mattered because only `just talos apply-node` could change it, so merging a
-   bump PR rolled nothing. With the target in the CR, Flux carries it and a merge is the whole
-   procedure.
+   bump PR rolled nothing.
 
-To hold one node back while the rest move, use `spec.nodeSelector` on the CR — it is a full
-`LabelSelector`, so `kubernetes.io/hostname NotIn [control-1]` parks that node declaratively, in
-the same file as the version and under review like any other change. `getTargetVersion` still
-prefers a node annotation over the CR (`upgrade.go:855`) and Talos no longer owns that key, so
-`kubectl annotate node <node> tuppr.home-operations.com/version=<string>` is the imperative
-fallback when you want a hold that leaves no diff — see "Rolling a bump back".
+   **The switchover costs one `apply-node` per node, once.** Talos writes that annotation from
+   machine config, so it survives on a node until a config without it is applied — and
+   `getTargetVersion` keeps preferring it until then, which means the first CR bump after this
+   change still rolls nothing. Only after that cleanup does Flux carry the target and later
+   bumps become merge-only. Confirm with the `HOLD` column in "Rolling a bump back": empty on
+   every node means the CR is in charge.
+
+To hold a node back while the rest move, use `spec.nodeSelector` on the CR — `getSortedNodes`
+passes it to `LabelSelectorAsSelector` and *lists* with it (`upgrade.go:625-641`), so an excluded
+node is never enumerated as a candidate and takes no outdated taint. `kubernetes.io/hostname
+NotIn [<node>]` is the shape; the CR itself says which nodes are currently held, if any.
+
+`getTargetVersion` still prefers a node annotation over the CR (`upgrade.go:855`) and Talos no
+longer owns that key, so `kubectl annotate node <node> tuppr.home-operations.com/version=<string>`
+is the imperative fallback for a hold that leaves no diff — see "Rolling a bump back".
 
 **A third thing is true for the CR.** Once a node reports `v<talos>-k<kernel>`, tuppr derives the
 talosctl job image tag from that same string and pulls

--- a/docker/talos-kernel/README.md
+++ b/docker/talos-kernel/README.md
@@ -364,12 +364,26 @@ Two things have to be true for a node. All three nodes satisfy both as of 2026-0
    The annotation mattered because only `just talos apply-node` could change it, so merging a
    bump PR rolled nothing.
 
-   **The switchover costs one `apply-node` per node, once.** Talos writes that annotation from
-   machine config, so it survives on a node until a config without it is applied — and
-   `getTargetVersion` keeps preferring it until then, which means the first CR bump after this
-   change still rolls nothing. Only after that cleanup does Flux carry the target and later
-   bumps become merge-only. Confirm with the `HOLD` column in "Rolling a bump back": empty on
-   every node means the CR is in charge.
+   **The switchover costs one `apply-node` per node, once, and the order matters.** Talos writes
+   that annotation from machine config, so it survives until a config without it is applied, and
+   `getTargetVersion` prefers it until then.
+
+   Do the `apply-node` runs **before** merging the version bump, not after. On a `Completed` CR
+   every node is already listed in `Status.CompletedNodes`, and `findNextNodes` skips anything in
+   that list *before* it compares versions (`upgrade.go:582-587`) — so dropping an annotation
+   while the CR is `Completed` is inert, and stays inert forever. Merging afterwards bumps the
+   generation, which clears `CompletedNodes` (`annotations.go:559-585`) and makes the freshly
+   un-annotated nodes pending on the next reconcile.
+
+   Merge first and the reverse happens, silently: `recordOutOfBandCompletedNodes`
+   (`upgrade.go:507-560`) writes every node that does not "need" an upgrade — which is all of
+   them, since each still reports its own annotation — straight into `CompletedNodes` at the new
+   target, and the CR goes `Completed` for a version nothing runs. The later `apply-node` is then
+   skipped by the list check above and nothing ever rolls. Recovering needs
+   `kubectl annotate talosupgrade talos tuppr.home-operations.com/reset=1`.
+
+   Confirm with the `HOLD` column in "Rolling a bump back": empty on every node means the CR is
+   in charge.
 
 To hold a node back while the rest move, use `spec.nodeSelector` on the CR — `getSortedNodes`
 passes it to `LabelSelectorAsSelector` and *lists* with it (`upgrade.go:625-641`), so an excluded

--- a/docs/tuppr-cr-version-target-plan.md
+++ b/docs/tuppr-cr-version-target-plan.md
@@ -57,8 +57,8 @@ Everything below was checked against source at tuppr 0.5.2, not assumed.
 | Outdated nodes carry a taint while parked | `upgrade.go:606-608` + `nodes.go:68-89`, `PreferNoSchedule` |
 | `flate.yaml` would break | `.github/workflows/flate.yaml:124` reads `.spec.talos.version` into a `releases/download/${TALOS_VERSION}` URL — a `-k` suffix 404s |
 | `talosctl.image.tag` must stay plain | `jobs.go:559-568` uses the tag verbatim when set |
-| The talos group would capture the new manager | `.renovaterc.json5:139-144` groups any `siderolabs/*` on `docker`/`github-releases` |
-| `versioning: loose` already applies to the kernel datasource | `.renovaterc.json5:259-264` keys off `matchDatasources: ["custom.linux-kernel"]` |
+| The talos group would capture the new manager | `.renovaterc.json5:167-177` groups any `siderolabs/*` on `docker`/`github-releases` |
+| `versioning: loose` already applies to the kernel datasource | `.renovaterc.json5:291-298` keys off `matchDatasources: ["custom.linux-kernel"]` |
 | Nothing else reads the annotation | grep: only the three node templates and the README |
 | 0.5.3 changes nothing relied on here | its only controller change is a `ghcr.io/siderolabs/installer` → Image Factory redirect, which never matches `ghcr.io/tanguille/installer/*` |
 

--- a/docs/tuppr-cr-version-target-plan.md
+++ b/docs/tuppr-cr-version-target-plan.md
@@ -1,0 +1,282 @@
+# Make Talos + kernel bumps merge-and-forget
+
+**Branch:** `feat/tuppr-cr-version-target`
+**Worktree:** `.claude/worktrees/tuppr-cr-version`
+
+Goal: get back the property plain tuppr had before the custom kernel — a
+Renovate PR lands, you merge it, the fleet rolls itself. Today a bump costs a
+manual pre-merge workflow dispatch, a ~90 min watch, and then `apply-node` on
+every node from a workstation holding the age key.
+
+## Why merging does nothing today
+
+The target version tuppr compares against does not live in git-synced cluster
+state. It lives in each node's machine config:
+
+```yaml
+# talos/nodes/controlplane/control-3.yaml.j2
+nodeAnnotations:
+  tuppr.home-operations.com/version: {{ pinned }}
+```
+
+That annotation only reaches a node through `just talos apply-node`, and
+`getTargetVersion` prefers it over `spec.talos.version`. So merging a CR bump
+changes nothing a node can see, and `docker/talos-kernel/README.md` "The
+rollout is not self-closing" correctly ends the procedure with three manual
+`just talos upgrade-node <node> <ip>` calls.
+
+Automating the build alone does not fix this. The version has to move into the
+CR.
+
+### Why it was put in the annotation
+
+`docker/talos-kernel/README.md` states the blocker plainly:
+
+> `spec.talos.version` cannot carry it — that field is Renovate-managed against
+> `siderolabs/talos` and would rewrite `v1.13.9-k7.1.9` to `v1.13.10`, eating
+> the suffix.
+
+That is correct for the *annotation-style* manager it uses today. It is not a
+property of the field. Two file-scoped regex custom managers can each own one
+half of the string.
+
+## Verified before writing this
+
+Everything below was checked against source at tuppr 0.5.2, not assumed.
+
+| Claim | Evidence |
+|---|---|
+| `prePull` defaults on | `talosupgrade_types.go:21` `+kubebuilder:default=true` |
+| A missing installer parks the run, it does not fail it | `prepull.go:133` sets `JobPhasePending` / `ReasonPrePullFailed`; requeue `prePullFailureBackoff` = 1m doubling, capped 5m at `attempts >= 4`. No attempt cap, no transition to `Failed` |
+| Terminal `Failed` is a different path | `upgrade.go:64` — real upgrade failures, cleared by `constants.ResetAnnotation` (`annotations.go:48`). Does not apply to pre-pull |
+| The CRD and the webhook accept the suffix | `talosupgrade_types.go:13` pattern `^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9\-\.]+)?$`; `webhook.go:80` / `validation.go:120` use the same pattern, so Flux's apply is not rejected |
+| The annotation outranks the CR | `upgrade.go:855` `getTargetVersion` |
+| A generation change re-arms completed nodes | `upgrade.go:583` `findNextNodes` skips `Status.CompletedNodes`; `annotations.go:97-105` resets it on generation change |
+| **Cordoning does not hold a node back** | `findNextNodes` (`upgrade.go:566-621`) contains no `Unschedulable` or `Spec.Taints` check — verified by grep. tuppr cordons and drains itself |
+| **Reverting `install.image`'s tag does not hold a node back** | `buildTalosUpgradeImage` (`upgrade.go:820,851`) keeps only the repo and substitutes the target tag |
+| Outdated nodes carry a taint while parked | `upgrade.go:606-608` + `nodes.go:68-89`, `PreferNoSchedule` |
+| `flate.yaml` would break | `.github/workflows/flate.yaml:124` reads `.spec.talos.version` into a `releases/download/${TALOS_VERSION}` URL — a `-k` suffix 404s |
+| `talosctl.image.tag` must stay plain | `jobs.go:559-568` uses the tag verbatim when set |
+| The talos group would capture the new manager | `.renovaterc.json5:139-144` groups any `siderolabs/*` on `docker`/`github-releases` |
+| `versioning: loose` already applies to the kernel datasource | `.renovaterc.json5:259-264` keys off `matchDatasources: ["custom.linux-kernel"]` |
+| Nothing else reads the annotation | grep: only the three node templates and the README |
+| 0.5.3 changes nothing relied on here | its only controller change is a `ghcr.io/siderolabs/installer` → Image Factory redirect, which never matches `ghcr.io/tanguille/installer/*` |
+
+Deployed tuppr is **0.5.2** (`app/ocirepository.yaml:13`).
+
+## The one trade-off to decide first
+
+`docker/talos-kernel/README.md` argues the annotation is per-node **on
+purpose**:
+
+> Keep the annotation per-node rather than hoisting it to a shared layer: it is
+> what allows one node to move while the others stay put, which is how all
+> three were rolled.
+
+Moving to the CR gives that up as the *default*. control-1 is the outlier —
+TrueNAS VM, only dGPU host, its own schematic and installer repo, hypervisor
+reset history — so this is a real loss.
+
+**The hold you get back (and it is cheap).** `getTargetVersion` still prefers a
+node annotation, and after Step 1 Talos no longer owns that key, so a manually
+set one is not reverted:
+
+```sh
+kubectl annotate node control-1 tuppr.home-operations.com/version=<current string>   # hold
+kubectl annotate node control-1 tuppr.home-operations.com/version-                   # release
+```
+
+Zero diff, no CR generation change. Confirm on one node before relying on it.
+
+Do **not** reach for cordoning or reverting `install.image` — both are verified
+above to be ignored by tuppr, and a repo revert to `factory.talos.dev` silently
+reinstalls the stock kernel.
+
+If per-node staging by default still matters more than merge-and-forget, stop
+here: Step 4 (the Renovate annotation gap) is already shipped and is worth
+having regardless.
+
+## Steps
+
+### Step 1: one atomic PR — managers, CR, consumers, templates
+
+These **cannot** be separate merges. Flux applies main immediately and
+`talosupgrade.yaml` is already a build trigger path, so every intermediate
+state is live and broken:
+
+- CR moved but `.justfile` not: `template` renders
+  `pinned=v1.14.0-k7.1.13-k7.1.13` (`.justfile:49` concatenates), and any
+  `apply-node` in that window writes a nonexistent `install.image`.
+- CR moved but build script not: `talos/mod.just:144` passes the full string as
+  `$1`, so `talos-kernel-build.sh:31` runs `git clone --branch v1.14.0-k7.1.13`
+  and fails.
+- CR moved but `flate.yaml` not: 404 on every container PR.
+- Managers alone are a no-op — both regexes require `-k`, which the CR lacks
+  until it moves.
+
+**1a. `.renovaterc.json5` — two `customManagers`:**
+
+```json5
+{
+  description: "tuppr target v<talos>-k<kernel>: Talos half",
+  customType: "regex",
+  managerFilePatterns: ["/tuppr/upgrades/talosupgrade\\.yaml$/"],
+  matchStrings: ["version:\\s+(?<currentValue>v\\d+\\.\\d+\\.\\d+)-k"],
+  depNameTemplate: "siderolabs/talos",
+  datasourceTemplate: "github-releases"
+},
+{
+  description: "tuppr target v<talos>-k<kernel>: kernel half",
+  customType: "regex",
+  managerFilePatterns: ["/tuppr/upgrades/talosupgrade\\.yaml$/"],
+  matchStrings: ["-k(?<currentValue>\\d+\\.\\d+(?:\\.\\d+)?)"],
+  depNameTemplate: "linux",
+  datasourceTemplate: "custom.linux-kernel"
+}
+```
+
+The kernel regex deliberately does **not** anchor on the Talos prefix. Renovate
+auto-replace does `replaceString.replace(escape(currentValue), newValue)` —
+first occurrence, non-global — over the whole matched span. With a span of
+`version: v1.17.3-k7.3` and a bare-series `currentValue` of `7.3` (the `loose`
+case this repo explicitly plans for), the first occurrence of `7.3` is inside
+`v1.17.3`, and Renovate would corrupt the Talos half. A span of `-k7.3` has
+exactly one occurrence and cannot mismatch.
+
+The Talos half is safe as written: span `version: v1.14.0-k`, currentValue
+`v1.14.0`, suffix untouched.
+
+Both regexes are RE2-safe (`(?<name>)`, `(?:)`, `\d`, `\s` only) — local
+renovate falls back to JS RegExp and will not catch a violation the hosted run
+rejects.
+
+The two managers extract two deps into two branches; no conflict inside
+Renovate, and Renovate rebases the second after the first merges. `depName:
+linux` is the same dep as the Dockerfile `ARG`, so both files land in one
+branch — which is exactly what the guard in 1c relies on.
+
+**1b. `talosupgrade.yaml`:**
+
+- `spec.talos.version` → `v1.14.0-k7.1.13`.
+- Delete the `# renovate:` annotation above it; 1a owns it now. Leaving both
+  means two managers fighting over one line.
+- Break the `&talosVersion` anchor. `talosctl.image.tag` stays the **plain**
+  upstream tag with its own
+  `# renovate: datasource=github-releases depName=siderolabs/talos` —
+  siderolabs never publishes `talosctl:v1.14.0-k7.1.13`, and the README records
+  that ImagePullBackOff measured on control-2 on 2026-08-21.
+
+**1c. consumers:**
+
+- `.github/workflows/flate.yaml:124` → read `.spec.talosctl.image.tag`.
+- `scripts/talos-kernel-build.sh:10` takes the full string and splits it:
+
+  ```bash
+  VERSION="${1:?usage: talos-kernel-build.sh <version> <node>...}"
+  TALOS_VERSION="${VERSION%-k*}"
+  KERNEL_VERSION="$(just kernel-version)"
+  [[ "${VERSION#*-k}" == "${KERNEL_VERSION}" ]] || {
+      echo "CR names k${VERSION#*-k}, Dockerfile builds ${KERNEL_VERSION}" >&2; exit 1; }
+  ```
+
+- `.justfile` `template`: `pinned` becomes `just tuppr-version talos` verbatim,
+  no concatenation — this also closes the "`pinned` derived in two places"
+  duplication. Add the same guard here, because `pinned` now comes from the CR
+  while `kernelVersion` still comes from the Dockerfile ARG:
+
+  ```bash
+  [[ "${talos_version#*-k}" == "${kernel_version}" ]] || { echo "..." >&2; exit 1; }
+  ```
+
+  A half-merged tree then fails to render instead of pinning a node to a tag
+  whose contents differ from what the `kernelVersion` comment claims.
+
+**1d. node templates:** delete the `nodeAnnotations` block from all three
+`talos/nodes/controlplane/control-{1,2,3}.yaml.j2`. Keep `install.image` on
+`{{ pinned }}` — tuppr discards the tag and reuses the repo, but the stored
+value still drives `just talos upgrade-node` and any fresh install.
+
+**Verify before merging:** `just talos render-config control-{1,2,3}` all yield
+`v1.14.0-k7.1.13` and pass `talosctl validate -m metal`; a Renovate dry-run
+shows *two* separate updates against `talosupgrade.yaml` and rewrites neither
+half wrongly (needs node 24 + a GH token, or it reads as "dep not detected" and
+tells you nothing); `flux diff kustomization cluster-apps`.
+
+### Step 2: the last manual `apply-node`
+
+Talos re-enforces node annotations from machine config, so until the config
+without it is applied, the stale annotation keeps outranking the CR. Three
+`apply-node` runs, once, to never do it again.
+
+**Verify:**
+`kubectl get nodes -o custom-columns=NAME:.metadata.name,V:.metadata.annotations.tuppr\.home-operations\.com/version`
+shows the column empty for all three.
+
+### Step 3: retire the pre-merge dispatch
+
+`.github/workflows/talos-kernel.yaml` keeps `push: branches: [main]` — that is
+now the whole mechanism. Keep `workflow_dispatch` as an escape hatch for when
+you *want* the window closed (the held 7.2.x PR when Cilium ships the fix).
+
+**Do not add `.justfile`, `talos/mod.just` or `talos/nodes/**/*.yaml.j2` to
+`paths:`.** Every unrelated edit there would start a ~2h run that re-pushes
+`kernel:`, `imager:`, `installer-base:` and the installers under the *same*
+tags, with a freshly generated module signing key in the amdgpu extension —
+contradicting the README's "tags are never reused" property — and
+`cancel-in-progress` would abort a real version build in flight. Instead add a
+`crane manifest` existence check at the top of the build script that exits 0
+when the installer tag already exists. That also makes the Step 1 merge and any
+rerun idempotent.
+
+Rewrite `docker/talos-kernel/README.md` "Per-bump maintenance" and "The rollout
+is not self-closing": the procedure becomes "merge the PR", plus a note that the
+CR sits in `Pending`/`PrePullFailed` for ~2h until the build publishes, and that
+Warning events every 5m in that window are expected.
+
+**Add a parked-state alert.** Pre-pull retries forever at 5m and never reaches
+`Failed`, and outdated nodes carry the `PreferNoSchedule` taint the whole time.
+A failed build therefore leaves the fleet quietly degraded. A Prometheus rule on
+phase `Pending` / reason `PrePullFailed` lasting > 4h is what keeps
+merge-and-forget from becoming merge-and-never-notice.
+
+### Step 4: Renovate gap on `kubernetesupgrade.yaml`
+
+Already shipped on `feat/talos-1.14.0-k7.1.13` (commit e6e042c3f). Listed for
+completeness; nothing to do if that branch merged.
+
+## Fresh installs still work
+
+No annotation → `getTargetVersion` returns the CR value; the node reports
+`v<talos>-k<kernel>` because the installer is built with `TAG="${VERSION}"`;
+`install.image` stays on `{{ pinned }}`.
+
+## Rollback
+
+Reverting the PR is a **live downgrade command**, not a no-op: the CR goes back
+to the older string and tuppr issues `talosctl upgrade` to the older tag on
+every node, one at a time. The older installer tag is still published — tags in
+`ghcr.io/tanguille/installer/*` are never reused.
+
+Fine for a kernel-only revert. For a Talos *minor* revert, suspend the CR
+(`handleSuspendAnnotation`) first and decide deliberately whether the
+Kubernetes and CNPG state on the nodes tolerates going backwards.
+
+## The hold still works
+
+7.2.x stays an open, unmerged Renovate PR. Nothing builds and nothing rolls
+until it is merged. Do not switch to `allowedVersions: <7.2` — the README
+explains it empties the feed once 7.1 leaves `moniker=stable` and bumps stop
+silently.
+
+## Process Instructions
+
+- After completing each step, update the plan with the current status.
+- Pause for user confirmation before proceeding to next step.
+- Suggest the prompt for continuing to the next step.
+- After the last step, make a final documentation pass. Once the contents of the
+  plan have been consolidated into existing documentation, the plan file can be
+  removed. If there is no relevant existing documentation, the plan should be
+  reworked into a reference document.
+
+**Important**: Every prompt should verify the branch and worktree before doing
+any work.

--- a/docs/tuppr-cr-version-target-plan.md
+++ b/docs/tuppr-cr-version-target-plan.md
@@ -112,30 +112,40 @@ having regardless.
 
 ## Steps
 
-### Step 1: one atomic PR — managers, CR, consumers, templates — **DONE** (e37104552)
+### Step 1: one atomic PR — managers, CR, consumers, templates — **DONE** (PR #4855)
 
-Shipped on `feat/tuppr-cr-version-target`, stacked on `feat/talos-1.14.0-k7.1.13`
-so the CR can name `v1.14.0-k7.1.13` directly and the merge is a live test of
-the new path rather than a no-op.
+Shipped on `feat/tuppr-cr-version-target`, originally stacked on
+`feat/talos-1.14.0-k7.1.13` (merged as #4856) and since rebased onto main, so
+the CR names `v1.14.0-k7.1.13` directly.
 
-Two deviations from the text below, both deliberate:
+Deviations from the text below, all deliberate:
 
 - The Talos-half regex gained `(?:-[a-z]+\.\d+)?` so it also matches a
   prerelease pin (`v1.14.0-rc.2-k7.1.10`, which is what the fleet ran when this
   was written). Without it the manager silently matches nothing on an rc.
-- The `-k` guard was added to `.justfile` `template` as well as the build
-  script, so a half-applied tree fails to *render*, not just to build.
+- The `-k` guard is in the build script only. It was briefly in `.justfile`
+  `template` too, then removed: `kernelVersion` has one consumer (a comment in
+  `control-2.yaml.j2`), so `template` derives it from the CR value instead and
+  there is nothing left to reconcile.
+- The kernel regex is unanchored (`-k<version>`, not `version:\s+…-k<version>`)
+  and the CR's comments therefore must not contain a literal `-k<digits>`.
 
 Verified: all three nodes render and pass `talosctl validate -m metal`; no
-`tuppr` string survives in any rendered config; the guard fires
-(`tuppr CR names k7.1.13, Dockerfile builds 7.1.99`); `.renovaterc.json5` parses
-and registers both managers; and the first-occurrence replacement semantics were
-simulated against both regexes — the un-narrowed kernel regex turns
-`v1.17.3-k7.3` into `v1.17.4-k7.3`, the shipped one into `v1.17.3-k7.4`.
+`tuppr` string survives in any rendered config; `.renovaterc.json5` parses and
+registers both managers; server-side dry-run accepts the CR.
 
-Still outstanding for this step: a Renovate dry-run against the real config
-(needs node 24 + a GH token). The repo's own validator false-flags
-`managerFilePatterns`, so a clean validator run is not the bar.
+Renovate dry-run **done**, on node 24.19.0 (renovate's bundled RE2 will not load
+on node 26 — `Unsupported node environment`):
+
+| dep | currentValue | replaceString | update |
+|---|---|---|---|
+| `linux` | `7.1.13` | `-k7.1.13` | 7.2.3, `renovate/linux-7.x` |
+| `siderolabs/talos` | `v1.14.0` | `version: v1.14.0-k` | none (latest) |
+
+One dep per manager. The first run extracted **three** `linux` deps, because two
+comments in the CR carried literal example versions — fixed by switching them to
+placeholders. The repo's own validator false-flags `managerFilePatterns`, so a
+clean validator run is not the bar; the dry-run is.
 
 These **cannot** be separate merges. Flux applies main immediately and
 `talosupgrade.yaml` is already a build trigger path, so every intermediate
@@ -173,15 +183,17 @@ state is live and broken:
 ```
 
 The kernel regex deliberately does **not** anchor on the Talos prefix. Renovate
-auto-replace does `replaceString.replace(escape(currentValue), newValue)` —
-first occurrence, non-global — over the whole matched span. With a span of
-`version: v1.17.3-k7.3` and a bare-series `currentValue` of `7.3` (the `loose`
-case this repo explicitly plans for), the first occurrence of `7.3` is inside
-`v1.17.3`, and Renovate would corrupt the Talos half. A span of `-k7.3` has
-exactly one occurrence and cannot mismatch.
+rewrites `currentValue` within the matched span, so the span must contain the
+kernel version and nothing else shaped like it. A span of `version: v1.17.3-k7.3`
+with a bare-series `currentValue` of `7.3` (the `loose` case this repo explicitly
+plans for) also contains `7.3` inside `v1.17.3`; a span of `-k7.3` does not.
 
 The Talos half is safe as written: span `version: v1.14.0-k`, currentValue
-`v1.14.0`, suffix untouched.
+`v1.14.0`, kernel suffix outside the span.
+
+The cost of unanchoring is that any literal `-k<digits>` in the file is extracted
+as its own dep — the first dry-run found three, from example versions in
+comments. Hence the placeholder rule stated in the CR.
 
 Both regexes are RE2-safe (`(?<name>)`, `(?:)`, `\d`, `\s` only) — local
 renovate falls back to JS RegExp and will not catch a violation the hosted run
@@ -239,15 +251,34 @@ shows *two* separate updates against `talosupgrade.yaml` and rewrites neither
 half wrongly (needs node 24 + a GH token, or it reads as "dep not detected" and
 tells you nothing); `flux diff kustomization cluster-apps`.
 
-### Step 2: the last manual `apply-node`
+### Step 2: the last manual `apply-node` — **run it BEFORE merging Step 1**
 
 Talos re-enforces node annotations from machine config, so until the config
-without it is applied, the stale annotation keeps outranking the CR. Three
-`apply-node` runs, once, to never do it again.
+without it is applied, the stale annotation keeps outranking the CR. Two
+`apply-node` runs (control-1 is held), once, to never do it again.
 
-**Verify:**
+The order is load-bearing and the wrong one fails silently:
+
+- **Right:** `apply-node` while the CR is `Completed`. Every node is already in
+  `Status.CompletedNodes`, and `findNextNodes` skips that list *before*
+  comparing versions (`upgrade.go:582-587`), so removing the annotation changes
+  nothing yet. Then merge Step 1 — the generation bump clears `CompletedNodes`
+  (`annotations.go:559-585`), both nodes come up pending, tuppr pre-pulls and
+  rolls them. The merge is the trigger, which is the property this plan is for.
+- **Wrong:** merge first. `recordOutOfBandCompletedNodes` (`upgrade.go:507-560`)
+  writes every node that does not need an upgrade — all of them, each still
+  reporting its own annotation — into `CompletedNodes` at the new target, and
+  the CR reports `Completed` for a version nothing runs. The later `apply-node`
+  is then skipped by that same list check, permanently. Recovery is
+  `kubectl annotate talosupgrade talos tuppr.home-operations.com/reset=1`.
+
+This already happened once: after #4856 merged, the CR sat `Completed` with
+`completedNodes: [control-3, control-1, control-2]` at `v1.14.0` while all three
+nodes ran `v1.14.0-rc.2-k7.1.10`.
+
+**Verify before merging Step 1:**
 `kubectl get nodes -o custom-columns=NAME:.metadata.name,V:.metadata.annotations.tuppr\.home-operations\.com/version`
-shows the column empty for all three.
+shows the column empty for control-2 and control-3.
 
 ### Step 3: retire the pre-merge dispatch
 

--- a/docs/tuppr-cr-version-target-plan.md
+++ b/docs/tuppr-cr-version-target-plan.md
@@ -77,20 +77,34 @@ Moving to the CR gives that up as the *default*. control-1 is the outlier —
 TrueNAS VM, only dGPU host, its own schematic and installer repo, hypervisor
 reset history — so this is a real loss.
 
-**The hold you get back (and it is cheap).** `getTargetVersion` still prefers a
-node annotation, and after Step 1 Talos no longer owns that key, so a manually
-set one is not reverted:
+**The hold you get back is declarative, in the same file as the version.** The
+CRD has `spec.nodeSelector` (a full `LabelSelector` — confirmed present on the
+deployed CRD, alongside `drain`, `maintenance`, `parallelism`, `silences`):
 
-```sh
-kubectl annotate node control-1 tuppr.home-operations.com/version=<current string>   # hold
-kubectl annotate node control-1 tuppr.home-operations.com/version-                   # release
+```yaml
+  nodeSelector:
+    matchExpressions:
+      - key: kubernetes.io/hostname
+        operator: NotIn
+        values: ["control-1"]
 ```
 
-Zero diff, no CR generation change. Confirm on one node before relying on it.
+Flux-applied, reviewable, revertible, no age key and no `apply-node` — the
+per-node hold the README argued for, moved to the CR layer rather than lost.
+Verify it against `findNextNodes` before relying on it.
+
+The imperative fallback, if you want a hold that leaves no diff:
+`getTargetVersion` still prefers a node annotation, and after Step 1 Talos no
+longer owns that key, so `kubectl annotate node control-1
+tuppr.home-operations.com/version=<current string>` pins it and `...version-`
+releases it.
 
 Do **not** reach for cordoning or reverting `install.image` — both are verified
 above to be ignored by tuppr, and a repo revert to `factory.talos.dev` silently
 reinstalls the stock kernel.
+
+`spec.maintenance.windows` is the declarative answer to "keep the window
+closed", which Step 3 currently leaves to `workflow_dispatch`.
 
 If per-node staging by default still matters more than merge-and-forget, stop
 here: Step 4 (the Renovate annotation gap) is already shipped and is worth

--- a/docs/tuppr-cr-version-target-plan.md
+++ b/docs/tuppr-cr-version-target-plan.md
@@ -98,7 +98,30 @@ having regardless.
 
 ## Steps
 
-### Step 1: one atomic PR — managers, CR, consumers, templates
+### Step 1: one atomic PR — managers, CR, consumers, templates — **DONE** (e37104552)
+
+Shipped on `feat/tuppr-cr-version-target`, stacked on `feat/talos-1.14.0-k7.1.13`
+so the CR can name `v1.14.0-k7.1.13` directly and the merge is a live test of
+the new path rather than a no-op.
+
+Two deviations from the text below, both deliberate:
+
+- The Talos-half regex gained `(?:-[a-z]+\.\d+)?` so it also matches a
+  prerelease pin (`v1.14.0-rc.2-k7.1.10`, which is what the fleet ran when this
+  was written). Without it the manager silently matches nothing on an rc.
+- The `-k` guard was added to `.justfile` `template` as well as the build
+  script, so a half-applied tree fails to *render*, not just to build.
+
+Verified: all three nodes render and pass `talosctl validate -m metal`; no
+`tuppr` string survives in any rendered config; the guard fires
+(`tuppr CR names k7.1.13, Dockerfile builds 7.1.99`); `.renovaterc.json5` parses
+and registers both managers; and the first-occurrence replacement semantics were
+simulated against both regexes — the un-narrowed kernel regex turns
+`v1.17.3-k7.3` into `v1.17.4-k7.3`, the shipped one into `v1.17.3-k7.4`.
+
+Still outstanding for this step: a Renovate dry-run against the real config
+(needs node 24 + a GH token). The repo's own validator false-flags
+`managerFilePatterns`, so a clean validator run is not the bar.
 
 These **cannot** be separate merges. Flux applies main immediately and
 `talosupgrade.yaml` is already a build trigger path, so every intermediate

--- a/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
@@ -6,34 +6,21 @@ metadata:
   name: talos
 spec:
   talos:
-    # v<talos>-k<kernel>: the string a node built from docker/talos-kernel actually reports, and
-    # the only thing tuppr compares (plain inequality). The kernel half has to be IN here or a
-    # kernel-only bump is invisible; it used to live in a per-node machine.nodeAnnotations, which
-    # only `just talos apply-node` could change -- so merging a PR rolled nothing.
-    # Both halves are Renovate-managed, by the two regex customManagers in .renovaterc.json5 and
-    # NOT by an inline annotation: the annotation manager captures the whole value and reads the
-    # -k suffix as a semver prerelease, rewriting the whole thing and eating the kernel half.
-    # Still not ghcr.io/siderolabs/installer either: publication of that image stopped partway
-    # through the v1.14 cycle once Image Factory became the default, so a docker datasource
-    # would silently freeze at the last tag it ever saw.
-    #
-    # NEVER write a literal -k<digits> anywhere else in this file, comments included. The kernel
-    # manager matches "-k<version>" unanchored (it has to; see .renovaterc.json5), so every such
-    # string in this file is extracted as its own dep and becomes something Renovate edits. A
-    # local dry-run on 2026-09-03 pulled three `linux` deps out of this one file, from two
-    # comments carrying example versions; only the field below should ever be one.
+    # The version a node built from docker/talos-kernel reports, and the only value tuppr
+    # compares. Renovate-managed by the two regex managers in .renovaterc.json5, one per half;
+    # an inline annotation reads -k7.1.13 as a prerelease and eats the kernel half.
+    # NEVER write another literal -k<digits> in this file, comments included: the kernel manager
+    # is unanchored, so each one is extracted as its own dep. A dry-run found three.
     version: v1.14.0-k7.1.13
   talosctl:
     image:
-      # The PLAIN upstream tag, never the -k<kernel> one: siderolabs publishes no
-      # talosctl:v<talos>-k<kernel> and the job ImagePullBackOffs until policy.timeout
-      # (measured on control-2, 2026-08-21). No longer aliased to the field above -- that field
-      # now carries the kernel suffix, which is exactly what must not reach this one.
+      # Plain upstream tag. A -k<kernel> one is unpublished and the job ImagePullBackOffs until
+      # policy.timeout (control-2, 2026-08-21). Not aliased to the field above any more.
       # renovate: datasource=github-releases depName=siderolabs/talos
       tag: v1.14.0
   # HOLD: control-1 moves by hand -- TrueNAS VM, only dGPU host, hypervisor-reset history.
-  # Excluded nodes are never enumerated as candidates, so they also take no outdated taint
-  # (getSortedNodes lists with this selector, upgrade.go:625-641). Delete the block to release.
+  # Excluded nodes are never enumerated, so they take no outdated taint either
+  # (getSortedNodes, upgrade.go:625-641). Delete the block to release.
   nodeSelector:
     matchExpressions:
       - key: kubernetes.io/hostname

--- a/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
@@ -6,16 +6,25 @@ metadata:
   name: talos
 spec:
   talos:
-    # Tracks the Talos release, not ghcr.io/siderolabs/installer: publication of that image
-    # stopped partway through the v1.14 cycle (alpha.0 still had it) once Image Factory became
-    # the default, so a docker datasource would silently freeze at the last tag it ever saw.
-    # renovate: datasource=github-releases depName=siderolabs/talos
-    version: &talosVersion v1.14.0
+    # v<talos>-k<kernel>: the string a node built from docker/talos-kernel actually reports, and
+    # the only thing tuppr compares (plain inequality). The kernel half has to be IN here or a
+    # kernel-only bump is invisible; it used to live in a per-node machine.nodeAnnotations, which
+    # only `just talos apply-node` could change -- so merging a PR rolled nothing.
+    # Both halves are Renovate-managed, by the two regex customManagers in .renovaterc.json5 and
+    # NOT by an inline annotation: the annotation manager captures the whole value and reads the
+    # -k suffix as a semver prerelease, rewriting v1.14.0-k7.1.13 to v1.14.0 and eating it.
+    # Still not ghcr.io/siderolabs/installer either: publication of that image stopped partway
+    # through the v1.14 cycle once Image Factory became the default, so a docker datasource
+    # would silently freeze at the last tag it ever saw.
+    version: v1.14.0-k7.1.13
   talosctl:
     image:
-      # Unset, tuppr derives this from the node's CURRENT version; a -k<kernel> one is unpublished
-      # and the job ImagePullBackOffs. Aliased so the two cannot drift.
-      tag: *talosVersion
+      # The PLAIN upstream tag, never the -k<kernel> one: siderolabs publishes no
+      # talosctl:v1.14.0-k7.1.13 and the job ImagePullBackOffs until policy.timeout
+      # (measured on control-2, 2026-08-21). No longer aliased to the field above -- that field
+      # now carries the kernel suffix, which is exactly what must not reach this one.
+      # renovate: datasource=github-releases depName=siderolabs/talos
+      tag: v1.14.0
   policy:
     rebootMode: powercycle
   healthChecks:

--- a/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
@@ -18,10 +18,10 @@ spec:
     # would silently freeze at the last tag it ever saw.
     #
     # NEVER write a literal -k<digits> anywhere else in this file, comments included. The kernel
-    # manager matches "-k<version>" unanchored (it has to; see .renovaterc.json5) and Renovate
-    # rewrites the FIRST occurrence in the file -- a version-shaped example in a comment above
-    # this line silently absorbs the bump and leaves the field below untouched. Caught by a
-    # local dry-run on 2026-09-03, which extracted three `linux` deps from this one file.
+    # manager matches "-k<version>" unanchored (it has to; see .renovaterc.json5), so every such
+    # string in this file is extracted as its own dep and becomes something Renovate edits. A
+    # local dry-run on 2026-09-03 pulled three `linux` deps out of this one file, from two
+    # comments carrying example versions; only the field below should ever be one.
     version: v1.14.0-k7.1.13
   talosctl:
     image:

--- a/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
@@ -12,15 +12,21 @@ spec:
     # only `just talos apply-node` could change -- so merging a PR rolled nothing.
     # Both halves are Renovate-managed, by the two regex customManagers in .renovaterc.json5 and
     # NOT by an inline annotation: the annotation manager captures the whole value and reads the
-    # -k suffix as a semver prerelease, rewriting v1.14.0-k7.1.13 to v1.14.0 and eating it.
+    # -k suffix as a semver prerelease, rewriting the whole thing and eating the kernel half.
     # Still not ghcr.io/siderolabs/installer either: publication of that image stopped partway
     # through the v1.14 cycle once Image Factory became the default, so a docker datasource
     # would silently freeze at the last tag it ever saw.
+    #
+    # NEVER write a literal -k<digits> anywhere else in this file, comments included. The kernel
+    # manager matches "-k<version>" unanchored (it has to; see .renovaterc.json5) and Renovate
+    # rewrites the FIRST occurrence in the file -- a version-shaped example in a comment above
+    # this line silently absorbs the bump and leaves the field below untouched. Caught by a
+    # local dry-run on 2026-09-03, which extracted three `linux` deps from this one file.
     version: v1.14.0-k7.1.13
   talosctl:
     image:
       # The PLAIN upstream tag, never the -k<kernel> one: siderolabs publishes no
-      # talosctl:v1.14.0-k7.1.13 and the job ImagePullBackOffs until policy.timeout
+      # talosctl:v<talos>-k<kernel> and the job ImagePullBackOffs until policy.timeout
       # (measured on control-2, 2026-08-21). No longer aliased to the field above -- that field
       # now carries the kernel suffix, which is exactly what must not reach this one.
       # renovate: datasource=github-releases depName=siderolabs/talos

--- a/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
@@ -31,12 +31,9 @@ spec:
       # now carries the kernel suffix, which is exactly what must not reach this one.
       # renovate: datasource=github-releases depName=siderolabs/talos
       tag: v1.14.0
-  # HOLD: control-1 is excluded from this rollout. getSortedNodes passes this straight to
-  # LabelSelectorAsSelector and lists with it (upgrade.go:625-641), so an excluded node is never
-  # a candidate at all -- not skipped late, never enumerated, so it takes no outdated taint
-  # either. It is the TrueNAS VM, the only dGPU host, and the one with the hypervisor-reset
-  # history, so it is the node to move by hand after watching the other two.
-  # Delete this block to release the hold; it is the whole diff, in the same file as the version.
+  # HOLD: control-1 moves by hand -- TrueNAS VM, only dGPU host, hypervisor-reset history.
+  # Excluded nodes are never enumerated as candidates, so they also take no outdated taint
+  # (getSortedNodes lists with this selector, upgrade.go:625-641). Delete the block to release.
   nodeSelector:
     matchExpressions:
       - key: kubernetes.io/hostname

--- a/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
@@ -31,6 +31,17 @@ spec:
       # now carries the kernel suffix, which is exactly what must not reach this one.
       # renovate: datasource=github-releases depName=siderolabs/talos
       tag: v1.14.0
+  # HOLD: control-1 is excluded from this rollout. getSortedNodes passes this straight to
+  # LabelSelectorAsSelector and lists with it (upgrade.go:625-641), so an excluded node is never
+  # a candidate at all -- not skipped late, never enumerated, so it takes no outdated taint
+  # either. It is the TrueNAS VM, the only dGPU host, and the one with the hypervisor-reset
+  # history, so it is the node to move by hand after watching the other two.
+  # Delete this block to release the hold; it is the whole diff, in the same file as the version.
+  nodeSelector:
+    matchExpressions:
+      - key: kubernetes.io/hostname
+        operator: NotIn
+        values: ["control-1"]
   policy:
     rebootMode: powercycle
   healthChecks:

--- a/scripts/talos-kernel-build.sh
+++ b/scripts/talos-kernel-build.sh
@@ -7,8 +7,12 @@
 # can drift from the release being built. See docker/talos-kernel/README.md.
 set -euo pipefail
 
-TALOS_VERSION="${1:?usage: talos-kernel-build.sh <talos-version> <node>...}"
+# The full v<talos>-k<kernel> string, straight from the tuppr CR, because that is the one
+# value tuppr compares and therefore the one the published tag must equal.
+VERSION="${1:?usage: talos-kernel-build.sh <version> <node>...}"
 shift
+# Everything upstream (talos and extensions release tags) wants the Talos half alone.
+TALOS_VERSION="${VERSION%-k*}"
 
 REGISTRY="${REGISTRY:-ghcr.io}"
 USERNAME="${USERNAME:-tanguille}"
@@ -22,9 +26,12 @@ trap 'rm -rf "${WORK}"' EXIT
 # the Dockerfile while the tag and the built kernel came from whatever number was typed.
 KERNEL_VERSION="$(just kernel-version)"
 
-# tuppr compares this to the version the node reports, so the kernel has to be IN the string
-# or a kernel-only bump is invisible to it. See README.md "Version tagging".
-VERSION="${TALOS_VERSION}-k${KERNEL_VERSION}"
+# The CR and the Dockerfile ARG are bumped by the same Renovate branch (depName linux on both),
+# so they agree or the tree is half-applied. Fail here rather than publish an installer whose
+# tag advertises one kernel and whose contents are another -- nothing downstream would catch it.
+[[ "${VERSION#*-k}" == "${KERNEL_VERSION}" ]] || {
+    echo "CR names k${VERSION#*-k}, Dockerfile builds ${KERNEL_VERSION}" >&2; exit 1
+}
 
 log() { printf '\n\033[1m==> %s\033[0m\n' "$*"; }
 

--- a/scripts/talos-kernel-build.sh
+++ b/scripts/talos-kernel-build.sh
@@ -7,11 +7,10 @@
 # can drift from the release being built. See docker/talos-kernel/README.md.
 set -euo pipefail
 
-# The full v<talos>-k<kernel> string, straight from the tuppr CR, because that is the one
-# value tuppr compares and therefore the one the published tag must equal.
+# The full v<talos>-k<kernel> string from the tuppr CR: the value tuppr compares, so the value
+# the published tag must equal. Upstream release tags want the Talos half alone.
 VERSION="${1:?usage: talos-kernel-build.sh <version> <node>...}"
 shift
-# Everything upstream (talos and extensions release tags) wants the Talos half alone.
 TALOS_VERSION="${VERSION%-k*}"
 
 REGISTRY="${REGISTRY:-ghcr.io}"
@@ -26,9 +25,8 @@ trap 'rm -rf "${WORK}"' EXIT
 # the Dockerfile while the tag and the built kernel came from whatever number was typed.
 KERNEL_VERSION="$(just kernel-version)"
 
-# The CR and the Dockerfile ARG are bumped by the same Renovate branch (depName linux on both),
-# so they agree or the tree is half-applied. Fail here rather than publish an installer whose
-# tag advertises one kernel and whose contents are another -- nothing downstream would catch it.
+# Same Renovate branch bumps both (depName linux), so a mismatch means a half-applied tree.
+# Fail here: an installer whose tag advertises a kernel it does not carry is caught nowhere else.
 [[ "${VERSION#*-k}" == "${KERNEL_VERSION}" ]] || {
     echo "CR names k${VERSION#*-k}, Dockerfile builds ${KERNEL_VERSION}" >&2; exit 1
 }

--- a/talos/nodes/controlplane/control-1.yaml.j2
+++ b/talos/nodes/controlplane/control-1.yaml.j2
@@ -6,9 +6,6 @@ machine:
     # Its own schematic (control-1.schematic.yaml adds the dGPU extensions), so its own installer
     # repo -- control-2/3 share talos/schematic.yaml and cannot use this image.
     image: ghcr.io/tanguille/installer/control-1:{{ pinned }}
-  # Must match the tag above exactly; getTargetVersion prefers this over spec.talos.version.
-  nodeAnnotations:
-    tuppr.home-operations.com/version: {{ pinned }}
   nodeLabels:
     # GPU label for applications; the amdgpu kernel module is loaded
     # automatically by the siderolabs/amdgpu system extension

--- a/talos/nodes/controlplane/control-2.yaml.j2
+++ b/talos/nodes/controlplane/control-2.yaml.j2
@@ -12,10 +12,6 @@ machine:
     # schematic); the repo is named for the schematic, not its id, which moves on every edit.
     # Full rationale: docker/talos-kernel/README.md "Version tagging".
     image: ghcr.io/tanguille/installer/shared:{{ pinned }}
-  # getTargetVersion (upgrade.go:855) prefers this over spec.talos.version. Must match the tag
-  # above exactly or tuppr requests an image that was never published.
-  nodeAnnotations:
-    tuppr.home-operations.com/version: {{ pinned }}
   nodeLabels:
     amd.com/igpu: "true"
     kepler-node: "true"

--- a/talos/nodes/controlplane/control-3.yaml.j2
+++ b/talos/nodes/controlplane/control-3.yaml.j2
@@ -7,9 +7,6 @@ machine:
     # Shared with control-2 (same schematic). Our registry, not the Factory: tuppr rebuilds the
     # upgrade target from this field, so leaving it on factory.talos.dev reinstalls the stock kernel.
     image: ghcr.io/tanguille/installer/shared:{{ pinned }}
-  # Must match the tag above exactly; getTargetVersion prefers this over spec.talos.version.
-  nodeAnnotations:
-    tuppr.home-operations.com/version: {{ pinned }}
   nodeLabels:
     amd.com/igpu: "true"
     kepler-node: "true"


### PR DESCRIPTION
Moves the Talos upgrade target out of a per-node machine-config annotation and into `spec.talos.version`, so merging a bump PR rolls the fleet instead of doing nothing.

Stacked on `feat/talos-1.14.0-k7.1.13`; merge that first.

## Why merging did nothing before

`tuppr.home-operations.com/version` lived in `machine.nodeAnnotations`, which only `just talos apply-node` can change, and `getTargetVersion` prefers it over `spec.talos.version`. Every rollout ended in three manual `upgrade-node` calls.

`spec.talos.version` could not carry `v<talos>-k<kernel>` because the inline-annotation manager captures the whole value and reads `-k…` as a semver prerelease. Two file-scoped regex managers each owning one half fixes that.

Merging before the ~90m build finishes is harmless: `prePull` (default on) parks the run in `Pending`/`PrePullFailed` on a 5m backoff until the installer exists (`prepull.go:133`, no attempt cap, never `Failed`).

## Evidence

| Check | Result |
|---|---|
| Renovate dry-run, `linux` | `currentValue 7.1.13`, `replaceString "-k7.1.13"` → 7.2.3 on `renovate/linux-7.x` |
| Renovate dry-run, `siderolabs/talos` | `currentValue v1.14.0`, `replaceString "version: v1.14.0-k"` → no update (latest) |
| deps extracted per manager | exactly 1 each |
| `talosctl validate -m metal` | passes, all 3 nodes |
| rendered `tuppr` annotation | absent from all 3 |
| rendered installer ref | `ghcr.io/tanguille/installer/{shared,control-1}:v1.14.0-k7.1.13` |
| `kernelVersion` derived from CR | renders `Linux 7.1.13` |
| build-script `-k` guard | fires on mismatch, before `git clone`/`buildx` |
| CRD `spec.nodeSelector` | present on deployed CRD |

## Two bugs the dry-run caught

Unanchored `-k<version>` matched literal example versions in this file's own comments — Renovate rewrites the first occurrence, so a bump would have edited a comment and rolled nothing. Comments now use placeholders. Anchoring instead is not an option: a wider span makes a bare-series kernel (`7.3`) match inside the Talos half (`v1.17.3`).

The Talos-half regex needs `(?:-[a-z]+\.\d+)?` — the fleet ran `v1.14.0-rc.2` for weeks and the manager would silently match nothing on an rc pin.

## Follow-ups, not in this PR

- One `apply-node` per node to drop the stale annotation; until then it still outranks the CR (both name the same version, so this is inert).
- Alert on `Pending`/`PrePullFailed` > 4h — a failed build otherwise leaves the fleet taint-degraded and silent.
- `ARG KERNEL_VERSION`'s default could be removed so the kernel version is single-sourced in the CR; that rewrites the 7.2-hold narrative across five README sections.
- `.mise.toml` still pins `1.14.0-rc.2`; mise's release-age gate hides `1.14.0`.

Plan and rationale: `docs/tuppr-cr-version-target-plan.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Talos and kernel versions are now managed together through a combined version target.
  - Automated update tracking separately monitors Talos releases and Linux kernel releases.
  - Rollouts can exclude designated nodes using selectors, supporting per-node maintenance holds.

- **Bug Fixes**
  - Added validation to prevent builds when the configured kernel version does not match the requested target.
  - Talos tooling now uses the correct upstream Talos version independently of the combined kernel target.

- **Documentation**
  - Updated upgrade, rollback, hold, and installer guidance for the new versioning workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->