### PR TITLE
fix(jellyfin): bump homepage widget to v2 for Jellyfin 12

### DIFF
--- a/kubernetes/apps/media/jellyfin/app/helmrelease.yaml
+++ b/kubernetes/apps/media/jellyfin/app/helmrelease.yaml
@@ -102,6 +102,7 @@ spec:
           gethomepage.dev/widget.type: jellyfin
           gethomepage.dev/widget.url: http://jellyfin.media.svc.cluster.local:8096
           gethomepage.dev/widget.key: "{{`{{HOMEPAGE_VAR_JELLYFIN_API_KEY}}`}}"
+          gethomepage.dev/widget.version: "2"
           gethomepage.dev/widget.fields: '["movies","series","episodes","songs"]'
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"


### PR DESCRIPTION
## Summary
gethomepage's Jellyfin widget requires `version: 2` for Jellyfin server 10.12+ (Jellyfin 12.0 is the renamed 10.12.0 - confirmed via gethomepage's own docs: "Jellyfin versions earlier than 10.12 require widget version 1, while versions 10.12 and newer require widget version 2"). We're now on 12.0, so the homepage dashboard widget was silently on the wrong version.

## Test plan
- [ ] Homepage dashboard's Jellyfin widget card populates correctly (movies/series/episodes/songs counts, now-playing)