### PR TITLE
chore(gitignore): ignore .claude/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@ talosconfig
 logs/
 work/
 .worktrees/
+# Agent scratch + the worktrees CLAUDE.md nests here; untracked but unignored
+# until now, so `git add` could sweep 14 live worktrees into a commit.
+.claude/
 .private/
 .venv/
 .agents/pr-review/


### PR DESCRIPTION
`.worktrees/` was ignored, `.claude/` was not, but CLAUDE.md nests worktrees under `.claude/worktrees/`. 14 live worktrees sat untracked-but-unignored, one `git add` away from a commit.

Verified separately: `git log --full-history origin/main -- .claude` returns nothing. No branch on origin has ever tracked `.claude`, so no history rewrite is needed.
