### PR TITLE
feat(bazarr): migrate to lavx fork 2.6.1 (Postgres-native, supervisor entrypoint)

### DIFF
--- a/kubernetes/apps/media/bazarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/bazarr/app/helmrelease.yaml
@@ -22,8 +22,15 @@ spec:
         containers:
           app:
             image:
-              repository: ghcr.io/home-operations/bazarr
-              tag: 1.6.0@sha256:cd63bbd0986c93e238eb8b9442604d249f0d4080099b389f822abe2062044417
+              repository: ghcr.io/lavx/bazarr
+              tag: 2.6.1@sha256:e1829749734fd53a3270d3de4c8bcf666dedd47050a043503dbe76b6d0e5358c
+            command:
+              - python
+            args:
+              - docker/supervisor.py
+              - --no-update
+              - --config
+              - /config
             env:
               TZ: ${TIMEZONE}
               POSTGRES_ENABLED: "True"
@@ -37,7 +44,7 @@ spec:
                 custom: true
                 spec:
                   httpGet:
-                    path: /api/system/ping
+                    path: /health
                     port: &port 6767
                   timeoutSeconds: 5
                   failureThreshold: 6

--- a/kubernetes/apps/media/bazarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/bazarr/app/helmrelease.yaml
@@ -44,7 +44,7 @@ spec:
                 custom: true
                 spec:
                   httpGet:
-                    path: /health
+                    path: /_supervisor/status
                     port: &port 6767
                   timeoutSeconds: 5
                   failureThreshold: 6

--- a/kubernetes/apps/media/bazarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/bazarr/app/helmrelease.yaml
@@ -24,6 +24,8 @@ spec:
             image:
               repository: ghcr.io/lavx/bazarr
               tag: 2.6.1@sha256:e1829749734fd53a3270d3de4c8bcf666dedd47050a043503dbe76b6d0e5358c
+            # Skip /entrypoint.sh (usermod/groupmod/chown/gosu, all root-only) under
+            # runAsNonRoot 568; args mirror the image CMD.
             command:
               - python
             args:


### PR DESCRIPTION
Migrate bazarr from the official image to the **LavX fork** (`ghcr.io/lavx/bazarr:2.6.1`), which wraps the app in a Python supervisor that manages the Flask backend process.

> **Rebased onto `main` (post #5031).** This merge resolves the image-lineage conflict by keeping the LavX fork, so it **supersedes** #5031's official `1.6.1` bazarr bump for this file — the official `home-operations/bazarr` image is retired by this PR. Note: as long as renovate keeps bumping `ghcr.io/home-operations/bazarr` on `main`, future official bazarr bumps will re-conflict here (consider excluding bazarr from renovate or tracking the LavX fork).

## What changes (single file: `kubernetes/apps/media/bazarr/app/helmrelease.yaml`)
- **image.repository**: `ghcr.io/home-operations/bazarr` → `ghcr.io/lavx/bazarr`
- **image.tag**: `1.6.1@sha256:e5d192a6…` → `2.6.1@sha256:e1829749…`
- **command/args** (new; the container previously ran the image's default `CMD`): `python docker/supervisor.py --no-update --config /config` — the LavX supervisor entrypoint. The image's `/entrypoint.sh` (usermod/groupmod/chown/gosu, all root-only) is skipped under `runAsNonRoot` 568.
- **probes**: liveness + readiness httpGet path `/api/system/ping` → `/_supervisor/status` (the startup probe is timing-based and unchanged)
- **unchanged**: `POSTGRES_ENABLED: "True"` was already present in `env` (from the shared `bazarr-secret` via `envFrom`); service/`--port` stays **6767** (LavX's default, per its Dockerfile/compose)

## Probes — verified against the LavX source
LavX's own `Dockerfile` `HEALTHCHECK` and `docker-compose.yml` both use **`http://localhost:6767/_supervisor/status`**. The supervisor registers `/_supervisor/status`, `/_supervisor/events`, and a static/SPA catch-all, but **no dedicated `/health` route** — `/health` is not in the proxy prefixes and only reaches Flask via the catch-all, whose response depends on Flask auth/routing. To match the upstream, project-blessed endpoint and avoid a probe-path that isn't a first-class route, the probes use `/_supervisor/status`.

## Postgres
Reuses the existing `media-postgres` instance (`postgres.media.svc.cluster.local:5432`) via the shared `bazarr-postgres` secret. ⚠️ **Assumption to confirm before merging:** the LavX `POSTGRES_ENABLED` path must auto-create the `bazarr` role/db on first connect, the way it does for radarr/sonarr/prowlarr — otherwise the pod crash-loops on auth failure.

_Created as a draft pending the postgres auto-creation confirmation._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated Bazarr to a newer application version.
  - Improved compatibility with non-root container execution.
  - Updated health monitoring to use the current supervisor status endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->