### PR TITLE
feat(talos): build v1.14.0 stable against linux 7.1.13

### DIFF
--- a/docker/talos-kernel/Dockerfile
+++ b/docker/talos-kernel/Dockerfile
@@ -13,7 +13,7 @@
 # `ARG KERNEL_VERSION`. Two declarations with only one default silently produced an SPDX
 # document with an empty version and an unmatchable CPE on any build not passing --build-arg.
 # renovate: datasource=custom.linux-kernel depName=linux
-ARG KERNEL_VERSION=7.1.10
+ARG KERNEL_VERSION=7.1.13
 
 # Passed by scripts/talos-kernel-build.sh, read out of the Talos release's own Makefile. No
 # default on purpose: a stale one would silently build against the wrong toolchain.

--- a/docker/talos-kernel/README.md
+++ b/docker/talos-kernel/README.md
@@ -1,8 +1,8 @@
 # Talos kernel package
 
 Builds a Talos-compatible Linux kernel package so the cluster can run a newer kernel
-than Talos ships. Talos v1.13.9 ships **Linux 6.18.44** and v1.14.0-rc.2 ships
-**Linux 6.18.46**; this tracks kernel.org **stable** (7.1.10 at time of writing).
+than Talos ships. Talos v1.14.0 ships **Linux 6.18.48**; this tracks kernel.org
+**stable** (7.1.13 at time of writing).
 
 Neither `siderolabs/talos` nor `siderolabs/pkgs` is forked. Both are consumed at their
 release tags and steered with make variables.
@@ -11,7 +11,7 @@ release tags and steered with make variables.
 
 The in-kernel Ceph client gained AES256-KRB5 (`aes256k`) support in **Linux 7.0**
 (`b7cc142dbafe libceph: add support for CEPH_CRYPTO_AES256KRB5`, merged in
-`ceph-for-7.0-rc1`). It is absent from 6.18.44 and was **not** backported to 6.18.y — it
+`ceph-for-7.0-rc1`). It is absent from 6.18.48 and was **not** backported to 6.18.y — it
 is a feature, not a fix. Without it the `csi-rbd-node` / `csi-cephfs-node` keys, which
 drive `rbd map` and `mount -t ceph`, cannot move off the insecure `aes` key type
 deprecated by CVE-2025-30156.
@@ -45,7 +45,7 @@ The Ceph `aes256k` feature this was built for is **not yet in use** — it also 
 |--------------------|----------------------------------------------------|----------------------------------------|
 | kernel.org moniker | **longterm**                                       | stable                                 |
 | Projected EOL      | Dec 2028                                           | none published; 7.2 shipped 2026-08-16 |
-| `siderolabs/pkgs`  | `release-1.13` and `release-1.14` both pin 6.18.44 | never shipped                          |
+| `siderolabs/pkgs`  | `release-1.14` pins 6.18.48                        | never shipped                          |
 
 Measured series lifetimes: 6.19.y made its last release 9 days after 7.0 shipped, 7.0.y 13
 days after 7.1. 7.2 is already out, so 7.1.y is likely within weeks of EOL. Mainline cadence
@@ -230,9 +230,9 @@ regression, and it is **not** version-specific to our 1.20: upstream reports 1.1
 and 1.21.0-pre.0 all failing on 7.2 while the same builds run fine on 7.1.
 
 The fix is [`67c619c`][fix] (probe via `bpf_core_enum_value_exists()` instead of emitting the
-call). Measured on 2026-08-30: present on the `v1.20` branch as `b73ca6e8d` (2026-08-28), absent
-from `v1.19` and `v1.18`, and in **no release** — 1.20.1 shipped 2026-08-18, ten days before the
-backport. Re-check with:
+call). Re-measured on 2026-09-03: still present on the `v1.20` branch as `b73ca6e8d`
+(2026-08-28), absent from `v1.19` and `v1.18`, and still in **no release** — 1.20.1 remains the
+latest and shipped 2026-08-18, ten days before the backport. Re-check with:
 
 ```sh
 gh api "repos/cilium/cilium/commits?sha=v1.20&per_page=100" \

--- a/kubernetes/apps/system-upgrade/tuppr/upgrades/kubernetesupgrade.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/upgrades/kubernetesupgrade.yaml
@@ -12,6 +12,9 @@ spec:
     image:
       # Unset, tuppr derives this from the node's CURRENT version; a -k<kernel> one is unpublished
       # and the job ImagePullBackOffs. Same trap as talosupgrade.yaml, hits this CRD too.
+      # Annotated because talosupgrade.yaml's &talosVersion anchor cannot cross files: without
+      # this the field is invisible to Renovate and silently rots one Talos release behind.
+      # renovate: datasource=github-releases depName=siderolabs/talos
       tag: v1.14.0
   healthChecks:
     - apiVersion: v1

--- a/kubernetes/apps/system-upgrade/tuppr/upgrades/kubernetesupgrade.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/upgrades/kubernetesupgrade.yaml
@@ -12,7 +12,7 @@ spec:
     image:
       # Unset, tuppr derives this from the node's CURRENT version; a -k<kernel> one is unpublished
       # and the job ImagePullBackOffs. Same trap as talosupgrade.yaml, hits this CRD too.
-      tag: v1.14.0-rc.2
+      tag: v1.14.0
   healthChecks:
     - apiVersion: v1
       kind: Node

--- a/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
@@ -10,7 +10,7 @@ spec:
     # stopped partway through the v1.14 cycle (alpha.0 still had it) once Image Factory became
     # the default, so a docker datasource would silently freeze at the last tag it ever saw.
     # renovate: datasource=github-releases depName=siderolabs/talos
-    version: &talosVersion v1.14.0-rc.2
+    version: &talosVersion v1.14.0
   talosctl:
     image:
       # Unset, tuppr derives this from the node's CURRENT version; a -k<kernel> one is unpublished


### PR DESCRIPTION
Talos v1.14.0 stable (released 2026-09-03) against linux 7.1.13, the current kernel.org stable in the 7.1 series. Installer tag becomes `v1.14.0-k7.1.13`.

Base of #4855.

## Staying on 7.1.y

The 7.2 hold still applies. Re-measured 2026-09-03: Cilium's `HAVE_SET_RETVAL` fix is on the `v1.20` branch as `b73ca6e8d` (2026-08-28) but in **no release** — 1.20.1 is latest and shipped 2026-08-18, ten days before the backport.

## Evidence, checked before dispatching the ~90m build

| Input | Result |
|---|---|
| Talos v1.14.0 `Makefile` | `TOOLS ?= v1.14.0-5-g87316ca`, `PKGS ?= v1.14.0-15-g2f03590` |
| `ghcr.io/siderolabs/{tools,llvm}` at that rev | both pullable |
| pkgs `config-amd64`, `certs/x509.genkey` @ `2f03590` | 200 / 200 |
| `linux-7.1.13.tar.xz` + `.tar.sign` | 200 / 200 |
| `siderolabs/extensions` v1.14.0 tag | exists |
| Derived tag | `v1.14.0-k7.1.13` |
| `talosctl validate -m metal` | passes, control-1 and control-3 |

Build dispatched against this branch before merge, per `docker/talos-kernel/README.md`: https://github.com/Tanguille/cluster/actions/runs/33782713577

## Also here

`kubernetesupgrade.yaml`'s `talosctl.image.tag` had no `# renovate:` annotation and no manager covering it, so it was invisible to Renovate and would have rotted a release behind on every Talos bump. The same inline-annotation style already works one field above it, on `spec.kubernetes.version`.

## Not included

`.mise.toml` stays on `1.14.0-rc.2`. mise's release-age gate hides `1.14.0` (`ls-remote` reports "1 newer release hidden"), and it is not a build input — CI clones talos at the tag. Renovate takes it when the gate clears.

README facts refreshed: Talos v1.14.0 ships Linux 6.18.48, `pkgs` pin, Cilium re-measurement.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Upgraded the Talos kernel to stable version 7.1.13.
  * Updated Talos references to stable release 1.14.0 with kernel 6.18.48.
  * Kubernetes and Talos upgrade configurations now use Talos 1.14.0 instead of the release candidate.
  * Updated compatibility notes and package tracking information for the new kernel and Talos release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->