### PR TITLE
fix(kopiur): hourly quick maintenance, daily 03:00 full, 1h epoch minDuration

### DIFF
--- a/kubernetes/apps/kopiur-system/kopiur/repository/clusterrepository.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/repository/clusterrepository.yaml
@@ -45,6 +45,16 @@ spec:
       securityContext:
         runAsUser: 568
         runAsGroup: 568
+    schedule:
+      # Quick maintenance (index/log work) hourly instead of the default 6h —
+      # closed epochs get compacted promptly. Full (content reclamation) stays
+      # the default daily, pinned to 03:00 local to avoid the midnight peak.
+      quick:
+        cron: 0 * * * *
+        jitter: 10m
+      full:
+        cron: 0 3 * * *
+        jitter: 1h
   # Movers ran BestEffort (no resources) — Talos OOM killer's first victims
   # under node memory pressure (bootstrap/mover exit 137, 07-20 outage).
   moverDefaults:
@@ -52,5 +62,11 @@ spec:
       requests:
         cpu: 50m
         memory: 128Mi
+  parameters:
+    epoch:
+      # kopia's default is 24h; 1h so closed epochs are compacted promptly
+      # and live index blob growth stays bounded. Upstream: onedr0p/home-ops#11650,
+      # joryirving/home-ops#9780.
+      minDuration: 1h
   scheduleDefaults:
     timezone: ${TIMEZONE}


### PR DESCRIPTION
## Summary

Kopiur (Kopia) backup tuning for the `kopia-nas` ClusterRepository (`kubernetes/apps/kopiur-system/kopiur/repository/clusterrepository.yaml`):

- **quick maintenance hourly** — `0 * * * *` with 10m jitter (default is every 6h), so index/log work runs every hour
- **full maintenance daily at 03:00** — `0 3 * * *` with 1h jitter, pinned off the midnight peak (default is daily at 00:00)
- **epoch `minDuration: 1h`** (Kopia default 24h) so closed epochs are compacted promptly and live index blob growth stays bounded

## Why

The default 24h epoch means closed epochs sit un-compacted for a full day, growing the live index blob; an hourly quick pass (index rebuild + log pruning) keeps that in check, with the heavy full reclaim (content deletion) left to the daily 03:00 slot.

The quick jitter is intentionally 10m: it spreads the hourly run and matches the jitter used by the two independent community implementations this change tracks.

## Validation

- YAML parses; `maintenance.schedule.{quick,full}` and `parameters.epoch.minDuration` all match the published `kopiur.home-operations.com/v1alpha1` ClusterRepository schema
- Existing `moverDefaults` resources and `maintenance.mover` securityContext untouched
- 10m/1h jitters and 03:00 cron match the established community values

## Rollback

Revert the single file; flux re-applies the previous schedule.