### PR TITLE
fix(gateway): point k8s-gateway OCIRepository at the Codeberg chart registry

### DIFF
--- a/kubernetes/apps/network/k8s-gateway/app/ocirepository.yaml
+++ b/kubernetes/apps/network/k8s-gateway/app/ocirepository.yaml
@@ -11,4 +11,4 @@ spec:
     operation: copy
   ref:
     tag: 3.7.2
-  url: oci://ghcr.io/k8s-gateway/charts/k8s-gateway
+  url: oci://codeberg.org/k8s-gateway/charts/k8s-gateway


### PR DESCRIPTION
## Overview

The k8s-gateway project migrated its chart OCI repository from GitHub Container Registry to Codeberg. The ghcr.io source no longer serves the chart, so Flux cannot fetch it. This points the k8s-gateway OCIRepository at the new registry, keeping the same tag (3.7.2).

## Validation

- Confirmed the Codeberg registry serves the chart anonymously via the standard OCI token flow:
  - tags/list returned 200 with tag 3.7.2 present
  - manifests/3.7.2 returned 200 with the application/vnd.cncf.helm.chart.content.v1.tar+gzip layer the OCIRepository layerSelector expects
- Single-line change to kubernetes/apps/network/k8s-gateway/app/ocirepository.yaml; no other references to the old URL exist in the repo (git grep ghcr.io/k8s-gateway on main returns only this file)

## Notes

- No cluster-side action needed beyond the normal Flux reconcile of the k8s-gateway OCIRepository and HelmRelease after merge.
- AI-assisted change (commit message and this description); per the project AI-usage policy the submitter is responsible for the changes.