### PR TITLE
refactor(cloudflared): move protocol setting from args to config.yaml

### DIFF
--- a/kubernetes/apps/network/cloudflared/app/helmrelease.yaml
+++ b/kubernetes/apps/network/cloudflared/app/helmrelease.yaml
@@ -22,18 +22,11 @@ spec:
             image:
               repository: mirror.gcr.io/cloudflare/cloudflared
               tag: 2026.8.3@sha256:51c9cefcb4569df44e1ad403ab1d3d8065aa8e84339bcfc6aee75502e1140339
-            env:
-              NO_AUTOUPDATE: true
-              TUNNEL_METRICS: 0.0.0.0:8080
             envFrom:
               - secretRef:
                   name: "{{ .Release.Name }}-secret"
             args:
               - tunnel
-              # QUIC's 5s idle timeout drops the edge connection on WAN blips
-              # that TCP would ride through; http2 rides through them instead
-              - --protocol
-              - http2
               - run
             probes:
               liveness: &probes

--- a/kubernetes/apps/network/cloudflared/app/resources/config.yaml
+++ b/kubernetes/apps/network/cloudflared/app/resources/config.yaml
@@ -1,4 +1,7 @@
 ---
+protocol: http2
+no-autoupdate: true
+metrics: 0.0.0.0:8080
 ingress:
   - hostname: ${SECRET_DOMAIN}
     originRequest: &originRequest


### PR DESCRIPTION
## Summary
Same behavior as #4931's `--protocol http2` fix, plus the pre-existing `NO_AUTOUPDATE`/`TUNNEL_METRICS` env vars, all consolidated into cloudflared's own `config.yaml` - which already exists here for the `ingress`/`originRequest` settings - instead of split across the HelmRelease's `args` and `env`. `protocol`, `no-autoupdate` and `metrics` are all documented top-level `config.yaml` keys, equivalent to their CLI-flag/env-var forms.

Net: HelmRelease container spec drops to image + secret + the bare `tunnel run` command; all cloudflared-specific tunnel config now lives in one file.

No behavior change - confirmed each moved setting is a real, documented `config.yaml` key with identical semantics to what it replaces.

## Test plan
- [ ] `cloudflared` logs show `protocol=http2` on connection registration after rollout, same as before
- [ ] Metrics endpoint still serves on `:8080` (liveness/readiness probes and ServiceMonitor depend on it)
- [ ] No regression to the last 13h+ of stable connections