### PR TITLE
feat(opencode): prepare suspended database inspection

### DIFF
--- a/kubernetes/apps/ai/opencode/inspection/README.md
+++ b/kubernetes/apps/ai/opencode/inspection/README.md
@@ -1,0 +1,80 @@
+# Temporary SQLite metadata inspection — preparation only
+
+`opencode/ks.yaml` registers a **suspended** independent Flux Kustomization.
+Production HelmRelease, replicas, configuration, routes and PVC are unchanged.
+The preparation diff alone cannot start the Job. An exact activation diff changing
+only this Kustomization's `suspend` to `false`, push, and reconciliation require
+explicit approval. Do not use direct apply, ephemeral containers or live installs.
+
+## Execution contract
+
+- One Job, no retries, 300-second deadline, no TTL and no Flux force replacement.
+- Required same-namespace pod affinity follows the existing OpenCode pod onto its
+  RWO PVC node (observed `control-3`). Recheck one ready application replica before
+  activation; do not relocate/stop it during inspection. Affinity is a scheduling
+  condition, not a continuing placement lock.
+- UID/GID 65532, no fsGroup or chown, no capabilities/token/privilege, read-only root.
+  Existing database directory/files must be group-readable/traversable; failure is
+  intentional if permissions differ. Never fix permissions live to force a result.
+- Only `.local/share/opencode` is exposed at `/source`, read-only at both claim and
+  mount level. This directory contains existing auth state as well as the DB;
+  the script opens **only** `opencode.db` (SQLite manages its WAL/SHM). Directory
+  exposure does not mean auth files are read. No home/global config mounts.
+- Script ConfigMap only; no data output files, temporary storage, network or installs.
+  NetworkPolicy selects only inspection pods and denies ingress/egress. Live Cilium
+  `enable-policy=default` was verified on 2026-09-06. Recheck overlapping allow
+  policies before activation: Kubernetes policies are additive.
+- `mode=ro`, query-only, one read transaction; no immutable flag, checkpoint,
+  OpenCode initialization, backup or copies. WAL/permission/SQLite errors fail closed
+  with a fixed message, without SQL error text, partial reports or tracebacks.
+- Logs contain schema names/column types/relationships/index structure, counts,
+  aggregate integrity/FK status and a structural SHA-256. Never row IDs, values,
+  defaults, DDL or JSON payloads. Unsupported identifier/type syntax and virtual
+  tables fail closed. Views/triggers are named but never evaluated for counts.
+- The structural fingerprint deliberately excludes defaults, CHECK expressions,
+  generated expressions, partial-index predicates and view/trigger bodies. It is
+  **not** proof of full schema equivalence or ALL-state preservation. This Job is
+  inventory preparation, not a migration or recoverable backup.
+
+## Image evidence
+
+Read-only `docker buildx imagetools inspect python:3.13-alpine` on 2026-09-06:
+
+- index: `sha256:7415fbc3c9e4979cc717d92377ab2bc7b2b4a2af1ac03cc52b5f3f88efedaf3a`
+- amd64: `sha256:46ee549c88617e9bc8acb843a326f1a5c0fa5608d7f9703509efe6d53b55f318`
+- upstream annotation: `3.13.15-alpine3.24`, source revision
+  `688a0b86bb44289df16a363e9f41d90514c1a5f9` in docker-library/python.
+
+## Offline validation
+
+From this directory, with `/tmp/opencode` present:
+
+```sh
+PYTHONDONTWRITEBYTECODE=1 python3 -m unittest -v test_inspect_db.py
+```
+
+Fixtures are synthetic, outside the workspace/PVC; tests never take a live DB path.
+Run repository `mise exec -- kustomize build` on this directory and the required
+`mise exec -- bash .agents/skills/pr-review/scripts/validate-pr.sh` from repo root.
+Host fixture tests do not prove read-only WAL support of the eventual container
+mount; that is an explicit live fail-closed gate, not an inferred success.
+
+## Later approved execution / cleanup (not performed)
+
+After approval of the exact activation diff and its push/merge, allow the existing
+parent `flux-system/cluster-apps` reconciliation to discover/unsuspend
+`ai/opencode-inspection`. The targeted command, only when approved, is:
+
+```sh
+flux reconcile kustomization opencode-inspection -n ai --with-source
+kubectl -n ai wait --for=condition=Complete job/opencode-inspection --timeout=330s
+kubectl -n ai logs job/opencode-inspection -c inspect
+```
+
+The parent name/path (`./kubernetes/apps`) was verified read-only on 2026-09-06.
+Do not force a cluster-wide reconcile merely for convenience. Failure must
+be investigated through metadata/fixed failure status, not retries with writable
+mounts. A completed Job is retained: repeat reconciliation must not rerun it.
+Deleting the Job while it remains desired in Git would recreate it. Cleanup needs
+a separately approved GitOps removal/prune of this inspection Kustomization and
+its Job, ConfigMap and NetworkPolicy; retain approved metadata evidence first.

--- a/kubernetes/apps/ai/opencode/inspection/README.md
+++ b/kubernetes/apps/ai/opencode/inspection/README.md
@@ -47,7 +47,7 @@ Read-only `docker buildx imagetools inspect python:3.13-alpine` on 2026-09-06:
 
 ## Offline validation
 
-From this directory, with `/tmp/opencode` present:
+From this directory:
 
 ```sh
 PYTHONDONTWRITEBYTECODE=1 python3 -m unittest -v test_inspect_db.py

--- a/kubernetes/apps/ai/opencode/inspection/inspect_db.py
+++ b/kubernetes/apps/ai/opencode/inspection/inspect_db.py
@@ -1,0 +1,90 @@
+"""Metadata only: no OpenCode bootstrap, exports, defaults, DDL or row payloads."""
+
+import hashlib
+from pathlib import Path
+import re
+import sqlite3
+import sys
+import time
+
+
+def token(value):
+    """Reject unusual identifiers rather than echoing untrusted schema text."""
+    if value is None:
+        return "-"
+    if not isinstance(value, str) or not re.fullmatch(r"[A-Za-z_][A-Za-z_0-9 ]{0,127}", value):
+        raise ValueError("unsupported metadata")
+    return value
+
+
+def inspect(path):
+    # mode=ro refuses missing files. Never use immutable on a changing WAL DB.
+    db = sqlite3.connect(Path(path).absolute().as_uri() + "?mode=ro", uri=True, timeout=2)
+    try:
+        db.enable_load_extension(False)
+        db.execute("PRAGMA query_only=ON")
+        db.execute("PRAGMA trusted_schema=OFF")
+        db.execute("PRAGMA temp_store=MEMORY")
+        deadline = time.monotonic() + 240
+        db.set_progress_handler(lambda: int(time.monotonic() > deadline), 1000)
+        db.execute("BEGIN")
+        structural = []
+        counts = []
+        tables = db.execute("SELECT name, type FROM sqlite_schema ORDER BY type, name").fetchall()
+        # Virtual tables could invoke application code; no such fallback is permitted.
+        if any(row[2] in ("virtual", "shadow") for row in db.execute("PRAGMA table_list")):
+            raise ValueError("unsupported virtual schema")
+        for name, kind in tables:
+            name, kind = token(name), token(kind)
+            structural.append(f"object {kind} {name}")
+            if kind != "table":
+                continue
+            # Select metadata fields explicitly: never retrieve dflt_value or raw DDL.
+            for col in db.execute(
+                'SELECT name, type, "notnull", pk, hidden FROM pragma_table_xinfo(?) ORDER BY cid',
+                (name,),
+            ):
+                structural.append(f"column {name} {token(col[0])} {token(col[1])} notnull={col[2]} pk={col[3]} hidden={col[4]}")
+            for fk in db.execute(
+                'SELECT "table", "from", "to", on_update, on_delete, match FROM pragma_foreign_key_list(?) ORDER BY id, seq',
+                (name,),
+            ):
+                structural.append("fk " + name + " " + " ".join(token(v) for v in fk))
+            for idx in db.execute(
+                'SELECT name, "unique", origin, partial FROM pragma_index_list(?) ORDER BY name', (name,)
+            ):
+                index = token(idx[0])
+                structural.append(f"index {name} {index} unique={idx[1]} origin={token(idx[2])} partial={idx[3]}")
+                for col in db.execute(
+                    'SELECT name, "desc", coll, key FROM pragma_index_xinfo(?) ORDER BY seqno', (index,)
+                ):
+                    structural.append(f"index-column {index} {token(col[0])} desc={col[1]} coll={token(col[2])} key={col[3]}")
+            count = db.execute('SELECT count(*) FROM "' + name + '"').fetchone()[0]
+            counts.append(f"count {name} {count}")
+        integrity_ok = all(row[0] == "ok" for row in db.execute("PRAGMA integrity_check"))
+        fk_count = sum(1 for _ in db.execute("PRAGMA foreign_key_check"))
+        fingerprint = hashlib.sha256("\n".join(structural).encode()).hexdigest()
+        db.rollback()  # End read transaction only; no database writes.
+        lines = ["inspection-format 1", "sqlite-version " + sqlite3.sqlite_version]
+        lines += structural + counts
+        lines += ["structural-sha256 " + fingerprint,
+                  "integrity " + ("ok" if integrity_ok else "failed"),
+                  f"foreign-key-violations {fk_count}"]
+        return lines, integrity_ok and fk_count == 0
+    finally:
+        db.close()
+
+
+def main(path: str | Path = "/source/opencode.db"):
+    try:
+        lines, healthy = inspect(path)
+    except Exception:
+        # Exception/SQL text can contain values; never emit it or a traceback.
+        print("inspection failed-closed", flush=True)
+        return 1
+    print("\n".join(lines), flush=True)
+    return 0 if healthy else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/kubernetes/apps/ai/opencode/inspection/job.yaml
+++ b/kubernetes/apps/ai/opencode/inspection/job.yaml
@@ -1,0 +1,67 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: opencode-inspection
+spec:
+  backoffLimit: 0
+  activeDeadlineSeconds: 300
+  # No TTL: retain terminal Job/log evidence; Flux must not repeatedly recreate it.
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: opencode-inspection
+    spec:
+      restartPolicy: Never
+      automountServiceAccountToken: false
+      enableServiceLinks: false
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: opencode
+                  app.kubernetes.io/instance: opencode
+              topologyKey: kubernetes.io/hostname
+      securityContext:
+        # Existing database is root:65532, group-readable. No fsGroup/chown of PVC.
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: inspect
+          # Registry index inspected 2026-09-06; version 3.13.15-alpine3.24.
+          image: docker.io/library/python:3.13-alpine@sha256:7415fbc3c9e4979cc717d92377ab2bc7b2b4a2af1ac03cc52b5f3f88efedaf3a
+          command: [python3, -I, -B, /script/inspect_db.py]
+          workingDir: /script
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: [ALL]
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+          volumeMounts:
+            - name: database
+              mountPath: /source
+              subPath: .local/share/opencode
+              readOnly: true
+            - name: script
+              mountPath: /script
+              readOnly: true
+      volumes:
+        - name: database
+          persistentVolumeClaim:
+            claimName: opencode
+            readOnly: true
+        - name: script
+          configMap:
+            name: opencode-inspection-script
+            defaultMode: 0444

--- a/kubernetes/apps/ai/opencode/inspection/kustomization.yaml
+++ b/kubernetes/apps/ai/opencode/inspection/kustomization.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: ai
+resources:
+  - job.yaml
+  - networkpolicy.yaml
+configMapGenerator:
+  - name: opencode-inspection-script
+    files:
+      - inspect_db.py
+generatorOptions:
+  disableNameSuffixHash: true

--- a/kubernetes/apps/ai/opencode/inspection/networkpolicy.yaml
+++ b/kubernetes/apps/ai/opencode/inspection/networkpolicy.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: opencode-inspection
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: opencode-inspection
+  policyTypes: [Ingress, Egress]
+  ingress: []
+  egress: []

--- a/kubernetes/apps/ai/opencode/inspection/test_inspect_db.py
+++ b/kubernetes/apps/ai/opencode/inspection/test_inspect_db.py
@@ -14,7 +14,7 @@ import inspect_db
 
 class InspectionTests(unittest.TestCase):
     def setUp(self):
-        self.tmp = tempfile.TemporaryDirectory(prefix="opencode-inspect-", dir="/tmp/opencode")
+        self.tmp = tempfile.TemporaryDirectory(prefix="opencode-inspect-")
         self.path = Path(self.tmp.name) / "opencode.db"
         self.db = sqlite3.connect(self.path)
         self.db.executescript("""

--- a/kubernetes/apps/ai/opencode/inspection/test_inspect_db.py
+++ b/kubernetes/apps/ai/opencode/inspection/test_inspect_db.py
@@ -1,0 +1,133 @@
+"""Offline synthetic fixtures only. Never point these tests at runtime state."""
+
+import contextlib
+import hashlib
+import io
+from pathlib import Path
+import sqlite3
+import tempfile
+import unittest
+from unittest import mock
+
+import inspect_db
+
+
+class InspectionTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory(prefix="opencode-inspect-", dir="/tmp/opencode")
+        self.path = Path(self.tmp.name) / "opencode.db"
+        self.db = sqlite3.connect(self.path)
+        self.db.executescript("""
+            CREATE TABLE project (id TEXT PRIMARY KEY);
+            CREATE TABLE session (id TEXT PRIMARY KEY, project_id TEXT REFERENCES project(id),
+                                  payload TEXT DEFAULT 'SECRET_DEFAULT');
+            CREATE INDEX session_project ON session(project_id);
+            CREATE VIEW hidden_view AS SELECT 'SECRET_VIEW';
+            CREATE TRIGGER hidden_trigger AFTER INSERT ON project BEGIN
+                SELECT 'SECRET_TRIGGER'; END;
+            INSERT INTO project VALUES ('SECRET_PROJECT_ID');
+            INSERT INTO session VALUES ('SECRET_SESSION_ID', 'SECRET_PROJECT_ID', 'SECRET_JSON_PAYLOAD');
+        """)
+        self.db.commit()
+
+    def tearDown(self):
+        self.db.close()
+        self.tmp.cleanup()
+
+    def capture(self, path=None):
+        output = io.StringIO()
+        with contextlib.redirect_stdout(output), contextlib.redirect_stderr(output):
+            code = inspect_db.main(path or self.path)
+        return code, output.getvalue()
+
+    def hashes(self):
+        return {p.name: hashlib.sha256(p.read_bytes()).hexdigest()
+                for p in self.path.parent.iterdir() if p.is_file()}
+
+    def test_metadata_only_and_source_unchanged(self):
+        before = self.hashes()
+        code, output = self.capture()
+        self.assertEqual(code, 0)
+        self.assertNotIn("SECRET", output)
+        self.assertNotIn("CREATE", output)
+        self.assertNotIn("DEFAULT", output)
+        self.assertNotIn("Traceback", output)
+        self.assertIn("count session 1", output)
+        self.assertIn("fk session project project_id id", output)
+        self.assertIn("integrity ok", output)
+        self.assertEqual(before, self.hashes())
+
+    def test_wal_rows_included_without_db_or_wal_changes(self):
+        self.db.execute("PRAGMA journal_mode=WAL")
+        self.db.execute("INSERT INTO project VALUES ('SECRET_WAL_ROW')")
+        self.db.commit()
+        before = self.hashes()
+        code, output = self.capture()
+        self.assertEqual(code, 0)
+        self.assertIn("count project 2", output)
+        self.assertNotIn("SECRET", output)
+        after = self.hashes()
+        # SHM is SQLite's lock/index coordination, not database payload. The live
+        # read-only volume is the additional enforcement against SHM writes.
+        for name in ("opencode.db", "opencode.db-wal"):
+            self.assertEqual(before[name], after[name])
+        self.assertEqual(set(before), set(after))
+
+    def test_missing_database_is_not_created(self):
+        path = self.path.parent / "missing.db"
+        self.assertEqual(self.capture(path), (1, "inspection failed-closed\n"))
+        self.assertFalse(path.exists())
+
+    def test_failure_does_not_log_exception_values(self):
+        with mock.patch.object(inspect_db, "inspect", side_effect=RuntimeError("SECRET_SQL_VALUE")):
+            self.assertEqual(self.capture(), (1, "inspection failed-closed\n"))
+
+    def test_fk_violation_only_aggregate(self):
+        self.db.execute("INSERT INTO session VALUES ('SECRET_BAD_ID', 'SECRET_MISSING', 'SECRET_BAD_PAYLOAD')")
+        self.db.commit()
+        code, output = self.capture()
+        self.assertEqual(code, 1)
+        self.assertIn("foreign-key-violations 1", output)
+        self.assertNotIn("SECRET", output)
+
+    def test_fingerprint_excludes_default_literals_and_rows(self):
+        before = next(x for x in self.capture()[1].splitlines() if x.startswith("structural-sha256"))
+        self.db.execute("INSERT INTO project VALUES ('SECRET_EXTRA_ROW')")
+        self.db.commit()
+        after = next(x for x in self.capture()[1].splitlines() if x.startswith("structural-sha256"))
+        self.assertEqual(before, after)
+        other = self.path.parent / "other.db"
+        with sqlite3.connect(other) as db:
+            schema = ";\n".join(row[0] for row in self.db.execute(
+                "SELECT sql FROM sqlite_schema WHERE sql IS NOT NULL ORDER BY rowid"))
+            db.executescript(schema.replace("SECRET_DEFAULT", "OTHER_SECRET_DEFAULT"))
+        alternate = next(x for x in self.capture(other)[1].splitlines() if x.startswith("structural-sha256"))
+        self.assertEqual(before, alternate)
+
+    def test_unsupported_identifier_fails_without_partial_output(self):
+        self.db.execute('CREATE TABLE "SECRET\nIDENTIFIER" (id TEXT)')
+        self.db.commit()
+        self.assertEqual(self.capture(), (1, "inspection failed-closed\n"))
+
+    def test_connection_is_readonly_and_one_transaction(self):
+        original = sqlite3.connect
+        statements = []
+
+        def connect(filename, **kwargs):
+            self.assertTrue(filename.endswith("?mode=ro"))
+            self.assertNotIn("immutable", filename)
+            db = original(filename, **kwargs)
+            with self.assertRaises(sqlite3.OperationalError):
+                db.execute("CREATE TABLE forbidden (id TEXT)")
+            db.set_trace_callback(statements.append)  # Synthetic test only; never live logs.
+            return db
+
+        with mock.patch.object(inspect_db.sqlite3, "connect", side_effect=connect):
+            self.assertEqual(self.capture()[0], 0)
+        self.assertEqual(statements.count("BEGIN"), 1)
+        self.assertEqual(statements.count("ROLLBACK"), 1)
+        self.assertIn("PRAGMA query_only=ON", statements)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/kubernetes/apps/ai/opencode/ks.yaml
+++ b/kubernetes/apps/ai/opencode/ks.yaml
@@ -23,3 +23,22 @@ spec:
       KOPIUR_PUID: "0"
       KOPIUR_PGID: "0"
       KOPIUR_MOVER_CAPS_ADD: "[DAC_READ_SEARCH]"
+---
+# Preparation only. Unsuspending requires a separately approved activation diff.
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: opencode-inspection
+  namespace: ai
+spec:
+  suspend: true
+  interval: 30m
+  path: ./kubernetes/apps/ai/opencode/inspection
+  targetNamespace: ai
+  prune: true
+  wait: true
+  timeout: 6m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/ai/opencode/ks.yaml
+++ b/kubernetes/apps/ai/opencode/ks.yaml
@@ -24,6 +24,7 @@ spec:
       KOPIUR_PGID: "0"
       KOPIUR_MOVER_CAPS_ADD: "[DAC_READ_SEARCH]"
 ---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 # Preparation only. Unsuspending requires a separately approved activation diff.
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
@@ -37,7 +38,6 @@ spec:
   targetNamespace: ai
   prune: true
   wait: true
-  timeout: 6m
   sourceRef:
     kind: GitRepository
     name: flux-system


### PR DESCRIPTION
## Summary
- Prepare a separate GitOps-managed, read-only SQLite schema/metadata inspection Job with aggregate counts and integrity status; no row payloads, credentials, database copies or OpenCode initialization.
- Keep the inspection Kustomization suspended (`suspend: true`): inactive until a separately approved activation diff. No production HelmRelease, image, replicas, secrets, routes or PVC capacity changes.
- Pin the Python image by registry-verified digest; constrain execution, read-only subPath access, same-node pod affinity and network access.

## Validation
- 8 offline synthetic fixture tests passed (metadata-only output, read-only connection, DB/WAL hashes, missing-file refusal, error suppression and aggregate FK checks).
- Repository validator passed: flate test all and shellcheck; YAML pre-commit formatting hook passed.
- Complete seven-file diff reviewed against current origin/main; git diff --check passed.
- Actual container/Ceph read-only WAL access remains pending an explicitly approved live inspection. Structural fingerprint is not proof of full schema equivalence or ALL-state migration.

## Approval boundary
Preparation/publication only. No merge, activation, live reconciliation, downtime, secret operations or migration authorized or performed. Cleanup requires separate approval.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a preparation-only, manually activated SQLite metadata inspection for OpenCode.
  * Reports schema structure, row counts, integrity status, foreign-key violations, and a structural fingerprint without exposing database contents.
  * Runs as a one-time, read-only, non-root Kubernetes Job with strict resource, network, and filesystem controls.
  * Retains logs and Job evidence for review and fails closed on inspection errors.
* **Documentation**
  * Added setup, validation, activation, and cleanup guidance.
* **Tests**
  * Added offline tests covering privacy, read-only behavior, WAL handling, fingerprint stability, and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->