### PR TITLE
fix(cloudflared): force http2 protocol to survive WAN blips

### DIFF
--- a/kubernetes/apps/network/cloudflared/app/helmrelease.yaml
+++ b/kubernetes/apps/network/cloudflared/app/helmrelease.yaml
@@ -30,6 +30,10 @@ spec:
                   name: "{{ .Release.Name }}-secret"
             args:
               - tunnel
+              # QUIC's 5s idle timeout drops the edge connection on WAN blips
+              # that TCP would ride through; http2 rides through them instead
+              - --protocol
+              - http2
               - run
             probes:
               liveness: &probes


### PR DESCRIPTION
## Summary
Root-caused the "Jellyfin is slow/unreachable" reports to a chronic, unrelated infra issue: the tunnel's default QUIC transport has a hardcoded 5-second idle timeout, and this WAN link drops for 5+ seconds intermittently (confirmed via 30 days of gatus ICMP monitoring against 1.1.1.1/8.8.8.8/Quad9, correlating hour-for-hour with `cloudflared_tunnel_ha_connections` idle-timeout disconnects on ~10 occasions in that window - roughly 25 of the last 30 days show at least one WAN ICMP failure). Every UDP blackout that long tears down the tunnel's edge connection, cutting every in-flight stream across every exposed service at once (Jellyfin, Home Assistant, share - confirmed simultaneous "stream canceled by remote" errors across all three during the same incident).

- `--protocol http2` switches the edge transport to HTTP/2-over-TCP, which rides out the same packet loss instead of disconnecting.
- Ruled out during investigation: not a Jellyfin bug (envoy access logs show a genuine, unrelated 503 from the just-migrated pod during a reload spike - separate issue, not a tunnel problem), not CrowdSec, not node/gateway health, not a cloudflared crash-loop (both pods were stable 30h+/3d+ at incident time; the version-pinned image has no known relevant regression).
- Both `cloudflared` HA connections stayed at 4/4 throughout the reported incidents - the tunnel itself never actually dropped during *that* window, but it has repeatedly during the WAN-blip hours found in the 30-day history, which is the actual chronic pattern being fixed here.

## Follow-up (not included, offering separately)
The liveness probe on `/ready` returns 503 at 0 active connections, which can cause kubelet to kill a pod mid-reconnect during exactly the WAN outage it's already recovering from (contributed to some of the 62 container restarts seen in 30d, though most restarts cluster around node-reboot events, not this). Worth dropping the liveness probe and keeping readiness-only, but scoping that as a separate change rather than bundling it here.

## Test plan
- [ ] `kubectl -n network logs -l app.kubernetes.io/name=cloudflared | grep "Registered tunnel connection"` shows `protocol=http2` after rollout
- [ ] `cloudflared_tunnel_ha_connections` stays at 4 through the next WAN ICMP-failure window (watch gatus)