### PR TITLE
feat(llmkube): alert when vllm decode latches at half speed

### DIFF
--- a/kubernetes/apps/ai/llmkube/models/kustomization.yaml
+++ b/kubernetes/apps/ai/llmkube/models/kustomization.yaml
@@ -3,6 +3,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - prometheusrule.yaml
   - qwen38-27b-vllm.yaml
   - qwen38-flash-next.yaml
   - qwen3-embedding.yaml

--- a/kubernetes/apps/ai/llmkube/models/prometheusrule.yaml
+++ b/kubernetes/apps/ai/llmkube/models/prometheusrule.yaml
@@ -1,0 +1,67 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: qwen38-27b-vllm-rules
+spec:
+  groups:
+    - name: qwen38-27b-vllm.rules
+      rules:
+        # The engine intermittently latches into a state where every decode step
+        # costs a constant +30.8ms and stays there until the pod is restarted.
+        # Measured 2026-09-05/06 at 4K M=1: 31.3ms healthy vs 62.1ms degraded,
+        # and the +30.8ms is identical at 32K (37.6 -> 68.3), so it is a fixed
+        # per-step cost, not a context or load effect.
+        #
+        # Nothing else moves when it happens: CUDA graph mode stays FULL (the
+        # engine's own cudagraph counter shows 320 steps/10s before and 144
+        # after, same mode), GPU sits at 100% busy on full core and memory
+        # clocks at 62-66C, VRAM/GTT differ by ~100KB, cgroup cpu.pressure is
+        # zero and nr_throttled is 0. Ruled out by direct test: engine build,
+        # KV connector, prefix-cache hits, concurrency 1-5, tool-calling,
+        # co-tenant GPU transcoding, and prompt length. Trigger still unknown.
+        # A pod restart is the only known remedy, which is why this alerts.
+        #
+        # ITL here is effectively the step time: vLLM advances every running
+        # request one token per step, so this grows legitimately with BOTH
+        # context and batch size. That sets the threshold:
+        #   healthy M=1 is 31.3ms at 4K and rises ~0.2ms per 1K tokens of
+        #   context (43.5ms at 64K, ~49ms at 96K = the p99 prompt)
+        #   degraded is >=59ms at any context
+        # 55ms is not a guess: over the 2026-09-05 20:00-00:30Z windows this
+        # metric read 31.2/32.2/32.3/33.9/39.5ms while healthy and
+        # 58.8/59.7/62.4/62.9/67.2/67.3/73.0ms while latched, so it separates
+        # every observed case with margin on both sides. 60ms was tried first
+        # and would have missed the 58.8 and 59.7 windows.
+        # It would false-fire on a sustained M=1 context past ~122K;
+        # maxModelLen is 246944, so that is reachable but well outside the p99
+        # of 94K. Raise the threshold rather than widen the guard if traffic
+        # that long ever becomes normal.
+        #
+        # The running<2 guard is load-bearing, not caution: per-stream step time
+        # is 48ms at concurrency 5 on a HEALTHY engine, which would trip 60ms on
+        # its own. Production concurrency sits near 1, so this still watches the
+        # regime the workload actually runs in.
+        - alert: VLLMDecodeStepLatched
+          expr: |-
+            (
+              rate(vllm:inter_token_latency_seconds_sum{model_name="qwen-3.8"}[15m])
+              /
+              rate(vllm:inter_token_latency_seconds_count{model_name="qwen-3.8"}[15m])
+              > 0.055
+            )
+            and
+            (avg_over_time(vllm:num_requests_running{model_name="qwen-3.8"}[15m]) < 2)
+          # Long enough that a burst of very-long-context requests rides it out;
+          # the condition is persistent once latched, so nothing is lost by
+          # waiting. 15m rate + 30m for = ~45m worst-case notice.
+          for: 30m
+          annotations:
+            summary: >-
+              qwen38-27b-vllm decode is latched at
+              {{ $value | humanizeDuration }}/token near single-stream — roughly
+              half speed. Restart the pod to clear it; stopping co-tenants or
+              waiting does not.
+          labels:
+            severity: warning


### PR DESCRIPTION
Alerts on the vLLM decode degradation found on 2026-09-05/06: the engine intermittently latches into a state where every decode step costs a constant **+30.8 ms** and stays there until the pod is restarted.

## The condition

| context | healthy ITL | latched ITL |
|---|---|---|
| 4K | 31.3 ms (31.9 tok/s) | 62.1 ms (16.1 tok/s) |
| 32K | 37.6 ms (26.6 tok/s) | 68.3 ms |

The same +30.8 ms at both, so it is a fixed per-step cost, not a context or load effect. Everything else is unchanged between the two states: cudagraph mode stays `FULL` (the engine's own counter shows 320 steps/10s before and 144 after, same mode), GPU is 100% busy on full core and memory clocks at 62-66 °C, VRAM/GTT differ by ~100 KB, and `cpu.pressure` and `nr_throttled` are both zero.

**Trigger is not identified.** Ruled out by direct test: engine build (dev388 vs dev437), the KV offload connector, prefix-cache hits, concurrency 1-5, tool-calling/grammar, co-tenant GPU transcoding (fileflows), prompt length, and the cpu request. A pod restart is the only known remedy, and stopping co-tenants or waiting does not clear it — so the alert says restart.

## Threshold

Derived from the metric's own history, not guessed. Over 2026-09-05 20:00-00:30Z this expression read:

- healthy: 31.2 / 32.2 / 32.3 / 33.9 / 39.5 ms
- latched: 58.8 / 59.7 / 62.4 / 62.9 / 67.2 / 67.3 / 73.0 ms

55 ms separates those with margin on both sides. 60 ms was tried first and would have **missed** the 58.8 and 59.7 ms windows.

Verified against VictoriaMetrics over that range: the full expression returns a series for every latched window and nothing for the healthy ones.

## The concurrency guard

`avg_over_time(num_requests_running[15m]) < 2` is load-bearing, not caution. ITL is effectively step time (vLLM advances every running request one token per step), so it grows legitimately with batch size: a **healthy** engine at concurrency 5 already sits at 48 ms and would trip 55 ms on its own. Production concurrency sits near 1, so the alert still watches the regime this workload actually runs in.

## Known limit

ITL also grows legitimately with context, at ~0.2 ms per 1K tokens (43.5 ms at 64K, ~49 ms at 96K = the p99 prompt). This would false-fire on a sustained M=1 context past ~122K. `maxModelLen` is 246944, so that is reachable but well outside the p99. If traffic that long becomes normal, raise the threshold rather than widen the guard.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added monitoring for elevated inter-token latency in the Qwen 3.8 model.
  - Introduced an alert when latency remains above the defined threshold under low request load for 30 minutes.
  - Enabled the alert configuration in application deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->