### PR TITLE
chore(agents): drop agent-tool references from tracked files

### DIFF
--- a/.agents/skills/git-worktree-isolation/SKILL.md
+++ b/.agents/skills/git-worktree-isolation/SKILL.md
@@ -20,7 +20,7 @@ compatibility: Requires `git` 2.x worktree support and write access to the repos
 git fetch origin
 git worktree add -b <branch> .worktrees/<task> origin/main
 cd .worktrees/<task>
-for f in .env .mcp.json CLAUDE.local.md .vscode .claude; do cp -r "../../$f" . 2>/dev/null; done  # untracked local config
+cp -r ../../.env ../../.mcp.json ../../.vscode . 2>/dev/null  # untracked local config; add your agent-tool config dir too
 
 # detached experiment
 git worktree add --detach .worktrees/<task> <commit-ish>

--- a/.agents/skills/pr-review/scripts/validate-pr.sh
+++ b/.agents/skills/pr-review/scripts/validate-pr.sh
@@ -65,10 +65,9 @@ echo ""
 
 # Phase 2: Shellcheck (if shell scripts exist)
 echo "[2/2] Shell Script Validation..."
-# exclude the repo-local .claude dir (session configs, worktrees) — anchored to REPO_ROOT so
-# running from inside a .claude/worktrees/* worktree doesn't exclude the entire tree — and
-# .worktrees/ (parallel checkouts validate themselves)
-SHELL_SCRIPTS=$(find "${REPO_ROOT}" -name "*.sh" -type f -not -path "${REPO_ROOT}/.claude/*" -not -path "${REPO_ROOT}/.worktrees/*" 2>/dev/null)
+# skip nested worktrees wherever they live — parallel checkouts validate themselves, and a
+# REPO_ROOT-anchored exclude would swallow the whole tree when run from inside one
+SHELL_SCRIPTS=$(find "${REPO_ROOT}" -name "*.sh" -type f -not -path "*/worktrees/*" 2>/dev/null)
 if [ -n "$SHELL_SCRIPTS" ]; then
     if command -v shellcheck &> /dev/null; then
         # shellcheck disable=SC2086 # word-splitting the list is intended; quoting it passes all paths as one filename


### PR DESCRIPTION
`git grep -ril claude` returned 3 files; it now returns nothing.

- `validate-pr.sh`: the shellcheck find excluded one specific agent directory, anchored to `REPO_ROOT`. Replaced with `-not -path "*/worktrees/*"`, which skips nested checkouts wherever they live and covers both worktree roots this repo uses.
- `git-worktree-isolation/SKILL.md`: the setup line copied a hardcoded list of local config into the new worktree. Trimmed to the config every checkout needs.

The ignore rule for the agent scratch dir went into `.git/info/exclude` rather than `.gitignore`, so it protects the checkout without putting the name back in the tree. Supersedes #4889.
