### PR TITLE
docs(llm-hosting): reject speculative decoding on qwen38-27b-vllm

### DIFF
--- a/docs/llm-hosting/bench/_metrics.py
+++ b/docs/llm-hosting/bench/_metrics.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""One /metrics scrape shared by the bench scripts that need spec-decode counters.
+
+The rest of this directory is deliberately standalone single-file scripts. This
+exists because walltime.py and toolbench.py otherwise carry byte-identical
+copies of the same scrape, and because the naive shape cost three full scrapes
+per rep (poll for idle, re-read idle for the clean flag, read the counters).
+The vLLM /metrics payload is hundreds of series and every read crosses a
+kubectl port-forward -- which wedged repeatedly in practice -- so one call
+returning everything is both less code and less load.
+"""
+import time
+import urllib.request
+
+SPEC = "vllm:spec_decode_num_"
+
+
+class Sample:
+    """running/waiting plus the three spec-decode counters, from one scrape."""
+
+    __slots__ = ("running", "waiting", "drafts", "draft_tokens", "accepted")
+
+    def __init__(self, running=0.0, waiting=0.0, drafts=0.0, draft_tokens=0.0,
+                 accepted=0.0):
+        self.running = running
+        self.waiting = waiting
+        self.drafts = drafts
+        self.draft_tokens = draft_tokens
+        self.accepted = accepted
+
+    @property
+    def idle(self):
+        return self.running == 0 and self.waiting == 0
+
+
+def sample(port, timeout=8):
+    """Scrape once. Spec counters read 0 when speculative decoding is off."""
+    s = Sample()
+    with urllib.request.urlopen(f"http://127.0.0.1:{port}/metrics",
+                                timeout=timeout) as r:
+        for ln in r.read().decode().splitlines():
+            if ln.startswith("#"):
+                continue
+            try:
+                v = float(ln.rsplit(" ", 1)[-1])
+            except ValueError:
+                continue
+            if ln.startswith("vllm:num_requests_running{"):
+                s.running += v
+            elif ln.startswith("vllm:num_requests_waiting{"):
+                s.waiting += v
+            elif ln.startswith(SPEC + "drafts_total"):
+                s.drafts = v
+            elif ln.startswith(SPEC + "draft_tokens_total"):
+                s.draft_tokens = v
+            elif ln.startswith(SPEC + "accepted_tokens_total"):
+                s.accepted = v
+    return s
+
+
+def wait_idle(port, tries=60, delay=5):
+    """Block until the engine is quiet, then return that same Sample.
+
+    Returns the scrape that proved idleness so the caller can use it as the
+    pre-run counter baseline instead of scraping again. Benchmarks must gate on
+    0 running / 0 waiting -- production traffic contaminates the numbers.
+    """
+    s = sample(port)
+    for _ in range(tries):
+        if s.idle:
+            return s
+        time.sleep(delay)
+        s = sample(port)
+    return s

--- a/docs/llm-hosting/bench/_metrics.py
+++ b/docs/llm-hosting/bench/_metrics.py
@@ -59,16 +59,28 @@ def sample(port, timeout=8):
 
 
 def wait_idle(port, tries=60, delay=5):
-    """Block until the engine is quiet, then return that same Sample.
+    """Block until the engine is quiet twice running, then return that Sample.
 
     Returns the scrape that proved idleness so the caller can use it as the
     pre-run counter baseline instead of scraping again. Benchmarks must gate on
     0 running / 0 waiting -- production traffic contaminates the numbers.
+
+    TWO consecutive idle scrapes, matching longctx.py: a single one can land in
+    the gap between two production requests and read idle on a busy engine.
+
+    On timeout this returns a NON-idle Sample rather than raising; every caller
+    must check `.idle` and exclude the rep, because the alternative is silently
+    averaging a contaminated run into the result.
     """
     s = sample(port)
     for _ in range(tries):
         if s.idle:
-            return s
+            time.sleep(1)
+            confirm = sample(port)
+            if confirm.idle:
+                return confirm
+            s = confirm
+            continue
         time.sleep(delay)
         s = sample(port)
     return s

--- a/docs/llm-hosting/bench/longctx.py
+++ b/docs/llm-hosting/bench/longctx.py
@@ -9,6 +9,14 @@ Decode speed is read from the server's own inter_token_latency metric, not from
 client stream timing: urllib's BufferedReader coalesces SSE events, which made a
 client-side measurement report 47000 tok/s at 0.0 ms ITL.
 
+INVALID UNDER SPECULATIVE DECODING. That counter records roughly one event per
+STEP, not per token, so with spec decode on it under-counts badly (184-426
+events for a fixed 511-token generation) and the derived tok/s is far too low --
+it reported 7.37 tok/s where wall-clock measured 18.84. Use walltime.py for any
+speculative config. Safe here as long as this deployment ships without
+--speculative-config, which it does (see docs/llm-hosting/spec-decode-rejected.md);
+this note exists so the next person to try one does not trust these numbers.
+
 Per rep it reports the EXACT mean ITL from the sum/count counter deltas, plus
 the share of tokens past the 50 and 75 ms bucket edges. The tail shares are what
 separate a uniformly slower kernel from occasional stalls; percentiles are

--- a/docs/llm-hosting/bench/toolbench.py
+++ b/docs/llm-hosting/bench/toolbench.py
@@ -158,6 +158,10 @@ aggs = []
 for r in range(REPS):
     # One scrape serves both the idle gate and the pre-run counter baseline.
     before = wait_idle(PORT)
+    if not before.idle:
+        print(f"       {r + 1:>4}  SKIPPED -- engine not idle, would contaminate",
+              flush=True)
+        continue
     w0 = time.perf_counter()
     with ThreadPoolExecutor(max_workers=CONC) as ex:
         res = list(ex.map(one, [f"{time.time_ns()}-{i}" for i in range(CONC)]))
@@ -174,5 +178,7 @@ for r in range(REPS):
           f"{agg / CONC:>11.2f} {100 * acc / drafted if drafted else 0:>8.1f}",
           flush=True)
 
-print(f"\nmedian aggregate tok/s: {st.median(aggs) if aggs else 0:.2f}"
-      f"   per stream: {(st.median(aggs) if aggs else 0) / CONC:.2f}", flush=True)
+if not aggs:
+    raise SystemExit("no clean reps -- engine never went idle, nothing measured")
+print(f"\nn={len(aggs)} clean   median aggregate tok/s: {st.median(aggs):.2f}"
+      f"   per stream: {st.median(aggs) / CONC:.2f}", flush=True)

--- a/docs/llm-hosting/bench/toolbench.py
+++ b/docs/llm-hosting/bench/toolbench.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Decode rate under grammar-constrained tool calling, optionally concurrent.
+
+Production traffic on this model is tool calling, and that regime is exactly
+where MTP + spec decode wedged to ~0.2 tok/s (100x) on this hardware. Any
+speculative config has to be cleared here, not just on plain completions.
+
+Reports wall-clock decode rate with TTFT separated, plus the spec-decode
+counters, so a wedge shows up as a collapsed rate rather than a plausible-
+looking average. CONC > 1 also exercises the seqs x (spec+1) batch shape that
+single-stream benchmarks never reach.
+
+SYSTEM_FILE loads a system prompt (e.g. the assembled Hermes one) so the
+measurement includes the long stable prefix production actually sends. PRESET
+picks the tool schema: `deployment` is a wide synthetic schema that stresses the
+grammar, `vmcp` is the real two-tool contract (find_tool + call_tool) this
+cluster's gateway exposes.
+
+Usage: toolbench.py PORT MODEL [CONC] [REPS] [SYSTEM_FILE] [PRESET]
+"""
+import json, sys, time, urllib.request, statistics as st
+from concurrent.futures import ThreadPoolExecutor
+
+from _metrics import sample, wait_idle
+
+PORT, MODEL = int(sys.argv[1]), sys.argv[2]
+CONC = int(sys.argv[3]) if len(sys.argv) > 3 else 1
+REPS = int(sys.argv[4]) if len(sys.argv) > 4 else 2
+SYSTEM_FILE = sys.argv[5] if len(sys.argv) > 5 and sys.argv[5] != "-" else None
+PRESET = sys.argv[6] if len(sys.argv) > 6 else "deployment"
+SYSTEM = open(SYSTEM_FILE).read() if SYSTEM_FILE else None
+GEN = 400
+
+# A schema wide enough that the grammar actually constrains a long generation;
+# the argument names are what a drafter/lookup would try to predict.
+TOOLS = [{
+    "type": "function",
+    "function": {
+        "name": "create_deployment",
+        "description": "Create a Kubernetes deployment manifest",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"},
+                "namespace": {"type": "string"},
+                "image": {"type": "string"},
+                "replicas": {"type": "integer"},
+                "cpu_request": {"type": "string"},
+                "memory_request": {"type": "string"},
+                "cpu_limit": {"type": "string"},
+                "memory_limit": {"type": "string"},
+                "env_vars": {"type": "array", "items": {"type": "string"}},
+                "volume_mounts": {"type": "array", "items": {"type": "string"}},
+                "node_selector": {"type": "string"},
+                "service_port": {"type": "integer"},
+                "readiness_path": {"type": "string"},
+                "liveness_path": {"type": "string"},
+                "notes": {"type": "string"},
+            },
+            "required": ["name", "namespace", "image", "replicas", "cpu_request",
+                         "memory_request", "cpu_limit", "memory_limit", "env_vars",
+                         "volume_mounts", "node_selector", "service_port",
+                         "readiness_path", "liveness_path", "notes"],
+        },
+    },
+}]
+
+# The real gateway contract: vmcp exposes exactly these two tools, and the
+# argument key is `parameters`. Narrow schema, so the grammar constrains far
+# less than the preset above -- which is the point of testing both.
+VMCP_TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "find_tool",
+            "description": "Search for available tools by capability",
+            "parameters": {
+                "type": "object",
+                "properties": {"query": {"type": "string"}},
+                "required": ["query"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "call_tool",
+            "description": "Invoke a tool discovered via find_tool",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "tool_name": {"type": "string"},
+                    "parameters": {"type": "object"},
+                },
+                "required": ["tool_name", "parameters"],
+            },
+        },
+    },
+]
+
+VMCP_ASK = ("The qwen38-27b-vllm pod in namespace ai is showing elevated decode "
+            "latency. Investigate: find the right tool, then call it to pull the "
+            "pod's recent logs and its current resource usage, and summarise what "
+            "you would check next.")
+
+ASK = ("Create a deployment named qwen38-27b-vllm in namespace ai using image "
+       "vllm/vllm-openai-rocm:nightly with 1 replica, 2 CPU and 32Gi memory "
+       "requests, 4 CPU and 48Gi limits, env vars VLLM_ROCM_USE_AITER=1 and "
+       "HIP_VISIBLE_DEVICES=0, volume mounts /cache and /kvoffload, node "
+       "selector amd.com/gpu=true, service port 8000, readiness and liveness "
+       "both on /health. Add a detailed notes field explaining the choices.")
+
+
+def one(salt):
+    """One tool call; returns (ttft, decode_s, tokens)."""
+    vmcp = PRESET == "vmcp"
+    msgs = []
+    if SYSTEM:
+        msgs.append({"role": "system", "content": SYSTEM})
+    msgs.append({"role": "user", "content": f"[run {salt}] {VMCP_ASK if vmcp else ASK}"})
+    payload = {
+        "model": MODEL,
+        "messages": msgs,
+        "tools": VMCP_TOOLS if vmcp else TOOLS,
+        "max_tokens": GEN, "temperature": 0.7, "stream": True,
+        "stream_options": {"include_usage": True},
+    }
+    if not vmcp:
+        # Forced, so every rep generates the same wide structured payload.
+        payload["tool_choice"] = {"type": "function",
+                                  "function": {"name": "create_deployment"}}
+    body = json.dumps(payload).encode()
+    t0 = time.perf_counter()
+    ttft, usage = None, {}
+    rq = urllib.request.Request(f"http://127.0.0.1:{PORT}/v1/chat/completions",
+                                data=body, headers={"Content-Type": "application/json"})
+    with urllib.request.urlopen(rq, timeout=300) as resp:
+        for raw in resp:
+            if not raw.startswith(b"data: "):
+                continue
+            chunk = raw[6:].strip()
+            if chunk == b"[DONE]":
+                break
+            d = json.loads(chunk)
+            if d.get("usage"):
+                usage = d["usage"]
+            if ttft is None and d.get("choices"):
+                delta = d["choices"][0].get("delta") or {}
+                if delta.get("content") or delta.get("tool_calls"):
+                    ttft = time.perf_counter() - t0
+    total = time.perf_counter() - t0
+    return ttft or 0, total - (ttft or 0), usage.get("completion_tokens", 0)
+
+
+print(f"conc={CONC}  {'rep':>4} {'TTFT s':>8} {'decode s':>9} {'toks':>6} "
+      f"{'agg tok/s':>10} {'per-stream':>11} {'accept%':>8}", flush=True)
+aggs = []
+for r in range(REPS):
+    # One scrape serves both the idle gate and the pre-run counter baseline.
+    before = wait_idle(PORT)
+    w0 = time.perf_counter()
+    with ThreadPoolExecutor(max_workers=CONC) as ex:
+        res = list(ex.map(one, [f"{time.time_ns()}-{i}" for i in range(CONC)]))
+    wall = time.perf_counter() - w0
+    after = sample(PORT)
+    toks = sum(x[2] for x in res)
+    ttft = st.median([x[0] for x in res])
+    dec = st.median([x[1] for x in res])
+    agg = toks / wall if wall else 0
+    drafted = after.draft_tokens - before.draft_tokens
+    acc = after.accepted - before.accepted
+    aggs.append(agg)
+    print(f"       {r + 1:>4} {ttft:>8.2f} {dec:>9.2f} {toks:>6} {agg:>10.2f} "
+          f"{agg / CONC:>11.2f} {100 * acc / drafted if drafted else 0:>8.1f}",
+          flush=True)
+
+print(f"\nmedian aggregate tok/s: {st.median(aggs) if aggs else 0:.2f}"
+      f"   per stream: {(st.median(aggs) if aggs else 0) / CONC:.2f}", flush=True)

--- a/docs/llm-hosting/bench/walltime.py
+++ b/docs/llm-hosting/bench/walltime.py
@@ -43,12 +43,14 @@ def make_prompt(salt):
 
 
 print(f"{'rep':>4} {'TTFT s':>8} {'decode s':>9} {'toks':>6} {'tok/s':>8} "
-      f"{'accept%':>8} {'tok/step':>9} {'ms/step':>8} {'clean':>6}", flush=True)
+      f"{'accept%':>8} {'tok/step':>9} {'ms/step':>8}", flush=True)
 rates, yields = [], []
 for r in range(REPS):
     # One scrape serves both the idle gate and the pre-run counter baseline.
     before = wait_idle(PORT)
-    clean = before.idle
+    if not before.idle:
+        print(f"{r + 1:>4}  SKIPPED -- engine not idle, would contaminate", flush=True)
+        continue
     body = json.dumps({
         "model": MODEL, "prompt": make_prompt(f"{time.time_ns()}-r{r}"),
         "max_tokens": GEN, "temperature": 0.7, "ignore_eos": True,
@@ -84,13 +86,15 @@ for r in range(REPS):
     steps = drafts + max(n - spec_toks, 0)
     ypst = n / steps if steps else 0
     ms = 1000 * decode_s / steps if steps else 0
-    if clean and rate:
+    if rate:
         rates.append(rate)
         yields.append(ypst)
     print(f"{r + 1:>4} {ttft or 0:>8.2f} {decode_s:>9.2f} {n:>6} {rate:>8.2f} "
-          f"{100 * acc / drafted if drafted else 0:>8.1f} {ypst:>9.2f} {ms:>8.1f} "
-          f"{'yes' if clean else 'DIRTY':>6}", flush=True)
+          f"{100 * acc / drafted if drafted else 0:>8.1f} {ypst:>9.2f} {ms:>8.1f}",
+          flush=True)
 
+if not rates:
+    raise SystemExit("no clean reps -- engine never went idle, nothing measured")
 print(f"\nn={len(rates)} clean   median wall-clock decode tok/s: "
-      f"{st.median(rates) if rates else 0:.2f}"
-      f"   median tokens/step: {st.median(yields) if yields else 0:.2f}", flush=True)
+      f"{st.median(rates):.2f}"
+      f"   median tokens/step: {st.median(yields):.2f}", flush=True)

--- a/docs/llm-hosting/bench/walltime.py
+++ b/docs/llm-hosting/bench/walltime.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Wall-clock decode rate, valid under speculative decoding.
+
+longctx.py derives tok/s from vllm:inter_token_latency_seconds sum/count. Under
+spec decode that counter records fewer events than tokens generated (184-426
+seen for a 511-token generation), so its mean is a per-step figure, not a
+per-token one, and the derived tok/s is wrong. This measures generated tokens
+per second of wall clock after first token instead, which is method-agnostic.
+
+PROMPT_FILE feeds a real prompt instead of the synthetic corpus, for measuring
+n-gram/prompt-lookup on traffic-shaped input. A salt line is prepended so reps
+cannot serve from the prefix cache.
+
+Usage: walltime.py PORT MODEL [PROMPT_TOKENS] [REPS] [PROMPT_FILE] [GEN]
+"""
+import json, sys, time, urllib.request, statistics as st
+
+from _metrics import sample, wait_idle
+
+PORT, MODEL = int(sys.argv[1]), sys.argv[2]
+PROMPT_TOKENS = int(sys.argv[3]) if len(sys.argv) > 3 else 4000
+REPS = int(sys.argv[4]) if len(sys.argv) > 4 else 4
+PROMPT_FILE = sys.argv[5] if len(sys.argv) > 5 else None
+GEN = int(sys.argv[6]) if len(sys.argv) > 6 else 512
+FILE_TEXT = open(PROMPT_FILE).read() if PROMPT_FILE else None
+WORDS = ("storage replication consensus quorum latency throughput partition ledger "
+         "checkpoint compaction manifest snapshot heartbeat gossip shard rebalance "
+         "durability coordinator epoch lease tombstone compress index segment").split()
+
+
+def make_prompt(salt):
+    if FILE_TEXT is not None:
+        return f"Session {salt} unique run identifier.\n{FILE_TEXT}"
+    parts = [f"Session {salt} unique run identifier. Technical corpus follows.\n"]
+    rnd = 0
+    for i in range(PROMPT_TOKENS):
+        rnd = (rnd * 1103515245 + 12345 + i) & 0x7FFFFFFF
+        parts.append(WORDS[rnd % len(WORDS)])
+        if i % 18 == 17:
+            parts.append(".\n")
+    parts.append("\n\nSummarize the corpus above in one sentence.")
+    return " ".join(parts)
+
+
+print(f"{'rep':>4} {'TTFT s':>8} {'decode s':>9} {'toks':>6} {'tok/s':>8} "
+      f"{'accept%':>8} {'tok/step':>9} {'ms/step':>8} {'clean':>6}", flush=True)
+rates, yields = [], []
+for r in range(REPS):
+    # One scrape serves both the idle gate and the pre-run counter baseline.
+    before = wait_idle(PORT)
+    clean = before.idle
+    body = json.dumps({
+        "model": MODEL, "prompt": make_prompt(f"{time.time_ns()}-r{r}"),
+        "max_tokens": GEN, "temperature": 0.7, "ignore_eos": True,
+        "stream": True, "stream_options": {"include_usage": True},
+    }).encode()
+    t0 = time.perf_counter()
+    ttft, usage = None, {}
+    rq = urllib.request.Request(f"http://127.0.0.1:{PORT}/v1/completions", data=body,
+                                headers={"Content-Type": "application/json"})
+    with urllib.request.urlopen(rq, timeout=1800) as resp:
+        for raw in resp:
+            if not raw.startswith(b"data: "):
+                continue
+            chunk = raw[6:].strip()
+            if chunk == b"[DONE]":
+                break
+            d = json.loads(chunk)
+            if d.get("usage"):
+                usage = d["usage"]
+            if ttft is None and d.get("choices") and d["choices"][0].get("text"):
+                ttft = time.perf_counter() - t0
+    total = time.perf_counter() - t0
+    after = sample(PORT)
+    n = usage.get("completion_tokens", 0)
+    decode_s = total - (ttft or 0)
+    rate = (n - 1) / decode_s if decode_s > 0 and n else 0
+    # A spec step emits its accepted drafts plus the one always-valid token; the
+    # rest of the generation runs one token per step.
+    drafts = after.drafts - before.drafts
+    drafted = after.draft_tokens - before.draft_tokens
+    acc = after.accepted - before.accepted
+    spec_toks = acc + drafts
+    steps = drafts + max(n - spec_toks, 0)
+    ypst = n / steps if steps else 0
+    ms = 1000 * decode_s / steps if steps else 0
+    if clean and rate:
+        rates.append(rate)
+        yields.append(ypst)
+    print(f"{r + 1:>4} {ttft or 0:>8.2f} {decode_s:>9.2f} {n:>6} {rate:>8.2f} "
+          f"{100 * acc / drafted if drafted else 0:>8.1f} {ypst:>9.2f} {ms:>8.1f} "
+          f"{'yes' if clean else 'DIRTY':>6}", flush=True)
+
+print(f"\nn={len(rates)} clean   median wall-clock decode tok/s: "
+      f"{st.median(rates) if rates else 0:.2f}"
+      f"   median tokens/step: {st.median(yields) if yields else 0:.2f}", flush=True)

--- a/docs/llm-hosting/spec-decode-rejected.md
+++ b/docs/llm-hosting/spec-decode-rejected.md
@@ -10,17 +10,22 @@ published benchmarks.
 
 ## Verdict
 
-**DO NOT ENABLE speculative decoding of any kind on this deployment.** Every
-method vLLM offers was evaluated on 2026-09-07 and every one is unusable. This
-is a closed question until the upstream bugs below move; re-open it only when
-one of the named issues is fixed, not on a new idea.
+**DO NOT ENABLE speculative decoding of any kind on this deployment.** Re-open
+only when one of the named upstream issues is fixed, not on a new idea.
 
-| method | status | why |
-| --- | --- | --- |
-| **n-gram / prompt-lookup** | **corrupts output** | vllm#39273: SSM state corruption on hybrid GDN models — truncated/repeated fragments. Fast (1.8-2.1x) and silently wrong. Confirmed in production. |
-| **MTP** | rejected | + tool-calling grammar wedges to ~0.2 tok/s (100x) under concurrent tool traffic; -27% at M=5 standalone. Production traffic *is* grammar-constrained tool calling. |
-| **DSpark** | rejected | 0.59x measured (18.84 vs 31.73). Drafter KV is additive and bf16: +70% B/token, forcing the cap to 88K, below the 112K production peak. |
-| **EAGLE3 / DFlash** | blocked | Same drafter-KV tax as DSpark, plus vllm#41640 (below). No published drafter for this base sized under the ~2.5 GiB break-even. |
+Status is not uniform across methods — two were measured on this hardware, two
+were ruled out on mechanism without a benchmark:
+
+| method | status | basis | why |
+| --- | --- | --- | --- |
+| **n-gram / prompt-lookup** | **corrupts output** | measured, incl. production | vllm#39273: SSM state corruption on hybrid GDN models — truncated/repeated fragments. Faster (see caveat below) and silently wrong. |
+| **DSpark** | rejected | measured | 0.59x (18.84 vs 31.73). Drafter KV is additive and bf16: +70% B/token, forcing the cap to 88K, below the 112K production peak. |
+| **MTP** | rejected | measured previously | + tool-calling grammar wedges to ~0.2 tok/s (100x) under concurrent tool traffic; -27% at M=5 standalone. Production traffic *is* grammar-constrained tool calling. |
+| **EAGLE3 / DFlash** | blocked | **not benchmarked** — mechanism only | Same drafter-KV tax as DSpark, plus vllm#41640 (below). No published drafter for this base sized under the ~2.5 GiB break-even, so there was nothing to benchmark. |
+
+Also untested, and worth knowing before any retry: n-gram was never run against
+a same-prompt spec-off control, and no method was tested under sustained
+concurrency beyond conc 5.
 
 Three independent blockers apply to every **drafter-based** method (MTP, DSpark,
 EAGLE3, DFlash), any one disqualifying:
@@ -61,12 +66,19 @@ and queue depth all looked healthy throughout the corrupting run — 43-67%
 acceptance and 2.7-3.7 tokens/step on live traffic. The counters measure whether
 drafts were *accepted*, never whether the result was *correct*.
 
-**Methodology lesson, the important one in this document:** every benchmark here
-measured speed and none verified output quality, so a correctness regression
-shipped to production looking like a 2x win. `spectest.py` was the only script
-that checked fidelity at all, it reported `DIVERGED`, and that signal was
-dismissed as a formatting artifact. Any future speculative-decoding trial must
-gate on a quality check before a performance number is even quoted.
+**Methodology lesson, the important one in this document:** the tooling to catch
+this existed and its result was not treated as a gate. `spectest.py` compares
+generated text against the source and reports `OK` / `TRUNCATED` / `DIVERGED`;
+it ran, it reported **`DIVERGED`**, and that was dismissed as a formatting
+artifact after eyeballing only the first 200 characters — while the known
+corruption mode is *progressive*, so the tail was where the evidence would have
+been. Every other script measured speed alone. No performance number was ever
+gated on a passing quality check, so a correctness regression reached production
+looking like a 2x win.
+
+Any future speculative-decoding trial must treat a `spectest.py` pass as a
+precondition for quoting a performance number at all, and must read the whole
+output, not the head.
 
 The performance findings below remain valid and are kept for when the upstream
 bug is fixed; they are not a reason to enable it before then.
@@ -75,8 +87,17 @@ bug is fixed; they are not a reason to enable it before then.
 
 **n-gram is a large win on echo-heavy traffic and a loss on traffic with nothing
 to quote back.** Same pod, same config, varying only the prompt: **61.64 tok/s**
-on a real "edit this manifest" prompt versus a **31.73** baseline (1.94x), and
-**21.4** on a synthetic prompt with little to look up (0.67x).
+on a real "edit this manifest" prompt, and **21.4** on a synthetic prompt with
+little to look up.
+
+> **The speedup ratios in this document are PROVISIONAL.** Every "vs baseline"
+> figure compares against 31.73 tok/s, which was measured on a *different
+> prompt* (synthetic, 4K) and before the config change. Decode rate should be
+> largely prompt-independent, and a post-revert spec-off run on the same pod
+> measured 32.80 tok/s / 30.4 ms/step, which is consistent — but the
+> same-prompt control was never run, because the corruption was found first and
+> the config reverted. Treat 1.8-2.1x as indicative, not settled. Running that
+> control is the first step of any future retry.
 
 Drafter-based methods (MTP, DSpark, EAGLE3, DFlash) remain dead here, for three
 independent reasons below, any one disqualifying. DSpark measured 18.84 tok/s
@@ -152,7 +173,7 @@ cost. Both runs: 4K prompt, 4 clean reps, idle preflight, unique salt.
 
 ### Why it loses, from the engine's own counters
 
-```
+```text
 num_drafts_total          1992
 num_draft_tokens_total   13659     (6.86/draft, i.e. the full block of 7)
 num_accepted_tokens_total 2574     → 18.8% acceptance
@@ -266,7 +287,7 @@ group, so blocker 1 does not apply either. It needs no change to
 
 Config under test:
 
-```
+```sh
 --speculative-config '{"method":"ngram","num_speculative_tokens":5,"prompt_lookup_min":3,"prompt_lookup_max":8}'
 ```
 
@@ -303,7 +324,7 @@ The decisive run is the **real manifest edit** (`walltime.py` with
 of this repo's own `qwen38-27b-vllm.yaml`, generating 1200 tokens. This is the
 shape production actually sends — output that heavily quotes its input.
 
-```
+```text
 rep  TTFT s  decode s  toks   tok/s  accept%  tok/step  ms/step
  1     8.58    19.45   1200   61.64     89.7     3.33      54.0
  2     8.67    19.02   1200   63.04     89.1     3.45      54.7
@@ -380,7 +401,7 @@ build cutoff. Suspects that touch paths this config actually runs:
   our attention backend.
 - `5690b02c0` online quantization with partially pre-quantized checkpoints
   (#51392) — touches `layers/linear.py` + `quantization/base_config.py`.
-- `6cbb3c154` [Perf][GDN] cudagraph-capture metadata without a device sync
+- `6cbb3c154` `[Perf][GDN]` cudagraph-capture metadata without a device sync
   (#55404) and `874df9373` mamba state for padded prompt tails (#55178).
 
 **Eliminated:** `a69e75b9b` "Fast Start" (#54921) — opt-in via
@@ -394,7 +415,7 @@ Keep the pin.
 
 ## Reproducing
 
-```
+```sh
 # baseline / non-spec only -- ITL-derived
 python3 docs/llm-hosting/bench/longctx.py <port> qwen-3.8 4000 4
 

--- a/docs/llm-hosting/spec-decode-rejected.md
+++ b/docs/llm-hosting/spec-decode-rejected.md
@@ -399,14 +399,31 @@ Keep the pin.
 python3 docs/llm-hosting/bench/longctx.py <port> qwen-3.8 4000 4
 
 # anything with speculative decoding on -- wall-clock decode rate.
-# Doubles as the n-gram FLOOR: its prompt admits no lookups.
+# Soft floor only: this prompt draws on a 24-word vocabulary, so 3-gram
+# repeats occur by chance and n-gram does fire (232 drafts, 63% acceptance).
 python3 docs/llm-hosting/bench/walltime.py <port> qwen-3.8 4000 4
+
+# a real workload shape -- pass any prompt file, plus a generation length
+python3 docs/llm-hosting/bench/walltime.py <port> qwen-3.8 0 3 prompt.txt 1200
+
+# grammar-constrained tool calling, optionally concurrent and with a system
+# prompt: the regime that wedged MTP. PRESET is `deployment` or `vmcp`.
+python3 docs/llm-hosting/bench/toolbench.py <port> qwen-3.8 5 2 system.txt vmcp
 
 # n-gram CEILING: verbatim quote-back, and checks the output really matches
 python3 docs/llm-hosting/bench/spectest.py <port> qwen-3.8
 ```
 
-`walltime.py` is the only script added here; it does an idle preflight and
-refuses to count a dirty rep, matching the methodology the rest of this
-directory uses. It exists because `longctx.py` cannot measure a speculative
-config and `spectest.py` folds prefill into its rate and runs a single rep.
+`spectest.py` and `longctx.py` already existed; `walltime.py`, `toolbench.py`
+and `_metrics.py` are added here. All do an idle preflight and refuse to count a
+dirty rep, matching the methodology the rest of this directory uses.
+
+`walltime.py` exists because `longctx.py` derives tok/s from the ITL counter,
+which is invalid under speculative decoding, and because `spectest.py` folds
+prefill into its rate and runs a single rep. `toolbench.py` exists because
+nothing here exercised tool-calling grammar under concurrency. `_metrics.py`
+holds the single `/metrics` scrape the two new scripts share.
+
+**`spectest.py` is the only one that checks correctness, and it is the one that
+matters.** The others measure speed, and speed alone is what made a corrupting
+config look like a 2x win.

--- a/docs/llm-hosting/spec-decode-rejected.md
+++ b/docs/llm-hosting/spec-decode-rejected.md
@@ -1,0 +1,412 @@
+# Speculative decoding on qwen38-27b-vllm (gfx1201): evaluated and rejected
+
+Standing decision, not a point-in-time log — `qwen38-27b-vllm.yaml` points here
+by name. Evaluated 2026-09-07; revisit only on the upstream fixes named below.
+
+Evaluated DSpark end to end on the live deployment, plus a nightly-image
+regression retest that ran alongside it. Every number here was measured on
+control-1 against the production pod on 2026-09-07; nothing is carried over from
+published benchmarks.
+
+## Verdict
+
+**DO NOT ENABLE speculative decoding of any kind on this deployment.** Every
+method vLLM offers was evaluated on 2026-09-07 and every one is unusable. This
+is a closed question until the upstream bugs below move; re-open it only when
+one of the named issues is fixed, not on a new idea.
+
+| method | status | why |
+| --- | --- | --- |
+| **n-gram / prompt-lookup** | **corrupts output** | vllm#39273: SSM state corruption on hybrid GDN models — truncated/repeated fragments. Fast (1.8-2.1x) and silently wrong. Confirmed in production. |
+| **MTP** | rejected | + tool-calling grammar wedges to ~0.2 tok/s (100x) under concurrent tool traffic; -27% at M=5 standalone. Production traffic *is* grammar-constrained tool calling. |
+| **DSpark** | rejected | 0.59x measured (18.84 vs 31.73). Drafter KV is additive and bf16: +70% B/token, forcing the cap to 88K, below the 112K production peak. |
+| **EAGLE3 / DFlash** | blocked | Same drafter-KV tax as DSpark, plus vllm#41640 (below). No published drafter for this base sized under the ~2.5 GiB break-even. |
+
+Three independent blockers apply to every **drafter-based** method (MTP, DSpark,
+EAGLE3, DFlash), any one disqualifying:
+
+1. **Drafter KV is additive and bf16** — pushes the model-length cap below the
+   112K production peak.
+2. **vllm#41640 (unmerged, stale since 2026-08-24)** — vLLM cannot identify a
+   GQA drafter's KV group on a non-MLA target, so every group including the
+   Mamba groups is treated as a draft group. That disables prefix caching and
+   makes the KV offload tier write-only. This deployment cannot afford either:
+   removing the fs tier alone halved single-stream decode.
+3. **vllm#49002 (open)** — the tool-calling/structured-output wedge.
+
+And the one blocker that kills the **drafter-free** method: **vllm#39273**, the
+GDN corruption bug. n-gram sidesteps all three of the above by construction —
+no draft model, no draft KV group — and is still unusable because it produces
+wrong output on this model family.
+
+So the exit condition is narrow: **vllm#39273 fixed** re-opens n-gram, which is
+the only method whose performance was ever worth having here. Everything
+drafter-based additionally needs vllm#41640 *and* vllm#49002, and a drafter
+under ~2.5 GiB that does not currently exist.
+
+n-gram is fast — measurably 1.8-2.1x on echo-heavy work — and it silently
+corrupts output.
+
+**Disqualifying: vllm#39273, "Ngram speculative decoding produces corrupted
+output on hybrid GDN (Qwen3.5) models."** Reported symptom is repeated and
+truncated fragments that degrade progressively; the diagnosis is SSM state
+corruption, not a sampling error. Qwen3.8-27B is a GDN hybrid, so this is our
+exact configuration. Found the hard way: after a live production trial, Hermes
+reported truncated outputs. Related, for the tool-calling path specifically:
+vllm#10442 and vllm#9423 (spec decode truncating under guided/structured
+decoding).
+
+Nothing in the engine's metrics flags this. Acceptance, tokens/step, preemptions
+and queue depth all looked healthy throughout the corrupting run — 43-67%
+acceptance and 2.7-3.7 tokens/step on live traffic. The counters measure whether
+drafts were *accepted*, never whether the result was *correct*.
+
+**Methodology lesson, the important one in this document:** every benchmark here
+measured speed and none verified output quality, so a correctness regression
+shipped to production looking like a 2x win. `spectest.py` was the only script
+that checked fidelity at all, it reported `DIVERGED`, and that signal was
+dismissed as a formatting artifact. Any future speculative-decoding trial must
+gate on a quality check before a performance number is even quoted.
+
+The performance findings below remain valid and are kept for when the upstream
+bug is fixed; they are not a reason to enable it before then.
+
+### Performance, for the record only
+
+**n-gram is a large win on echo-heavy traffic and a loss on traffic with nothing
+to quote back.** Same pod, same config, varying only the prompt: **61.64 tok/s**
+on a real "edit this manifest" prompt versus a **31.73** baseline (1.94x), and
+**21.4** on a synthetic prompt with little to look up (0.67x).
+
+Drafter-based methods (MTP, DSpark, EAGLE3, DFlash) remain dead here, for three
+independent reasons below, any one disqualifying. DSpark measured 18.84 tok/s
+(0.59x). n-gram clears all three — no draft model, no draft KV group, no cap
+change.
+
+### The model that fits every measurement
+
+Enabling n-gram costs a **flat ~50 ms/step against the baseline's ~32 ms**, a
+~1.56x tax paid on *every* step, including steps where no draft is proposed
+(CPU-side suffix search, the forced V1 model-runner fallback, and async
+scheduling being disabled). Acceptance decides whether that is earned back:
+
+| workload | accept% | tokens/step | tok/s | vs baseline |
+| --- | --- | --- | --- | --- |
+| synthetic, poor lookups | 30.8 | 1.03 | 21.4 | 0.67x |
+| synthetic, lucky lookups | 95-97 | 2.06-2.18 | 41-43 | 1.3x |
+| real manifest edit (8K) | 89.7 | 3.33 | 61.6 | **1.94x** |
+
+A sweep over five workload shapes built from real repo content confirms it,
+ordered by how much of the output already exists in the prompt (2 reps each,
+`walltime.py` with `PROMPT_FILE`, 800 tokens generated):
+
+| shape | tok/s | vs 31.73 | accept% | tokens/step | ms/step |
+| --- | --- | --- | --- | --- | --- |
+| refactor-python (emit modified script) | 65.84 | 2.07x | 76-93 | 3.36 | 49-52 |
+| edit-manifest (emit modified yaml) | 57.24 | 1.80x | 82-85 | 3.10 | 53-55 |
+| extract-json (quote values into JSON) | 38.65 | 1.22x | 69-81 | 2.06 | 52-54 |
+| explain-code (prose, quotes lines) | 30.87 | 0.97x | 48-75 | 1.58 | 49-55 |
+| summarize-doc (prose, own words) | 23.32 | 0.73x | 28 | 1.16 | 50 |
+
+Perfectly monotonic in echo ratio, and `ms/step` held at 48.2-55.2 across every
+row of both tables while tok/s moved 3x.
+
+**Break-even is ~1.56 tokens/step.** Production traffic on this model is
+coding-agent and tool-calling work whose output heavily quotes its input, i.e.
+the top of that table. Live production traffic measured 43-67% acceptance and
+2.7-3.7 tokens/step before the run was reverted for corruption.
+
+Corrected from an earlier draft of this document: a first pass concluded n-gram
+was a net loss and blamed the LDS gate at M=2 for a ~4.3x step cost. That figure
+came from subtracting a *guessed* prefill from `spectest.py`'s
+prefill-inclusive rate. Direct measurement puts the step cost at 1.56x, not
+4.3x, and the earlier "floor" prompt turned out to be bimodal noise rather than
+a floor. The LDS gate is real and does make a multi-token step more expensive —
+it is simply much cheaper than the token yield it buys.
+
+## Method note: the ITL counter lies under speculative decoding
+
+`bench/longctx.py` derives tok/s from `vllm:inter_token_latency_seconds`
+sum/count. Under speculative decoding that counter records far fewer events than
+tokens emitted — 184-426 events for a fixed 511-token generation — so its mean
+is closer to per-*step* than per-token and the derived rate is wrong.
+
+It reported DSpark at 7.37 tok/s. Wall-clock measurement of the same config on
+the same pod gave 18.84. **Use `bench/walltime.py` (tokens ÷ wall clock after
+first token) for anything with speculative decoding on.** longctx.py remains
+correct for non-speculative runs, where one token is one ITL sample.
+
+## DSpark measurement
+
+Drafter `RadixArk/Qwen3.8-27B-DSpark` @`b9a5dbdf03bc999c6c73c426b19c2d9041cea393`
+(bf16, 3.46 GiB, 5 layers, `block_size` 7), `num_speculative_tokens` 7,
+`draft_sample_method` probabilistic, adaptive verification off.
+
+| config | tok/s | TTFT | how measured |
+| --- | --- | --- | --- |
+| pinned baseline, no spec decode | 31.73 | 4.07s | longctx, ITL-derived (valid, non-spec) |
+| DSpark, cap 88,000 | 18.84 | 4.28s | walltime, wall-clock |
+
+0.59x — a 1.68x slowdown. TTFT is unchanged, so this is entirely a decode-side
+cost. Both runs: 4K prompt, 4 clean reps, idle preflight, unique salt.
+
+### Why it loses, from the engine's own counters
+
+```
+num_drafts_total          1992
+num_draft_tokens_total   13659     (6.86/draft, i.e. the full block of 7)
+num_accepted_tokens_total 2574     → 18.8% acceptance
+accepted per position:  0:1281  1:526  2:265  3:184  4:140  5:103  6:75
+```
+
+Per-position acceptance decays 64% → 26% → 13% → 9% → 7% → 5% → 3.8%. Mean
+accepted is 1.29 tokens/step, so a step emits ~2.29 tokens instead of 1. That is
+a real 2.3x token yield, and it still loses, because the step got more expensive
+than that.
+
+Decode here is memory-bandwidth-bound (every GEMM is already at the memory
+ceiling — see the standalone-bench findings). DSpark runs the drafter **7 times
+sequentially** per step: 7 x 3.46 GiB ≈ 24 GiB of weight traffic against the
+W4A16 target's single ~15 GiB pass. You buy 2.29x tokens for ~2.6x the traffic.
+
+### Break-even ceiling for a drafter on this box
+
+At the measured acceptance curve, a step must satisfy
+`target + 7·drafter ≤ 2.29 · target`, i.e. **`drafter ≤ 0.184 · target`**.
+Against a ~13.5 GiB effective W4A16 target that is **~2.5 GiB**. The only
+published Qwen3.8-27B DSpark drafter is 3.46 GiB ≈ 0.256x — roughly 40% over
+budget on weight traffic alone, before the KV tax below. This is why the
+measured 0.59x is worse than the ~1.0x the traffic math alone predicts.
+
+A W4A16 drafter would cut draft weight traffic ~4x and clear that ceiling, but
+it does not fix either problem below, so it is not on its own a reason to retry.
+
+## The three blockers
+
+### 1. Drafter KV is additive, and it is bf16
+
+The drafter brings its own KV cache: 5 full-attention layers at bf16 while the
+target's KV is fp8_e4m3. Per-token KV goes **33,494 B → 56,940 B (+70%)**
+(engine's own figure: 7.95 GiB needed for 150,000 tokens).
+
+Consequences, in order of how they bit:
+
+- The first boot at `maxModelLen` 150,000 **refused to start**:
+  `ValueError: ... 7.95 GiB KV cache is needed, which is larger than the
+  available KV cache memory (5.49 GiB) ... estimated maximum model length is
+  98560`.
+- At the retry cap of 88,000 the pool came out 96,724 tokens = **1.10x**
+  pool/cap, inside the band this config measures as slow-to-unstable (the
+  bisect puts the cliff at ~1.17x). The honest cap for that pool is ~82,000.
+- 88,000 is already **below the 112K observed production peak**, so shipping it
+  would fail prompts that are served today.
+
+Quantizing the drafter does not help here: KV cost follows the drafter's
+*layers*, not its weights. The W4A16 DFlash2 drafter has the same 5 layers.
+
+### 2. Prefix caching and the KV offload tier get disabled (vllm#41640, open)
+
+With DSpark on, the engine logs:
+
+> Speculative decoding (method=dspark) is enabled but no KV cache group could be
+> identified as the draft model's, so every group -- including Mamba groups
+> [0..9] -- will be treated as a draft group. A Mamba group cannot satisfy the
+> widened lookup window that implies, so prefix-cache reuse across requests will
+> be disabled and any external KV offload tier will store without ever serving a
+> hit.
+
+and the scheduler adds `EAGLE/MTP draft attention groups [0..14] detected. The
+trailing chunk of these groups will be excluded from offloading due to
+volatility.`
+
+This deployment cannot afford that: removing the fs secondary tier alone was
+measured to **halve single-stream decode** (15.5 vs 31 tok/s, exact-revert
+confirmed), and prefix caching runs 27-40% hit rate on real traffic.
+
+Root cause, in `vllm/v1/core/kv_cache_utils.py` at our pinned `8a728663c`:
+`_annotate_eagle_groups` identifies the drafter's KV group only via a
+`non_causal_multi_token_decode` marker set exclusively on `MLAAttentionSpec`, or
+a DeepSeek-V4-specific positional fallback. Neither can match a **GQA drafter on
+a non-MLA target**, which is exactly Qwen3.8-27B (GQA + GDN, not MLA). When
+neither fires, `_warn_if_unannotated_eagle_mamba` emits the warning above and
+every group is treated as a draft group.
+
+- vllm#41640 generalizes the annotation (`is_eagle` on `AttentionSpec`). Two
+  maintainers reviewed it favorably; it then went stale (bot-marked 2026-08-24)
+  with unresolved conflicts. **Not merged.**
+- vllm#55622 (2026-09-07) hit the identical problem independently for GLM-5.3's
+  GQA drafters and confirmed the same fix shape; withdrawn as fork-only.
+- vllm#55519 (open) only suppresses a false-positive variant of the warning; it
+  does not fix detection.
+
+Not fundamental in principle — a fix exists and is half-reviewed — but unfixed
+in anything shipped, and stalled for months. Treat as fundamental for planning.
+
+### 3. The tool-calling / structured-output wedge is still open (vllm#49002)
+
+Opened 2026-07-18, still open at last activity 2026-08-31, root cause not found;
+the reporter ruled out the grammar-bitmask-cost theory by direct benchmark.
+This is the same failure class already recorded here for MTP: MTP + tool-calling
+grammar wedged to ~0.2 tok/s (100x) under concurrent tool traffic. Production
+traffic on this model **is** grammar-constrained tool calling, so any
+drafter-based method is exposed to it.
+
+vllm#50924 (dspark grammar bitmask width mismatch, EngineCore crash) closed
+2026-08-10, but that is a crash-on-first-request bug, not this wedge.
+
+## n-gram / prompt-lookup — the one survivor
+
+`use_eagle()` in `vllm/config/speculative.py` returns True only for
+`("eagle", "eagle3", "mtp", "dflash", "dspark")`. That method gates both
+`_annotate_eagle_groups` and the Mamba-group warning, so **`ngram` cannot trip
+blocker 2 by construction**. The slot-accounting table in the same file lists
+n-gram as needing zero additional KV-cache slots: no draft model, no draft KV
+group, so blocker 1 does not apply either. It needs no change to
+`maxModelLen` or `--kv-cache-memory`.
+
+Config under test:
+
+```
+--speculative-config '{"method":"ngram","num_speculative_tokens":5,"prompt_lookup_min":3,"prompt_lookup_max":8}'
+```
+
+n-gram's win is entirely workload-shaped — it drafts by finding the current
+suffix earlier in the context — so a single benchmark number would be
+meaningless. Bracket it with two scripts that already suit the two ends:
+
+- **floor**: `bench/walltime.py`, whose random-word "summarize" prompt has
+  nothing meaningful to quote back. It is a *soft* floor, not a zero-hit case:
+  the corpus is drawn from a 24-word vocabulary, so 3-gram repeats occur by
+  chance and n-gram did fire (232 drafts, 63.2% acceptance). A true zero-hit
+  floor would need a high-entropy prompt. Still the closer of the two to a
+  request with nothing useful to look up.
+- **ceiling**: `bench/spectest.py`, already written for exactly this question —
+  a long code module the output must quote back verbatim, the coding-agent
+  shape where prompt-lookup should hit hardest. It also verifies the model
+  really quoted the source, so a fast-but-diverged run cannot be mistaken for a
+  win.
+
+Real tool-calling traffic lands between the two. The plausible win is output
+that echoes spans already in the prompt — repeated JSON keys, schema fields,
+argument names copied from the tool spec.
+
+### Result
+
+Measured with `num_speculative_tokens` 4 (`spec+1 = 5`, matching `parallelSlots`;
+`cudagraph_capture_sizes [5,10,15,20,25]`). Blocker 2 confirmed absent by
+measurement: no `draft group` or Mamba-group warning in the boot log, as the
+`use_eagle()` source read predicted. KV pool 291,461 @ cap 246,944 = 1.18x, so
+no cap change was needed and the 1.17x cliff is cleared.
+
+The decisive run is the **real manifest edit** (`walltime.py` with
+`PROMPT_FILE`): an 8,065-token prompt asking for a byte-for-byte modified copy
+of this repo's own `qwen38-27b-vllm.yaml`, generating 1200 tokens. This is the
+shape production actually sends — output that heavily quotes its input.
+
+```
+rep  TTFT s  decode s  toks   tok/s  accept%  tok/step  ms/step
+ 1     8.58    19.45   1200   61.64     89.7     3.33      54.0
+ 2     8.67    19.02   1200   63.04     89.1     3.45      54.7
+ 3     8.68    19.94   1200   60.13     88.1     3.32      55.2
+```
+
+Flat across reps, unlike the synthetic prompt, because the amount of quotable
+material is a property of the task rather than of luck.
+
+n-gram's per-position acceptance is nearly flat where DSpark's decayed — synthetic
+173/146/133/126, quote-back 86/74/73/68 (98%/86%/99%/93% conditional). It drafts
+only when it finds a match, so it is silent rather than wasteful on the steps it
+cannot help; what those steps still pay is the flat per-step tax below.
+
+Two fixed costs the baseline did not pay, from the boot log, and the likeliest
+components of that tax alongside the CPU-side suffix search:
+
+> Async scheduling not supported with ngram-based speculative decoding and will
+> be disabled.
+> Model Runner V2 does not yet support ngram/ngram_gpu speculative decoding;
+> using the V1 model runner instead.
+
+Note on the ceiling harness: `spectest.py` reported `DIVERGED at char 0` because
+the model emitted a "Here are handler_0 through handler_12..." preamble before
+quoting; the quoted code itself matched. Its rate also folds prefill in, so its
+number is not comparable to a `walltime.py` figure. Neither affects the verdict.
+
+### Open before shipping
+
+1. **The baseline is not yet apples-to-apples.** 31.73 was measured on the
+   synthetic 4K prompt; 61.64 on the 8K manifest prompt. Decode rate should be
+   near-independent of prompt content, but the 1.94x claim is only sound once
+   the same manifest prompt is run with speculative decoding *off*. That costs
+   one reboot and is the single highest-value remaining measurement.
+2. **Concurrency is unmeasured.** Every number here is single-stream. Under
+   concurrency a spec step batches `seqs x (spec+1)` tokens, which walks
+   straight into the `MAX_SKINNY_BATCH_SIZE=5` / LDS-gate territory documented
+   in the manifest. The win could shrink or invert at `parallelSlots` 5.
+3. **The tool-calling wedge (blocker 3) is untested for n-gram.** It was
+   observed with MTP. n-gram's drafts are not model-generated, so it may be
+   unaffected — but production traffic here *is* grammar-constrained tool
+   calling, and that is exactly the regime that wedged before.
+
+Not worth tuning: `prompt_lookup_*` and raising `num_speculative_tokens`. At
+~89% acceptance and 3.33 of a possible 5 tokens per step, the headroom left in
+the drafting itself is small; the per-step tax is where the remaining cost is.
+
+## Unrelated finding: the nightly regression persists
+
+The `vllm-openai-rocm:nightly` decode regression that forced the pin to
+`0d07767` is **still present in the 2026-09-07 build** (`74d4a95`,
+`v0.28.1rc1.dev472+gd9105ea80`), measured the same way:
+
+| image | built | vLLM | tok/s @4K |
+| --- | --- | --- | --- |
+| `0d07767` (pinned) | 09-04 | dev388+g8a728663c | 31.73 |
+| `74d4a95` (latest) | 09-07 | dev472+gd9105ea80 | 16.05 |
+
+Exactly 1.98x, flat across 4 reps, TTFT unchanged — decode-only.
+
+Ruled out as causes, by direct comparison of the two images: torch
+(`2.12.0+git6bbd260`), triton (`3.7.1+gitf0b55c07`), numpy, transformers and
+ROCm 7.2.3 are identical; the AITER Python tree hashes identically
+(`72ccfebb…`, 620 files both sides); both boots select the same
+`GDN decode kernel: triton`; and both mounted patches applied in both
+(`LDS_CAPACITY_ELEMENTS 32768 -> 39321`, `supports_kv_connector -> True`,
+`RDNAHybridW4A16LinearKernel`, `ROCM_AITER_UNIFIED_ATTN`). The KV pool was
+larger on the new image (304,808 both, 1.23x), so pool sizing is not a variable.
+
+So the delta is purely the 84 vLLM commits between `8a728663c` and the 09-05
+build cutoff. Suspects that touch paths this config actually runs:
+
+- `8277c42e4` [Perf] pin async h2d copies (#55202) — touches `rocm_aiter_fa.py`,
+  our attention backend.
+- `5690b02c0` online quantization with partially pre-quantized checkpoints
+  (#51392) — touches `layers/linear.py` + `quantization/base_config.py`.
+- `6cbb3c154` [Perf][GDN] cudagraph-capture metadata without a device sync
+  (#55404) and `874df9373` mamba state for padded prompt tails (#55178).
+
+**Eliminated:** `a69e75b9b` "Fast Start" (#54921) — opt-in via
+`load_format="ipc_cache"`, and its `linear.py` / `base_config.py` changes are
+additive capability flags only. Also eliminated: the LDS-gate patch target
+`rdna_hybrid_w4a16.py` is untouched in the whole window, so the patch still
+applies and is not the cause.
+
+Nothing between the 09-05 and 09-07 builds reverts or fixes any of the above.
+Keep the pin.
+
+## Reproducing
+
+```
+# baseline / non-spec only -- ITL-derived
+python3 docs/llm-hosting/bench/longctx.py <port> qwen-3.8 4000 4
+
+# anything with speculative decoding on -- wall-clock decode rate.
+# Doubles as the n-gram FLOOR: its prompt admits no lookups.
+python3 docs/llm-hosting/bench/walltime.py <port> qwen-3.8 4000 4
+
+# n-gram CEILING: verbatim quote-back, and checks the output really matches
+python3 docs/llm-hosting/bench/spectest.py <port> qwen-3.8
+```
+
+`walltime.py` is the only script added here; it does an idle preflight and
+refuses to count a dirty rep, matching the methodology the rest of this
+directory uses. It exists because `longctx.py` cannot measure a speculative
+config and `spectest.py` folds prefill into its rate and runs a single rep.

--- a/kubernetes/apps/ai/llmkube/models/qwen38-27b-vllm.yaml
+++ b/kubernetes/apps/ai/llmkube/models/qwen38-27b-vllm.yaml
@@ -408,10 +408,28 @@ spec:
     # Keep prior-turn reasoning in context; carried over from the qwen36 config.
     - --default-chat-template-kwargs
     - '{"preserve_thinking": true}'
-    # MTP speculative decoding is deliberately OMITTED: measured on this
-    # hardware, MTP + tool-calling grammar wedges to ~0.2 tok/s (100x
-    # regression) under concurrent tool traffic. Re-test that wedge before
-    # re-adding.
+    # NO --speculative-config. Every method vLLM offers was evaluated 2026-09-07
+    # and all are unusable -- full evidence in
+    # docs/llm-hosting/spec-decode-rejected.md. Summary:
+    #
+    #   n-gram  CORRUPTS OUTPUT. vllm#39273: SSM state corruption on hybrid GDN
+    #           models (this is one), truncated/repeated fragments. Was trialled
+    #           in production and reverted the same day after Hermes reported
+    #           truncated outputs. It benchmarks 1.8-2.1x faster and is WRONG --
+    #           acceptance/tokens-per-step stayed healthy the whole time, so the
+    #           engine metrics do NOT catch it.
+    #   MTP     + tool-calling grammar wedges to ~0.2 tok/s (100x) under
+    #           concurrent tool traffic; -27% at M=5 alone.
+    #   DSpark  0.59x measured, and its drafter KV (+70% B/token, bf16) forces
+    #           maxModelLen below the 112K production peak.
+    #   EAGLE3/ same drafter-KV tax, plus vllm#41640 (unmerged): a GQA drafter's
+    #   DFlash  KV group is unidentifiable on a non-MLA target, so prefix caching
+    #           is disabled and the KV offload tier goes write-only.
+    #
+    # Re-open ONLY when a named upstream issue is fixed: vllm#39273 for n-gram,
+    # and vllm#41640 + vllm#49002 for anything drafter-based. Gate any retry on
+    # an OUTPUT-QUALITY check before quoting a speed number -- that is the
+    # mistake that let the n-gram corruption reach production.
     # Separate pools, both needed -- ssm does NOT inherit from the other on
     # Qwen3.5 (its config forces auto to fp32). Dropping it cost 7,160 KV
     # tokens and halved the CPU tier. bfloat16 is vLLM's floor for either.

--- a/kubernetes/apps/ai/llmkube/models/qwen38-27b-vllm.yaml
+++ b/kubernetes/apps/ai/llmkube/models/qwen38-27b-vllm.yaml
@@ -412,24 +412,34 @@ spec:
     # and all are unusable -- full evidence in
     # docs/llm-hosting/spec-decode-rejected.md. Summary:
     #
-    #   n-gram  CORRUPTS OUTPUT. vllm#39273: SSM state corruption on hybrid GDN
-    #           models (this is one), truncated/repeated fragments. Was trialled
-    #           in production and reverted the same day after Hermes reported
-    #           truncated outputs. It benchmarks 1.8-2.1x faster and is WRONG --
-    #           acceptance/tokens-per-step stayed healthy the whole time, so the
+    #   n-gram  CORRUPTS OUTPUT (measured, incl. in production). vllm#39273: SSM
+    #           state corruption on hybrid GDN models -- this is one --
+    #           truncated/repeated fragments. Trialled on live traffic and
+    #           reverted the same day after Hermes reported truncated outputs.
+    #           Benchmarked ~1.8-2.1x faster on echo-heavy work (PROVISIONAL:
+    #           never run against a same-prompt spec-off control) and WRONG.
+    #           Acceptance and tokens-per-step stayed healthy throughout, so the
     #           engine metrics do NOT catch it.
+    #   DSpark  0.59x (measured). Drafter KV +70% B/token, bf16, forces
+    #           maxModelLen below the 112K production peak.
     #   MTP     + tool-calling grammar wedges to ~0.2 tok/s (100x) under
     #           concurrent tool traffic; -27% at M=5 alone.
-    #   DSpark  0.59x measured, and its drafter KV (+70% B/token, bf16) forces
-    #           maxModelLen below the 112K production peak.
-    #   EAGLE3/ same drafter-KV tax, plus vllm#41640 (unmerged): a GQA drafter's
-    #   DFlash  KV group is unidentifiable on a non-MLA target, so prefix caching
-    #           is disabled and the KV offload tier goes write-only.
+    #   EAGLE3/ NOT benchmarked, ruled out on mechanism: same drafter-KV tax,
+    #   DFlash  plus vllm#41640 (unmerged) leaves a GQA drafter's KV group
+    #           unidentifiable on a non-MLA target, so prefix caching is
+    #           disabled and the KV offload tier goes write-only.
     #
     # Re-open ONLY when a named upstream issue is fixed: vllm#39273 for n-gram,
-    # and vllm#41640 + vllm#49002 for anything drafter-based. Gate any retry on
-    # an OUTPUT-QUALITY check before quoting a speed number -- that is the
-    # mistake that let the n-gram corruption reach production.
+    # vllm#41640 + vllm#49002 for anything drafter-based. An upstream fix
+    # re-opens EVALUATION, not shipping. Before enabling anything, ALL of:
+    #   1. spectest.py passes -- read the whole output, not the head. This is a
+    #      precondition for quoting a speed number at all, and skipping it is
+    #      what let the corruption reach production.
+    #   2. a same-prompt spec-off baseline on the same pod (never run).
+    #   3. a concurrency test at parallelSlots -- everything measured so far is
+    #      single-stream or conc<=5.
+    #   4. a tool-calling test under grammar constraint, the regime that wedged
+    #      MTP (bench/toolbench.py, vmcp preset).
     # Separate pools, both needed -- ssm does NOT inherit from the other on
     # Qwen3.5 (its config forces auto to fp32). Dropping it cost 7,160 KV
     # tokens and halved the CPU tier. bfloat16 is vLLM's floor for either.


### PR DESCRIPTION
Evaluated every speculative decoding method vLLM offers on `qwen38-27b-vllm` (gfx1201). None is usable. No config change — the manifest edit is comment-only.

## Verdict

| method | status | why |
| --- | --- | --- |
| n-gram | **corrupts output** | [vllm#39273](https://github.com/vllm-project/vllm/issues/39273): SSM state corruption on hybrid GDN models. Fast and silently wrong. |
| MTP | rejected | wedges to ~0.2 tok/s (100x) under concurrent tool traffic; -27% at M=5 alone |
| DSpark | rejected | 0.59x (18.84 vs 31.73); drafter KV +70% B/token forces cap to 88K, under the 112K production peak |
| EAGLE3 / DFlash | blocked | same KV tax + [vllm#41640](https://github.com/vllm-project/vllm/pull/41640) unmerged |

n-gram sidesteps all three drafter blockers by construction (no draft model, no draft KV group) and is still unusable because of a fourth, independent bug.

## n-gram performance, for the record

Measured before the corruption was found. Cost is a flat ~50ms/step vs ~32ms baseline, paid on every step including those proposing nothing; break-even is ~1.56 tokens/step.

| shape | tok/s | vs 31.73 | accept% | tokens/step |
| --- | --- | --- | --- | --- |
| refactor-python | 65.84 | 2.07x | 76-93 | 3.36 |
| edit-manifest | 57.24 | 1.80x | 82-85 | 3.10 |
| extract-json | 38.65 | 1.22x | 69-81 | 2.06 |
| explain-code | 30.87 | 0.97x | 48-75 | 1.58 |
| summarize-doc | 23.32 | 0.73x | 28 | 1.16 |

Monotonic in how much of the output already appears in the prompt. `ms/step` held at 48-55 across every row while tok/s moved 3x. Live production traffic: 43-67% acceptance, 2.7-3.7 tokens/step, zero preemptions — healthy the entire time it was corrupting output.

## Production trial

Ran on live traffic, reverted the same day after Hermes reported truncated outputs. `flux resume` restored the pinned config; baseline re-verified after revert at 32.80 tok/s / 1.00 tokens/step / 30.4 ms/step.

## Methodology lesson

Every benchmark measured speed; none verified output quality. A correctness regression reached production looking like a 2x win, and no engine metric flagged it — acceptance counters measure whether drafts were *accepted*, never whether output was *correct*. `spectest.py` did report `DIVERGED` and that signal was dismissed as a formatting artifact. The doc requires any future trial to gate on a quality check before a speed number is quoted.

## Harness

- `walltime.py` — wall-clock decode; the ITL counter records per *step* under spec decode and read 7.37 where wall-clock measured 18.84
- `toolbench.py` — grammar-constrained tool calling, the regime that wedged MTP; optional Hermes system prompt + vmcp two-tool contract
- `_metrics.py` — one shared `/metrics` scrape (was 3 per rep across two copies)
- `longctx.py` — warning added rather than changed; it is correct for the shipped config

## Follow-up

Subscriptions to the three upstream issues need `gh auth refresh -s notifications`; 👍 already added to each.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added benchmarks for wall-clock generation speed and grammar-constrained tool calling.
  * Added shared metrics sampling and engine-idle detection for benchmark runs.

* **Documentation**
  * Documented limitations of inter-token latency measurements with speculative decoding.
  * Recorded the evaluation and rejection of speculative decoding methods.
  * Expanded deployment documentation with evaluation findings and conditions for reconsideration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->