### PR TITLE
feat(renovate): auto-merge searxng

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -136,6 +136,16 @@
       automergeType: "pr"
     },
     {
+      // User-cleared (2026-09-08): "these updates have always been harmless." Self-hosted
+      // search app, PDB + RollingUpdate, no secrets in the image, no vendor SaaS. Covers all
+      // update types (calver tag bumps and digest refreshes on the same tag).
+      description: "Auto-merge searxng (user-cleared, 2026-09-08)",
+      matchDatasources: ["docker"],
+      matchPackageNames: ["ghcr.io/searxng/searxng"],
+      automerge: true,
+      automergeType: "pr"
+    },
+    {
       description: "vllm-openai-rocm nightly digest — the rolling `nightly` tag is digest-pinned so Renovate can detect new builds at all; never auto-merge, a bump rolls the single-GPU serving pod and can move the KV pool that maxModelLen is sized against",
       matchDatasources: ["docker"],
       matchPackageNames: ["vllm/vllm-openai-rocm"],


### PR DESCRIPTION
## What

Adds one `packageRule` to `.renovaterc.json5` so **searxng auto-merges** (user-cleared, 2026-09-08):

```json5
{
  description: "Auto-merge searxng (user-cleared, 2026-09-08)",
  matchDatasources: ["docker"],
  matchPackageNames: ["ghcr.io/searxng/searxng"],
  automerge: true,
  automergeType: "pr"
}
```

## Why

searxng is the self-hosted search app (`kubernetes/apps/default/searxng/`). Its image updates are low-risk by design:

- **PDB + `RollingUpdate`** — a bump is a rolling replacement, not a hard restart.
- **No secrets in the image** — config lives in `resources/` (SOPS), the image carries only the app.
- **No vendor / SaaS dependency** — fully self-hosted.

The rule covers **all update types** for the searxng image (calver tag bumps like `2026.9.7 → 2026.9.8` *and* digest refreshes on the same tag), so future searxng Renovate PRs merge themselves without a manual gate. `automergeType: "pr"` (the default) is set explicitly to match the existing `home-operations` digest rule.

## Scoping — why it is safe

- `matchDatasources: ["docker"]` + the exact package name means the rule only ever matches the searxng image; it cannot bleed into any other dep.
- No existing rule touches searxng. The current automerge set is only `ghcr.io/home-operations/*` digests, and the `vllm` rule is an explicit `automerge: false`. No conflict, no override.

## Not changed

- No Kubernetes manifests, no Flux config, no images — the change is **Renovate config only**.
- No other `packageRule` touched; all 26 existing rules are byte-for-byte unchanged.
- No `*.sh` files modified; no SOPS secrets.

## Verification

- `json5` parse of the full `.renovaterc.json5`: **OK** (27 `packageRules`, 2 automerge rules: the pre-existing `home-operations` digest rule + the new searxng rule).
- Diff is **10 insertions, 1 file** (`.renovaterc.json5`), nothing else.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated merging is now enabled for tag and digest updates to the SearXNG Docker image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->